### PR TITLE
Update URL scheme for Open-iAPS

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -6,7 +6,7 @@ DEVELOPER_TEAM = ##TEAM_ID##
 BUNDLE_IDENTIFIER = ru.artpancreas.$(DEVELOPMENT_TEAM).FreeAPS
 APP_GROUP_ID = group.com.$(DEVELOPMENT_TEAM).loopkit.LoopGroup
 APP_ICON = OiAPS_Icon
-APP_URL_SCHEME = freeaps-x
+APP_URL_SCHEME = Open-iAPS
 
 #include? "../../ConfigOverride.xcconfig"
 #include? "ConfigOverride.xcconfig"

--- a/FreeAPS/Resources/Info.plist
+++ b/FreeAPS/Resources/Info.plist
@@ -36,7 +36,6 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>$(APP_URL_SCHEME)</string>
-				<string>freeaps-x</string>
 			</array>
 		</dict>
 	</array>

--- a/FreeAPS/Sources/APS/CGM/CGMType.swift
+++ b/FreeAPS/Sources/APS/CGM/CGMType.swift
@@ -54,7 +54,7 @@ enum CGMType: String, JSON, CaseIterable, Identifiable {
         case .simulator:
             return nil
         case .libreTransmitter:
-            return URL(string: "freeaps-x://libre-transmitter")!
+            return URL(string: "Open-iAPS://libre-transmitter")!
         }
     }
 

--- a/FreeAPS/Sources/Models/AlertEntry.swift
+++ b/FreeAPS/Sources/Models/AlertEntry.swift
@@ -15,7 +15,7 @@ struct AlertEntry: JSON, Codable, Hashable {
     let contentBody: String?
     var errorMessage: String?
 
-    static let manual = "freeaps-x"
+    static let manual = "Open-iAPS"
 
     static func == (lhs: AlertEntry, rhs: AlertEntry) -> Bool {
         lhs.issuedDate == rhs.issuedDate

--- a/FreeAPS/Sources/Models/CarbsEntry.swift
+++ b/FreeAPS/Sources/Models/CarbsEntry.swift
@@ -11,7 +11,7 @@ struct CarbsEntry: JSON, Equatable, Hashable {
     let isFPU: Bool?
     let fpuID: String?
 
-    static let manual = "freeaps-x"
+    static let manual = "Open-iAPS"
     static let appleHealth = "applehealth"
 
     static func == (lhs: CarbsEntry, rhs: CarbsEntry) -> Bool {

--- a/FreeAPS/Sources/Models/NightscoutTreatment.swift
+++ b/FreeAPS/Sources/Models/NightscoutTreatment.swift
@@ -19,7 +19,7 @@ struct NigtscoutTreatment: JSON, Hashable, Equatable {
     let targetTop: Decimal?
     let targetBottom: Decimal?
 
-    static let local = "freeaps-x"
+    static let local = "Open-iAPS"
 
     static let empty = NigtscoutTreatment(from: "{}")!
 

--- a/FreeAPS/Sources/Models/TempTarget.swift
+++ b/FreeAPS/Sources/Models/TempTarget.swift
@@ -10,7 +10,7 @@ struct TempTarget: JSON, Identifiable, Equatable, Hashable {
     let enteredBy: String?
     let reason: String?
 
-    static let manual = "freeaps-x"
+    static let manual = "Open-iAPS"
     static let custom = "Temp target"
     static let cancel = "Cancel"
 

--- a/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
@@ -37,8 +37,8 @@ extension NightscoutAPI {
     func checkConnection() -> AnyPublisher<Void, Swift.Error> {
         struct Check: Codable, Equatable {
             var eventType = "Note"
-            var enteredBy = "freeaps-x"
-            var notes = "iAPS connected"
+            var enteredBy = "Open-iAPS"
+            var notes = "Open-iAPS connected"
         }
         let check = Check()
         var request = URLRequest(url: url.appendingPathComponent(Config.treatmentsPath))

--- a/FreeAPS/Sources/Services/WatchManager/GarminManager.swift
+++ b/FreeAPS/Sources/Services/WatchManager/GarminManager.swift
@@ -63,7 +63,7 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
 
     init(resolver: Resolver) {
         super.init()
-        connectIQ?.initialize(withUrlScheme: "freeaps-x", uiOverrideDelegate: self)
+        connectIQ?.initialize(withUrlScheme: "Open-iAPS", uiOverrideDelegate: self)
         injectServices(resolver)
         restoreDevices()
         subscribeToOpenFromGarminConnect()


### PR DESCRIPTION
- Config.xconfig: APP_URL_SCHEME = Open-iAPS
- remove hardcoded "freeaps-x", leaving $(APP_URL_SCHEME)
- CGMType.swift: libreTransmitter: URL(string: "Open-iAPS://libre-transmitter"
- AlertEntry.swift: static let manual = "Open-iAPS"
- CarbsEntry.swift: static let manual = "Open-iAPS"
- NightscoutTreatment.swift: static let local = "Open-iAPS"
- Sources/Models/TempTarget.swift: static let manual = "Open-iAPS"
- NightscoutAPI.swift: var enteredBy = "Open-iAPS", var notes = "Open-iAPS connected"
- GarminManager.swift: connectIQ?.initialize(withUrlScheme: "Open-iAPS", uiOverrideDelegate: self)