### PR TITLE
Hide Autotune

### DIFF
--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
@@ -410,18 +410,18 @@ extension PreferencesEditor {
                     ),
                     settable: self
                 ),
-                Field(
-                    displayName: NSLocalizedString(
-                        "Autotune ISF Adjustment Fraction",
-                        comment: "Autotune ISF Adjustment Fraction"
-                    ),
-                    type: .decimal(keypath: \.autotuneISFAdjustmentFraction),
-                    infoText: NSLocalizedString(
-                        "The default of 0.5 for this value keeps autotune ISF closer to pump ISF via a weighted average of fullNewISF and pumpISF. 1.0 allows full adjustment, 0 is no adjustment from pump ISF.",
-                        comment: "Autotune ISF Adjustment Fraction"
-                    ),
-                    settable: self
-                ),
+                /* Field(
+                        displayName: NSLocalizedString(
+                            "Autotune ISF Adjustment Fraction",
+                            comment: "Autotune ISF Adjustment Fraction"
+                        ),
+                        type: .decimal(keypath: \.autotuneISFAdjustmentFraction),
+                        infoText: NSLocalizedString(
+                            "The default of 0.5 for this value keeps autotune ISF closer to pump ISF via a weighted average of fullNewISF and pumpISF. 1.0 allows full adjustment, 0 is no adjustment from pump ISF.",
+                            comment: "Autotune ISF Adjustment Fraction"
+                        ),
+                        settable: self
+                    ), */
                 Field(
                     displayName: NSLocalizedString("Remaining Carbs Fraction", comment: "Remaining Carbs Fraction"),
                     type: .decimal(keypath: \.remainingCarbsFraction),

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -96,8 +96,8 @@ extension Settings {
                                 .navigationLink(to: .configEditor(file: OpenAPS.FreeAPS.announcements), from: self)
                             Text("Enacted announcements")
                                 .navigationLink(to: .configEditor(file: OpenAPS.FreeAPS.announcementsEnacted), from: self)
-                            //Text("Autotune")
-                                //.navigationLink(to: .configEditor(file: OpenAPS.Settings.autotune), from: self)
+                            // Text("Autotune")
+                            // .navigationLink(to: .configEditor(file: OpenAPS.Settings.autotune), from: self)
                             Text("Glucose")
                                 .navigationLink(to: .configEditor(file: OpenAPS.Monitor.glucose), from: self)
                         }


### PR DESCRIPTION
I think Autotune probably causes problems for more people than it helps. I think people expect to be able to just turn it on and it will dial everything in for them, without realizing that In order for it to really be useful, you have to announce all meals and can only use a single ISF and CR, which means no dynISF.

Apparently in AAPS, if you want to use Autotune you not only have to use the dev branch, but you also have to go into "engineering mode". I didn't actually remove anything from Oi, I just commented out the AT submenu so you can't turn it on without doing a(n albeit very easy and straightforward) customization.