### PR TITLE
Add branch name and commit hash to the "What to test" field in TestFlight

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -153,6 +153,7 @@ platform :ios do
       skip_submission: false,
       ipa: "iAPS.ipa",
       skip_waiting_for_build_processing: true,
+      changelog: git_branch+" "+last_git_commit[:abbreviated_commit_hash],
     )
   end
 


### PR DESCRIPTION
This was originally introduced by @MikePlante1 in iAPS Artificial-Pancreas/iAPS#360

This PR includes a feature for uploading the branch name and git reference as a “changelog” to TestFlight, displayed under “What to Test” for each build. However , there is a bug in AppStore Connect / TestFlight, where fastlane fails to upload changelog if it was never entered before.

The workaround is to make a manual “Test Details” entry from AppStoreConnect (ASC), then build again. Then, the branch and git ref will be displayed under "What to Test" in both TestFlight and ASC.

See https://github.com/nightscout/Open-iAPS/issues/23 and  https://github.com/nightscout/Open-iAPS/pull/63 for details.