### PR TITLE
Reduce smoothing time window

### DIFF
--- a/FreeAPS/Sources/APS/FetchGlucoseManager.swift
+++ b/FreeAPS/Sources/APS/FetchGlucoseManager.swift
@@ -139,7 +139,7 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
             var smoothedValues = oldGlucoses + filtered
             // smooth with 3 repeats
             for _ in 1 ... 3 {
-                smoothedValues.smoothSavitzkyGolayQuaDratic(withFilterWidth: 3)
+                smoothedValues.smoothSavitzkyGolayQuaDratic(withFilterWidth: 1)  // use width of 1, meaning only 3 values are used representing 10min
             }
             // find the new values only
             filtered = smoothedValues.filter { $0.dateString > syncDate }


### PR DESCRIPTION
@avouspierre : Suggestion to use the Savitzky-Golay filter for smoothing only across 10min (3 values) instead of 30min (7 values)

I played around with the Smoothing algorithm and found out that it uses quite a large timeframe to base the filter on. It is 30 min at the moment. I created a rather noise Glucose simulation in the integrated GlucoseSimulator with a rather broader target goal of 70 - 150 to get more noise at https://github.com/nightscout/Open-iAPS/blob/f404fc49bfe4732dbb61c3a1b202d5b1f22ce178/FreeAPS/Sources/APS/CGM/GlucoseSimulatorSource.swift#L157

The smoothing result with a 10 minute window is suffficient in my view.  Changed the graph settings a bit for better visual of smoothing effect.

| new setting | old setting |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-22 at 19 11 57](https://github.com/nightscout/Open-iAPS/assets/539276/53d95694-9180-443e-b84c-b49cb1f89e5a) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-22 at 19 11 57](https://github.com/nightscout/Open-iAPS/assets/539276/53d95694-9180-443e-b84c-b49cb1f89e5a) |
| | Same pic as place holder. Currently simulating with the original setting for comparison - takes a while. |
