### PR TITLE
Rework glucose dialog

### DIFF
--- a/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
@@ -13,7 +13,7 @@ extension DataTable {
         @Published var mode: Mode = .treatments
         @Published var treatments: [Treatment] = []
         @Published var glucose: [Glucose] = []
-        @Published var manualGlcuose: Decimal = 0
+        @Published var manualGlucose: Decimal = 0
         @Published var maxBolus: Decimal = 0
         @Published var externalInsulinAmount: Decimal = 0
         @Published var externalInsulinDate = Date()
@@ -176,7 +176,7 @@ extension DataTable {
         }
 
         func addManualGlucose() {
-            let glucose = units == .mmolL ? manualGlcuose.asMgdL : manualGlcuose
+            let glucose = units == .mmolL ? manualGlucose.asMgdL : manualGlucose
             let now = Date()
             let id = UUID().uuidString
 


### PR DESCRIPTION
This ports https://github.com/Artificial-Pancreas/iAPS/pull/272 into Open-iAPS, which replaces the manual glucose entry pop-up with a sheet.

This is part of #47

![Simulator Screenshot - iPhone 15 - 2024-04-30 at 22 45 28](https://github.com/nightscout/Open-iAPS/assets/14946926/494c86a2-8e36-42b2-ae1a-2362266f3788)

![Simulator Screenshot - iPhone 15 - 2024-04-30 at 22 45 31](https://github.com/nightscout/Open-iAPS/assets/14946926/01c3abc8-7af3-44d9-ac5d-4d9a42d14417)
