### PR TITLE
Add SMB flag and display SMBs in history.

### DIFF
--- a/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -45,6 +45,7 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
                         rate: nil,
                         temp: nil,
                         carbInput: nil,
+                        isSMB: dose.automatic,
                         isExternalInsulin: dose.manuallyEntered
                     )]
                 case .tempBasal:

--- a/FreeAPS/Sources/Models/PumpHistoryEvent.swift
+++ b/FreeAPS/Sources/Models/PumpHistoryEvent.swift
@@ -11,6 +11,7 @@ struct PumpHistoryEvent: JSON, Equatable {
     let temp: TempType?
     let carbInput: Int?
     let note: String?
+    let isSMB: Bool?
     let isExternalInsulin: Bool?
 
     init(
@@ -24,6 +25,7 @@ struct PumpHistoryEvent: JSON, Equatable {
         temp: TempType? = nil,
         carbInput: Int? = nil,
         note: String? = nil,
+        isSMB: Bool? = nil,
         isExternalInsulin: Bool? = nil
     ) {
         self.id = id
@@ -36,6 +38,7 @@ struct PumpHistoryEvent: JSON, Equatable {
         self.temp = temp
         self.carbInput = carbInput
         self.note = note
+        self.isSMB = isSMB
         self.isExternalInsulin = isExternalInsulin
     }
 }
@@ -84,6 +87,7 @@ extension PumpHistoryEvent {
         case temp
         case carbInput = "carb_input"
         case note
+        case isSMB
         case isExternalInsulin
     }
 }

--- a/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
@@ -66,6 +66,7 @@ enum DataTable {
         let isFPU: Bool?
         let fpuID: String?
         let note: String?
+        let isSMB: Bool?
         let isExternal: Bool?
 
         private var numberFormatter: NumberFormatter {
@@ -94,6 +95,7 @@ enum DataTable {
             isFPU: Bool? = false,
             fpuID: String? = nil,
             note: String? = nil,
+            isSMB: Bool? = nil,
             isExternal: Bool? = nil
         ) {
             self.units = units
@@ -107,6 +109,7 @@ enum DataTable {
             self.isFPU = isFPU
             self.fpuID = fpuID
             self.note = note
+            self.isSMB = isSMB
             self.isExternal = isExternal
         }
 
@@ -138,6 +141,8 @@ enum DataTable {
 
                 if isExternal ?? false {
                     bolusText += " " + NSLocalizedString("External", comment: "External Insulin")
+                } else if isSMB ?? false {
+                    bolusText += " " + NSLocalizedString("SMB", comment: "SMB")
                 }
 
                 return numberFormatter

--- a/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
@@ -77,6 +77,7 @@ extension DataTable {
                             date: $0.timestamp,
                             amount: $0.amount,
                             idPumpEvent: $0.id,
+                            isSMB: $0.isSMB,
                             isExternal: $0.isExternalInsulin
                         )
                     }


### PR DESCRIPTION
Based on https://github.com/Artificial-Pancreas/iAPS/pull/219 for #47. 

Creates a new flag for `isSMB` and displays SMBs similar to external insulin within the history sheet. In a follow-up PR, will cleanup the History list. 

![simulator_screenshot_291702D7-4AF7-46C7-9AD2-15300A85F83B](https://github.com/nightscout/Open-iAPS/assets/14946926/1d956240-fde0-4b15-a512-9f68f8e7c90f)
