### PR TITLE
Fix the default CGM with a fresh install.

### DIFF
--- a/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
+++ b/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
@@ -11,7 +11,7 @@
   "insulinReqPercentage" : 70,
   "skipBolusScreenAfterCarbs" : false,
   "displayHR" : false,
-  "cgm" : "nightscout",
+  "cgm" : "none",
   "cgmManagerTypeByIdentifier":"",
   "uploadGlucose" : true,
   "useCalendar" : false,


### PR DESCRIPTION
Start with “none” as CGM type allowing to have the icon “Add CGM”.