### PR TITLE
Update text of Non-Pump in comments to external 

### DIFF
--- a/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
@@ -1222,7 +1222,7 @@ Enact a temp Basal or a temp target */
 /* An Automatic delivered bolus (SMB) */
 "SMB" = "SMB";
 
-/* A manually entered dose of non-pump insulin */
+/* A manually entered dose of external insulin */
 "External Insulin" = "Externes Insulin";
 
 /* Status highlight when manual temp basal is running. */

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -1220,7 +1220,7 @@ Enact a temp Basal or a temp target */
 /* An Automatic delivered bolus (SMB) */
 "SMB" = "SMB";
 
-/* A manually entered dose of non-pump insulin */
+/* A manually entered dose of external insulin */
 "External Insulin" = "External Insulin";
 
 /* Status highlight when manual temp basal is running. */


### PR DESCRIPTION
Some lingering Non-pump text got by me when I was replacing all the instances of Non-Pump with external. This should clean up the last remaining instances of Non-Pump (minus those within LoopKit)