### PR TITLE
Config.xcconfig: #include? "../../ConfigOverride.xcconfig"

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -8,5 +8,5 @@ APP_GROUP_ID = group.com.$(DEVELOPMENT_TEAM).loopkit.LoopGroup
 APP_ICON = OiAPS_Icon
 APP_URL_SCHEME = freeaps-x
 
-#include? "ConfigOverride.xcconfig"
 #include? "../../ConfigOverride.xcconfig"
+#include? "ConfigOverride.xcconfig"


### PR DESCRIPTION
Allow config override file to take action from two directories up, to align with Loop and other DIY projects.