### PR TITLE
fix resistanceLowersTarget

### DIFF
--- a/FreeAPS/Resources/json/defaults/preferences.json
+++ b/FreeAPS/Resources/json/defaults/preferences.json
@@ -9,7 +9,7 @@
   "high_temptarget_raises_sensitivity" : false,
   "low_temptarget_lowers_sensitivity" : false,
   "sensitivity_raises_target" : true,
-  "resistanceLowersTarget" : false,
+  "resistance_lowers_target" : false,
   "adv_target_adjustments" : false,
   "exercise_mode" : false,
   "half_basal_exercise_target" : 160,

--- a/FreeAPS/Sources/Models/Preferences.swift
+++ b/FreeAPS/Sources/Models/Preferences.swift
@@ -68,7 +68,7 @@ extension Preferences {
         case highTemptargetRaisesSensitivity = "high_temptarget_raises_sensitivity"
         case lowTemptargetLowersSensitivity = "low_temptarget_lowers_sensitivity"
         case sensitivityRaisesTarget = "sensitivity_raises_target"
-        case resistanceLowersTarget
+        case resistanceLowersTarget = "resistance_lowers_target"
         case advTargetAdjustments = "adv_target_adjustments"
         case exerciseMode = "exercise_mode"
         case halfBasalExerciseTarget = "half_basal_exercise_target"


### PR DESCRIPTION
Reproduced the error with current `dev` where target does not change even when resistance is detected and `Resistance Lowers Target` is toggled on.

After applying this PR, target was lowered as expected.

⚠️ WARNING: This fix will reset preferences again.

Addresses https://github.com/nightscout/Open-iAPS/issues/152