### PR TITLE
Override refactoring and additional functionnalities

### DIFF
--- a/Core_Data.xcdatamodeld/Core_Data.xcdatamodel/contents
+++ b/Core_Data.xcdatamodeld/Core_Data.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22222" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="BGaverages" representedClassName="BGaverages" syncable="YES" codeGenerationType="class">
         <attribute name="average" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
         <attribute name="average_1" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
@@ -65,6 +65,7 @@
         <attribute name="isf" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="isfAndCr" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isPreset" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="percentage" optional="YES" attributeType="Double" defaultValueString="100" usesScalarValueType="YES"/>
         <attribute name="smbIsOff" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="smbIsScheduledOff" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -288,6 +288,11 @@
 		CA370FC152BC98B3D1832968 /* BasalProfileEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8BCB0C37DEB5EC377B9612 /* BasalProfileEditorRootView.swift */; };
 		CC6C406E2ACDD69E009B8058 /* RawFetchedProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6C406D2ACDD69E009B8058 /* RawFetchedProfile.swift */; };
 		CD78BB94E43B249D60CC1A1B /* NotificationsConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22963BD06A9C83959D4914E4 /* NotificationsConfigRootView.swift */; };
+		CE0295982BE65817003D5E97 /* OverrideStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0295972BE65817003D5E97 /* OverrideStorage.swift */; };
+		CE02959B2BE65A40003D5E97 /* OverrideProfil.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE02959A2BE65A40003D5E97 /* OverrideProfil.swift */; };
+		CE02959F2BE7A003003D5E97 /* TestCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE02959E2BE7A003003D5E97 /* TestCoreData.swift */; };
+		CE0295A12BE7A4F9003D5E97 /* OverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0295A02BE7A4F9003D5E97 /* OverrideTests.swift */; };
+		CE0BF4B52BEA6CAB004C00DD /* NightscoutExercice.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0BF4B42BEA6CAB004C00DD /* NightscoutExercice.swift */; };
 		CE1F6DD92BADF4620064EB8D /* PluginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */; };
 		CE1F6DDB2BAE08B60064EB8D /* TidepoolManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DDA2BAE08B60064EB8D /* TidepoolManager.swift */; };
 		CE1F6DE72BAF1A180064EB8D /* BuildDetails.plist in Resources */ = {isa = PBXBuildFile; fileRef = CE1F6DE62BAF1A180064EB8D /* BuildDetails.plist */; };
@@ -812,6 +817,11 @@
 		C377490C77661D75E8C50649 /* ManualTempBasalRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalRootView.swift; sourceTree = "<group>"; };
 		C8D1A7CA8C10C4403D4BBFA7 /* BolusDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BolusDataFlow.swift; sourceTree = "<group>"; };
 		CC6C406D2ACDD69E009B8058 /* RawFetchedProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawFetchedProfile.swift; sourceTree = "<group>"; };
+		CE0295972BE65817003D5E97 /* OverrideStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideStorage.swift; sourceTree = "<group>"; };
+		CE02959A2BE65A40003D5E97 /* OverrideProfil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideProfil.swift; sourceTree = "<group>"; };
+		CE02959E2BE7A003003D5E97 /* TestCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCoreData.swift; sourceTree = "<group>"; };
+		CE0295A02BE7A4F9003D5E97 /* OverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideTests.swift; sourceTree = "<group>"; };
+		CE0BF4B42BEA6CAB004C00DD /* NightscoutExercice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutExercice.swift; sourceTree = "<group>"; };
 		CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginManagerTests.swift; sourceTree = "<group>"; };
 		CE1F6DDA2BAE08B60064EB8D /* TidepoolManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolManager.swift; sourceTree = "<group>"; };
 		CE1F6DE62BAF1A180064EB8D /* BuildDetails.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = BuildDetails.plist; sourceTree = "<group>"; };
@@ -1600,6 +1610,7 @@
 				19012CDB291D2CB900FB8210 /* LoopStats.swift */,
 				FE41E4D329463C660047FD55 /* NightscoutStatistics.swift */,
 				FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */,
+				CE0BF4B42BEA6CAB004C00DD /* NightscoutExercice.swift */,
 				191F62672AD6B05A004D7911 /* NightscoutSettings.swift */,
 				1967DFBD29D052C200759F30 /* Icons.swift */,
 				19D4E4EA29FC6A9F00351451 /* TIRforChart.swift */,
@@ -1607,6 +1618,7 @@
 				193F6CDC2A512C8F001240FD /* Loops.swift */,
 				CC6C406D2ACDD69E009B8058 /* RawFetchedProfile.swift */,
 				BDF530D72B40F8AC002CAF43 /* LockScreenView.swift */,
+				CE02959A2BE65A40003D5E97 /* OverrideProfil.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1653,6 +1665,7 @@
 				38F3B2EE25ED8E2A005C48AA /* TempTargetsStorage.swift */,
 				CE82E02428E867BA00473A9C /* AlertStorage.swift */,
 				1956FB202AFF79E200C7B4FF /* CoreDataStorage.swift */,
+				CE0295972BE65817003D5E97 /* OverrideStorage.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -1827,6 +1840,8 @@
 				38FCF3F825E902C20078B0D1 /* FileStorageTests.swift */,
 				CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */,
 				CEE9A65D2BBC9F6500EB5194 /* CalibrationsTests.swift */,
+				CE02959E2BE7A003003D5E97 /* TestCoreData.swift */,
+				CE0295A02BE7A4F9003D5E97 /* OverrideTests.swift */,
 			);
 			path = FreeAPSTests;
 			sourceTree = "<group>";
@@ -2706,6 +2721,7 @@
 				3883581C25EE79BB00E024B2 /* DecimalTextField.swift in Sources */,
 				6B1A8D2E2B156EEF00E76752 /* LiveActivityBridge.swift in Sources */,
 				38DAB28A260D349500F74C1A /* FetchGlucoseManager.swift in Sources */,
+				CE02959B2BE65A40003D5E97 /* OverrideProfil.swift in Sources */,
 				38F37828261260DC009DB701 /* Color+Extensions.swift in Sources */,
 				3811DE3F25C9D4A100A708ED /* SettingsStateModel.swift in Sources */,
 				CE7CA3582A064E2F004BE681 /* ListStateView.swift in Sources */,
@@ -2744,6 +2760,7 @@
 				E974172296125A5AE99E634C /* PumpConfigRootView.swift in Sources */,
 				CE7CA3522A064973004BE681 /* ListTempPresetsIntent.swift in Sources */,
 				448B6FCB252BD4796E2960C0 /* PumpSettingsEditorDataFlow.swift in Sources */,
+				CE0BF4B52BEA6CAB004C00DD /* NightscoutExercice.swift in Sources */,
 				38E44536274E411700EC9A94 /* Disk.swift in Sources */,
 				2BE9A6FA20875F6F4F9CD461 /* PumpSettingsEditorProvider.swift in Sources */,
 				6B9625766B697D1C98E455A2 /* PumpSettingsEditorStateModel.swift in Sources */,
@@ -2764,6 +2781,7 @@
 				FA630397F76B582C8D8681A7 /* BasalProfileEditorProvider.swift in Sources */,
 				63E890B4D951EAA91C071D5C /* BasalProfileEditorStateModel.swift in Sources */,
 				38FEF3FA2737E42000574A46 /* BaseStateModel.swift in Sources */,
+				CE0295982BE65817003D5E97 /* OverrideStorage.swift in Sources */,
 				CC6C406E2ACDD69E009B8058 /* RawFetchedProfile.swift in Sources */,
 				385CEA8225F23DFD002D6D5B /* NightscoutStatus.swift in Sources */,
 				F90692AA274B7AAE0037068D /* HealthKitManager.swift in Sources */,
@@ -2897,7 +2915,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE02959F2BE7A003003D5E97 /* TestCoreData.swift in Sources */,
 				CEE9A65E2BBC9F6500EB5194 /* CalibrationsTests.swift in Sources */,
+				CE0295A12BE7A4F9003D5E97 /* OverrideTests.swift in Sources */,
 				CE1F6DD92BADF4620064EB8D /* PluginManagerTests.swift in Sources */,
 				38FCF3F925E902C20078B0D1 /* FileStorageTests.swift in Sources */,
 			);
@@ -3230,7 +3250,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IBSC_MODULE = FreeAPSWatch_WatchKit_Extension;
 				INFOPLIST_FILE = FreeAPSWatch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Open-iAPS;
+				INFOPLIST_KEY_CFBundleDisplayName = "Open-iAPS";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "$(BUNDLE_IDENTIFIER)";
 				MARKETING_VERSION = "$(APP_VERSION)";
@@ -3265,7 +3285,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				IBSC_MODULE = FreeAPSWatch_WatchKit_Extension;
 				INFOPLIST_FILE = FreeAPSWatch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Open-iAPS;
+				INFOPLIST_KEY_CFBundleDisplayName = "Open-iAPS";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "$(BUNDLE_IDENTIFIER)";
 				MARKETING_VERSION = "$(APP_VERSION)";

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -73,6 +73,7 @@ final class BaseAPSManager: APSManager, Injectable {
     @Injected() private var settingsManager: SettingsManager!
     @Injected() private var broadcaster: Broadcaster!
     @Injected() private var healthKitManager: HealthKitManager!
+    @Injected() private var overrideStorage: OverrideStorage!
     @Persisted(key: "lastAutotuneDate") private var lastAutotuneDate = Date()
     @Persisted(key: "lastStartLoopDate") private var lastStartLoopDate: Date = .distantPast
     @Persisted(key: "lastLoopDate") var lastLoopDate: Date = .distantPast {
@@ -359,10 +360,12 @@ final class BaseAPSManager: APSManager, Injectable {
         let now = Date()
         let temp = currentTemp(date: now)
 
+        let eventuelOverride: OverrideProfil? = overrideStorage.current()
+
         let mainPublisher = makeProfiles()
             .flatMap { _ in self.autosens() }
             .flatMap { _ in self.dailyAutotune() }
-            .flatMap { _ in self.openAPS.determineBasal(currentTemp: temp, clock: now) }
+            .flatMap { _ in self.openAPS.determineBasal(currentTemp: temp, clock: now, override: eventuelOverride) }
             .map { suggestion -> Bool in
                 if let suggestion = suggestion {
                     DispatchQueue.main.async {

--- a/FreeAPS/Sources/APS/FetchGlucoseManager.swift
+++ b/FreeAPS/Sources/APS/FetchGlucoseManager.swift
@@ -297,11 +297,11 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
     private func overcalibrate(entries: [BloodGlucose]) -> [BloodGlucose] {
         // overcalibrate
         var overcalibration: ((Int) -> (Double))?
-       
+
         if let cal = calibrationService {
             overcalibration = cal.calibrate
         }
-       
+
         if let overcalibration = overcalibration {
             return entries.map { entry in
                 var entry = entry

--- a/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
@@ -1,0 +1,329 @@
+import CoreData
+import Foundation
+import SwiftDate
+import Swinject
+
+/// Observer to register to be informed by a change in the current override
+protocol OverrideObserver {
+    func overrideDidUpdate(_ targets: [OverrideProfil?])
+}
+
+protocol OverrideStorage {
+    func storeOverride(_ targets: [OverrideProfil])
+    func storeOverridePresets(_ targets: [OverrideProfil])
+    func presets() -> [OverrideProfil]
+    func syncDate() -> Date
+    func recent() -> [OverrideProfil?]
+    //  func nightscoutTretmentsNotUploaded() -> [NightscoutTreatment]
+    func current() -> OverrideProfil?
+    func cancelCurrentOverride() -> Decimal?
+    func applyOverridePreset(_ presetId: String) -> Date?
+    func deleteOverridePreset(_ presetId: String)
+}
+
+/// Class to manage the store of override and override preset
+final class BaseOverrideStorage: OverrideStorage, Injectable {
+    private let processQueue = DispatchQueue(label: "BaseOverrideStorage.processQueue")
+    @Injected() private var broadcaster: Broadcaster!
+    @Injected() private var settingsManager: SettingsManager!
+
+    let coredataContext: NSManagedObjectContext
+    private var lastCurrentOverride: OverrideProfil?
+
+    init(
+        resolver: Resolver,
+        managedObjectContext: NSManagedObjectContext = CoreDataStack.shared.persistentContainer.viewContext
+    ) {
+        coredataContext = managedObjectContext
+        injectServices(resolver)
+    }
+
+    /// Convert a override Preset Core Data as a Override Profil
+    /// - Parameter preset: a override preset in Core Data
+    /// - Returns: A override  in Override Profil structure
+    private func OverridePresetToOverrideProfil(_ preset: OverridePresets) -> OverrideProfil {
+        OverrideProfil(
+            id: preset.id ?? UUID().uuidString,
+            name: preset.name,
+            duration: preset.duration as Decimal?,
+            indefinite: preset.indefinite,
+            percentage: preset.percentage,
+            target: preset.target as Decimal?,
+            advancedSettings: preset.advancedSettings,
+            smbIsOff: preset.smbIsOff,
+            isfAndCr: preset.isfAndCr,
+            isf: preset.isf,
+            cr: preset.cr,
+            smbIsScheduledOff: preset.smbIsScheduledOff,
+            start: preset.start as Decimal?,
+            end: preset.end as Decimal?,
+            smbMinutes: preset.smbMinutes as Decimal?,
+            uamMinutes: preset.uamMinutes as Decimal?,
+            enteredBy: OverrideProfil.manual,
+            reason: ""
+        )
+    }
+
+    /// Convert a override  Core Data as a Override Profil
+    /// - Parameter preset: a override  in Core Data
+    /// - Returns: A override  in Override Profil structure
+    private func OverrideToOverrideProfil(_ preset: Override) -> OverrideProfil {
+        OverrideProfil(
+            id: preset.id!,
+            name: preset.name == "" ? nil : preset.name,
+            createdAt: preset.date,
+            duration: preset.duration as Decimal?,
+            indefinite: preset.indefinite,
+            percentage: preset.percentage,
+            target: preset.target as Decimal?,
+            advancedSettings: preset.advancedSettings,
+            smbIsOff: preset.smbIsOff,
+            isfAndCr: preset.isfAndCr,
+            isf: preset.isf,
+            cr: preset.cr,
+            smbIsScheduledOff: preset.smbIsScheduledOff,
+            start: preset.start as Decimal?,
+            end: preset.end as Decimal?,
+            smbMinutes: preset.smbMinutes as Decimal?,
+            uamMinutes: preset.uamMinutes as Decimal?,
+            enteredBy: OverrideProfil.manual,
+            reason: ""
+        )
+    }
+
+    /// Fetch all override presets available in storage core data
+    /// - Returns: List of override Presets as Override Profil structure
+    func presets() -> [OverrideProfil] {
+        fetchOverridePreset().compactMap {
+            OverridePresetToOverrideProfil($0)
+        }
+    }
+
+    /// Fetch all override presets available in storage core data
+    /// - Returns: List of override Presets in core data structure
+    private func fetchOverridePreset() -> [OverridePresets] {
+        coredataContext.performAndWait {
+            let requestPresets = OverridePresets.fetchRequest() as NSFetchRequest<OverridePresets>
+            let results = try? self.coredataContext.fetch(requestPresets)
+            return results ?? []
+        }
+    }
+
+    /// delete a preset override
+    /// - Parameter presetId: the identifier of the preset override
+    func deleteOverridePreset(_ presetId: String) {
+        coredataContext.performAndWait {
+            let requestPresets = OverridePresets.fetchRequest() as NSFetchRequest<OverridePresets>
+            requestPresets.predicate = NSPredicate(
+                format: "id == %@", presetId
+            )
+            let results = try? self.coredataContext.fetch(requestPresets)
+            if let deleteObject = results?.first {
+                self.coredataContext.delete(deleteObject)
+            }
+        }
+    }
+
+    /// Store new or updated override target
+    /// - Parameter targets: List of new or updated override
+    func storeOverride(_ targets: [OverrideProfil]) {
+        storeOverride(targets, isPresets: false)
+    }
+
+    /// Store override preset in Core Data
+    /// - Parameter targets: List of new or updated override preset
+    func storeOverridePresets(_ targets: [OverrideProfil]) {
+        storeOverride(targets, isPresets: true)
+    }
+
+    /// store overrides in Core Data and eventually update the current override event
+    /// - Parameters:
+    ///   - targets: List of new or updated override as a preset or as a target
+    ///   - isPresets: definied if targerts is a override preset (true).
+    private func storeOverride(_ targets: [OverrideProfil], isPresets: Bool) {
+        // store in preset override
+        // processQueue.sync {
+        if isPresets {
+            let listOverridePresets = fetchOverridePreset()
+            _ = targets.compactMap { preset in
+                // find if existing or create a new one
+                let save = listOverridePresets
+                    .first(where: { $0.id == preset.id }) ?? OverridePresets(context: coredataContext)
+                save.id = preset.id
+                save.name = preset.name
+                save.end = preset.end as NSDecimalNumber?
+                save.start = preset.start as NSDecimalNumber?
+                save.advancedSettings = preset.advancedSettings ?? false
+                save.cr = preset.cr ?? false
+                save.duration = preset.duration as NSDecimalNumber?
+                save.indefinite = preset.indefinite ?? true
+                save.isf = preset.isf ?? false
+                save.isfAndCr = preset.isfAndCr ?? false
+                save.percentage = preset.percentage ?? 100.0
+                save.smbIsScheduledOff = preset.smbIsScheduledOff ?? false
+                save.smbIsOff = preset.smbIsOff ?? false
+                save.smbMinutes = (preset.smbMinutes ?? settingsManager.preferences.maxSMBBasalMinutes) as NSDecimalNumber?
+                save.uamMinutes = (preset.uamMinutes ?? settingsManager.preferences.maxUAMSMBBasalMinutes) as NSDecimalNumber?
+                save.target = preset.target as NSDecimalNumber?
+                return save
+            }
+
+            coredataContext.performAndWait {
+                try? coredataContext.save()
+            }
+
+        } else {
+            _ = targets.compactMap { target in
+                // update if existing or create
+                let save = fetchOverrideById(id: target.id) ?? Override(context: coredataContext)
+                save.id = target.id
+                save.date = target.createdAt ?? Date()
+                save.name = target.name ?? ""
+                save.end = target.end as NSDecimalNumber?
+                save.start = target.start as NSDecimalNumber?
+                save.advancedSettings = target.advancedSettings ?? false
+                save.cr = target.cr ?? false
+                save.duration = target.duration as NSDecimalNumber?
+                save.indefinite = target.indefinite ?? true
+                save.isf = target.isf ?? false
+                save.isfAndCr = target.isfAndCr ?? false
+                save.percentage = target.percentage ?? 100.0
+                save.smbIsScheduledOff = target.smbIsScheduledOff ?? false
+                save.smbIsOff = target.smbIsOff ?? false
+                save.smbMinutes = (target.smbMinutes ?? settingsManager.preferences.maxSMBBasalMinutes) as NSDecimalNumber?
+                save.uamMinutes = (target.uamMinutes ?? settingsManager.preferences.maxUAMSMBBasalMinutes) as NSDecimalNumber?
+                save.target = target.target as NSDecimalNumber?
+                save.enabled = false // # TODO: don't use the attribute - compatibility only
+                return save
+            }
+
+            coredataContext.performAndWait {
+                try? coredataContext.save()
+            }
+            // update the previous current value
+            _ = current()
+        }
+        // }
+    }
+
+    /// The start date of override data available by recent function
+    /// - Returns: the oldest date of data returned
+    func syncDate() -> Date {
+        Date().addingTimeInterval(-1.days.timeInterval)
+    }
+
+    private func fetchNumberOfOverrides(numbers: Int) -> [Override]? {
+        coredataContext.performAndWait {
+            let requestOverrides = Override.fetchRequest() as NSFetchRequest<Override>
+            let sortOverride = NSSortDescriptor(key: "date", ascending: false)
+            requestOverrides.sortDescriptors = [sortOverride]
+            requestOverrides.fetchLimit = numbers
+            return try? self.coredataContext.fetch(requestOverrides)
+        }
+    }
+
+    private func fetchOverrides(interval: Date) -> [Override]? {
+        var overrideArray = [Override]()
+        coredataContext.performAndWait {
+            let requestOverrides = Override.fetchRequest() as NSFetchRequest<Override>
+            let sortOverride = NSSortDescriptor(key: "date", ascending: false)
+            requestOverrides.sortDescriptors = [sortOverride]
+            requestOverrides.predicate = NSPredicate(
+                format: "date > %@", interval as NSDate
+            )
+            try? overrideArray = self.coredataContext.fetch(requestOverrides)
+        }
+        return overrideArray
+    }
+
+    private func fetchOverrideById(id: String) -> Override? {
+        coredataContext.performAndWait {
+            let requestOverrides = Override.fetchRequest() as NSFetchRequest<Override>
+            requestOverrides.predicate = NSPredicate(
+                format: "id == %@", id
+            )
+            return try? self.coredataContext.fetch(requestOverrides).first
+        }
+    }
+
+    /// Provides the last 24 hours override stored in the core data
+    /// - Returns: a array of override profil sorted by date
+    func recent() -> [OverrideProfil?] {
+        if let overrideRecent = fetchOverrides(interval: syncDate()) {
+            return overrideRecent.compactMap {
+                OverrideToOverrideProfil($0)
+            }
+        } else {
+            return []
+        }
+    }
+
+    /// Provides the current override or nil if no is current available
+    /// broadcast a observer overrideDidUpdate if the current override has changed since the last current function call
+    /// - Returns: A override profil currently in action
+    func current() -> OverrideProfil? {
+        var newCurrentOverride: OverrideProfil?
+
+        if let overrideRecent = fetchNumberOfOverrides(numbers: 1), let overrideCurrent = overrideRecent.first {
+            if overrideCurrent.indefinite {
+                newCurrentOverride = OverrideToOverrideProfil(overrideCurrent)
+
+            } else if
+                let duration = overrideCurrent.duration as Decimal?,
+                let date = overrideCurrent.date,
+                (Date().timeIntervalSinceReferenceDate - date.timeIntervalSinceReferenceDate).minutes < Double(duration),
+                date <= Date(),
+                duration != 0
+            {
+                newCurrentOverride = OverrideToOverrideProfil(overrideCurrent)
+            } else {
+                newCurrentOverride = nil
+            }
+        } else {
+            newCurrentOverride = nil
+        }
+
+        processQueue.sync {
+            if lastCurrentOverride != newCurrentOverride {
+                broadcaster.notify(OverrideObserver.self, on: processQueue) {
+                    $0.overrideDidUpdate([newCurrentOverride])
+                }
+            }
+        }
+
+        lastCurrentOverride = newCurrentOverride
+
+        return newCurrentOverride
+    }
+
+    /// Cancel the current override
+    /// - Returns: the final duration of the event
+    func cancelCurrentOverride() -> Decimal? {
+        guard var currentOverride = current() else { return nil }
+
+        currentOverride
+            .duration =
+            Decimal(
+                (Date().timeIntervalSinceReferenceDate - currentOverride.createdAt!.timeIntervalSinceReferenceDate)
+                    .minutes
+            )
+
+        storeOverride([currentOverride])
+
+        return currentOverride.duration
+    }
+
+    /// Apply a override preset as the current override
+    /// - Parameter presetId: the identifier of the preset override
+    /// - Returns: the date of the creation/start of the current override event
+    func applyOverridePreset(_ presetId: String) -> Date? {
+        guard var preset = presets().first(where: { $0.id == presetId }) else { return nil }
+
+        // cancel the eventual current override
+        _ = cancelCurrentOverride()
+
+        preset.createdAt = Date()
+        storeOverride([preset])
+        return preset.createdAt
+    }
+}

--- a/FreeAPS/Sources/Assemblies/StorageAssembly.swift
+++ b/FreeAPS/Sources/Assemblies/StorageAssembly.swift
@@ -1,3 +1,4 @@
+import CoreData
 import Foundation
 import Swinject
 
@@ -15,5 +16,6 @@ final class StorageAssembly: Assembly {
         container.register(SettingsManager.self) { r in BaseSettingsManager(resolver: r) }
         container.register(Keychain.self) { _ in BaseKeychain() }
         container.register(AlertHistoryStorage.self) { r in BaseAlertHistoryStorage(resolver: r) }
+        container.register(OverrideStorage.self) { r in BaseOverrideStorage(resolver: r) }
     }
 }

--- a/FreeAPS/Sources/Helpers/CoreDataStack.swift
+++ b/FreeAPS/Sources/Helpers/CoreDataStack.swift
@@ -2,12 +2,20 @@ import CoreData
 import Foundation
 
 class CoreDataStack: ObservableObject {
+    public static let modelName = "Core_Data"
+
+    public static let model: NSManagedObjectModel = {
+        // swiftlint:disable force_unwrapping
+        let modelURL = Bundle.main.url(forResource: modelName, withExtension: "momd")!
+        return NSManagedObjectModel(contentsOf: modelURL)!
+    }()
+
     init() {}
 
     static let shared = CoreDataStack()
 
     lazy var persistentContainer: NSPersistentContainer = {
-        let container = NSPersistentContainer(name: "Core_Data")
+        let container = NSPersistentContainer(name: CoreDataStack.modelName)
 
         container.loadPersistentStores(completionHandler: { _, error in
             guard let error = error as NSError? else { return }

--- a/FreeAPS/Sources/Models/NightscoutExercice.swift
+++ b/FreeAPS/Sources/Models/NightscoutExercice.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A structure to descrive a Override as a exercice for NightScout
+struct NightscoutExercice: JSON, Hashable, Equatable {
+    var duration: Int?
+    var eventType: EventType
+    var createdAt: Date?
+    var enteredBy: String?
+    var notes: String?
+
+    static let local = "Trio"
+
+    static let empty = NightscoutExercice(from: "{}")!
+
+    static func == (lhs: NightscoutExercice, rhs: NightscoutExercice) -> Bool {
+        (lhs.createdAt ?? Date()) == (rhs.createdAt ?? Date())
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(createdAt ?? Date())
+    }
+}
+
+extension NightscoutExercice {
+    private enum CodingKeys: String, CodingKey {
+        case duration
+        case eventType
+        case createdAt = "created_at"
+        case enteredBy
+        case notes
+    }
+}

--- a/FreeAPS/Sources/Models/OverrideProfil.swift
+++ b/FreeAPS/Sources/Models/OverrideProfil.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct OverrideProfil: JSON, Identifiable, Equatable, Hashable {
+    var id = UUID().uuidString
+    var name: String? = nil
+    var createdAt: Date? = nil
+    var duration: Decimal? = nil {
+        didSet {
+            indefinite = (duration == nil)
+        }
+    }
+
+    var indefinite: Bool? = false
+    var percentage: Double? = 100
+    var target: Decimal? = 0
+    var advancedSettings: Bool? = false
+    var smbIsOff: Bool? = false
+    var isfAndCr: Bool? = false
+    var isf: Bool? = false
+    var cr: Bool? = false
+    var smbIsScheduledOff: Bool? = false
+    var start: Decimal? = 0
+    var end: Decimal? = 0
+
+    var smbMinutes: Decimal? = nil
+    var uamMinutes: Decimal? = nil
+    var enteredBy: String? = OverrideProfil.manual
+    var reason: String?
+
+    static let manual = "Trio"
+    static let custom = "Temp override"
+    static let cancel = "Cancel"
+
+    var displayName: String {
+        if let name = name, name != "" {
+            return name
+        } else {
+            return OverrideProfil.custom
+        }
+    }
+
+    static func == (lhs: OverrideProfil, rhs: OverrideProfil) -> Bool {
+        lhs.createdAt == rhs.createdAt && lhs.indefinite == rhs.indefinite && lhs.duration == rhs.duration
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func cancel(at date: Date) -> OverrideProfil {
+        OverrideProfil(
+            name: OverrideProfil.cancel,
+            createdAt: date,
+            duration: nil,
+            indefinite: false,
+            percentage: 100.0,
+            target: 0,
+            advancedSettings: false,
+            smbIsOff: false,
+            isfAndCr: false,
+            isf: false,
+            cr: false,
+            smbIsScheduledOff: false,
+            start: 0,
+            end: 0,
+            smbMinutes: nil,
+            uamMinutes: nil,
+            enteredBy: OverrideProfil.manual,
+            reason: OverrideProfil.cancel
+        )
+    }
+}
+
+extension OverrideProfil {
+    private enum CodingKeys: String, CodingKey {
+        case id = "_id"
+        case name
+        case createdAt
+        case advancedSettings
+        case cr
+        case duration
+        case end
+        case indefinite
+        case isf
+        case isfAndCr
+        case percentage
+        case smbIsScheduledOff
+        case smbIsOff
+        case smbMinutes
+        case start
+        case target
+        case uamMinutes
+        case enteredBy
+        case reason
+    }
+}

--- a/FreeAPS/Sources/Models/PumpHistoryEvent.swift
+++ b/FreeAPS/Sources/Models/PumpHistoryEvent.swift
@@ -69,6 +69,7 @@ enum EventType: String, JSON {
     case nsAnnouncement = "Announcement"
     case nsSensorChange = "Sensor Start"
     case nsExternalInsulin = "External Insulin"
+    case nsExercice = "Exercice"
 }
 
 enum TempType: String, JSON {

--- a/FreeAPS/Sources/Modules/Home/HomeProvider.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeProvider.swift
@@ -18,6 +18,12 @@ extension Home {
             storage.retrieve(OpenAPS.Enact.enacted, as: Suggestion.self)
         }
 
+        var profile: BGTargets {
+            storage.retrieve(OpenAPS.Settings.bgTargets, as: BGTargets.self)
+                ?? BGTargets(from: OpenAPS.defaults(for: OpenAPS.Settings.bgTargets))
+                ?? BGTargets(units: .mmolL, userPrefferedUnits: .mmolL, targets: [])
+        }
+
         func heartbeatNow() {
             apsManager.heartbeat(date: Date())
         }

--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -31,6 +31,7 @@ struct MainChartView: View {
         static let bolusScale: CGFloat = 2.5
         static let carbsSize: CGFloat = 10
         static let carbsScale: CGFloat = 0.3
+        static let overrideNoTargetDefault: Decimal = 50
     }
 
     @Binding var glucose: [BloodGlucose]
@@ -53,6 +54,8 @@ struct MainChartView: View {
     @Binding var displayXgridLines: Bool
     @Binding var displayYgridLines: Bool
     @Binding var thresholdLines: Bool
+    @Binding var overrideHistory: [OverrideProfil?]
+    @Binding var targetBG: BGTargets?
 
     @State var didAppearTrigger = false
     @State private var glucoseDots: [CGRect] = []
@@ -63,6 +66,7 @@ struct MainChartView: View {
     @State private var tempBasalPath = Path()
     @State private var regularBasalPath = Path()
     @State private var tempTargetsPath = Path()
+    @State private var overridesPath = Path()
     @State private var suspensionsPath = Path()
     @State private var carbsDots: [DotInfo] = []
     @State private var carbsPath = Path()
@@ -155,6 +159,7 @@ struct MainChartView: View {
             ScrollViewReader { scroll in
                 ZStack(alignment: .top) {
                     tempTargetsView(fullSize: fullSize).drawingGroup()
+                    overridesView(fullSize: fullSize).drawingGroup()
                     basalView(fullSize: fullSize).drawingGroup()
 
                     mainView(fullSize: fullSize).id(Config.endID)
@@ -444,6 +449,24 @@ struct MainChartView: View {
         }
         .onChange(of: didAppearTrigger) { _ in
             calculateTempTargetsRects(fullSize: fullSize)
+        }
+    }
+
+    private func overridesView(fullSize: CGSize) -> some View {
+        ZStack {
+            overridesPath
+                .fill(Color.purple.opacity(0.5))
+            overridesPath
+                .stroke(Color.purple.opacity(0.5), lineWidth: 1)
+        }
+        .onChange(of: glucose) { _ in
+            calculateOverridesRects(fullSize: fullSize)
+        }
+        .onChange(of: overrideHistory) { _ in
+            calculateOverridesRects(fullSize: fullSize)
+        }
+        .onChange(of: didAppearTrigger) { _ in
+            calculateOverridesRects(fullSize: fullSize)
         }
     }
 
@@ -801,6 +824,58 @@ extension MainChartView {
 
             DispatchQueue.main.async {
                 tempTargetsPath = path
+            }
+        }
+    }
+
+    private func calculateOverridesRects(fullSize: CGSize) {
+        calculationQueue.async {
+            let rects = overrideHistory.enumerated().compactMap { (index, override) -> CGRect? in
+                if let override = override {
+                    let x0 = timeToXCoordinate(override.createdAt!.timeIntervalSince1970, fullSize: fullSize)
+                    var y0: CGFloat
+                    if override.target != nil, override.target! > 0 {
+                        y0 = glucoseToYCoordinate(Int(override.target!), fullSize: fullSize)
+                    } else if let targetBG = targetBG {
+                        // find the targetBG at the beginning
+                        let bestOffset = override.createdAt!.hour * 60 + override.createdAt!.minute
+                        let targetItemBG = targetBG.targets.sorted(by: { $0.offset < $1.offset })
+                            .last(where: { $0.offset < bestOffset })?.low ?? Config.overrideNoTargetDefault
+                        y0 = glucoseToYCoordinate(Int(targetItemBG), fullSize: fullSize)
+                    } else {
+                        y0 = glucoseToYCoordinate(Int(Config.overrideNoTargetDefault), fullSize: fullSize)
+                    }
+
+                    // only the first override could be indefinite
+                    let x1 = override.indefinite! && index == 0 ?
+                        timeToXCoordinate(Date().timeIntervalSince1970, fullSize: fullSize)
+                        :
+                        timeToXCoordinate(
+                            override.createdAt!.timeIntervalSince1970 + Int(override.duration ?? 0).minutes.timeInterval,
+                            fullSize: fullSize
+                        )
+                    let widthRect = override.indefinite! && index == 0 ?
+                        x1 - x0 + additionalWidth(viewWidth: fullSize.width)
+                        :
+                        x1 - x0
+
+                    return CGRect(
+                        x: x0,
+                        y: y0 - 3,
+                        width: widthRect,
+                        height: 6
+                    )
+                } else {
+                    return nil
+                }
+            }
+
+            let path = Path { path in
+                path.addRects(rects)
+            }
+
+            DispatchQueue.main.async {
+                overridesPath = path
             }
         }
     }

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -15,27 +15,11 @@ extension Home {
         @Environment(\.managedObjectContext) var moc
         @Environment(\.colorScheme) var colorScheme
 
-        @FetchRequest(
-            entity: Override.entity(),
-            sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)]
-        ) var fetchedPercent: FetchedResults<Override>
-
-        @FetchRequest(
-            entity: OverridePresets.entity(),
-            sortDescriptors: [NSSortDescriptor(key: "name", ascending: true)], predicate: NSPredicate(
-                format: "name != %@", "" as String
-            )
-        ) var fetchedProfiles: FetchedResults<OverridePresets>
-
+        // * TODO: To remove with #154 https://github.com/nightscout/Open-iAPS/issues/154
         @FetchRequest(
             entity: TempTargets.entity(),
             sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)]
         ) var sliderTTpresets: FetchedResults<TempTargets>
-
-        @FetchRequest(
-            entity: TempTargetsSlider.entity(),
-            sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)]
-        ) var enactedSliderTT: FetchedResults<TempTargetsSlider>
 
         private var numberFormatter: NumberFormatter {
             let formatter = NumberFormatter()
@@ -198,6 +182,7 @@ extension Home {
             let rawString = (tirFormatter.string(from: (tempTarget.targetBottom ?? 0) as NSNumber) ?? "") + " " + state.units
                 .rawValue
 
+            // * TODO: To remove with #154 https://github.com/nightscout/Open-iAPS/issues/154
             var string = ""
             if sliderTTpresets.first?.active ?? false {
                 let hbt = sliderTTpresets.first?.hbt ?? 0
@@ -210,12 +195,12 @@ extension Home {
         }
 
         var overrideString: String? {
-            guard fetchedPercent.first?.enabled ?? false else {
+            guard state.currentOverride != nil else {
                 return nil
             }
-            var percentString = "\((fetchedPercent.first?.percentage ?? 100).formatted(.number)) %"
-            var target = (fetchedPercent.first?.target ?? 100) as Decimal
-            let indefinite = (fetchedPercent.first?.indefinite ?? false)
+            var percentString = "\((state.currentOverride?.percentage ?? 100).formatted(.number)) %"
+            var target = (state.currentOverride?.target ?? 100) as Decimal
+            let indefinite = (state.currentOverride?.indefinite ?? false)
             let unit = state.units.rawValue
             if state.units == .mmolL {
                 target = target.asMmolL
@@ -224,16 +209,16 @@ extension Home {
             if tempTargetString != nil || target == 0 { targetString = "" }
             percentString = percentString == "100 %" ? "" : percentString
 
-            let duration = (fetchedPercent.first?.duration ?? 0) as Decimal
+            let duration = state.currentOverride?.duration ?? 0
             let addedMinutes = Int(duration)
-            let date = fetchedPercent.first?.date ?? Date()
+            let date = state.currentOverride?.createdAt ?? Date()
             var newDuration: Decimal = 0
 
             if date.addingTimeInterval(addedMinutes.minutes.timeInterval) > Date() {
                 newDuration = Decimal(Date().distance(to: date.addingTimeInterval(addedMinutes.minutes.timeInterval)).minutes)
             }
 
-            var durationString = indefinite ?
+            let durationString = indefinite ?
                 "" : newDuration >= 1 ?
                 (newDuration.formatted(.number.grouping(.never).rounded().precision(.fractionLength(0))) + " min") :
                 (
@@ -248,12 +233,12 @@ extension Home {
             }
 
             let smbToggleString = (
-                (fetchedPercent.first?.smbIsOff ?? false) || fetchedPercent.first?.smbIsScheduledOff ?? false
+                (state.currentOverride?.smbIsOff ?? false) || state.currentOverride?.smbIsScheduledOff ?? false
             ) ?
                 " \u{20e0}" : ""
-            let smbScheduleString = (fetchedPercent.first?.smbIsScheduledOff ?? false) &&
-                !(fetchedPercent.first?.smbIsOff ?? false) ?
-                " \(fetchedPercent.first?.start ?? 0)-\(fetchedPercent.first?.end ?? 0)" : ""
+            let smbScheduleString = (state.currentOverride?.smbIsScheduledOff ?? false) &&
+                !(state.currentOverride?.smbIsOff ?? false) ?
+                " \(state.currentOverride?.start ?? 0)-\(state.currentOverride?.end ?? 0)" : ""
             let comma1 = (percentString == "" || (targetString == "" && durationString == "" && smbToggleString == ""))
                 ? "" : " , "
             let comma2 = (targetString == "" || (durationString == "" && smbToggleString == ""))
@@ -385,7 +370,9 @@ extension Home {
                     screenHours: $state.screenHours,
                     displayXgridLines: $state.displayXgridLines,
                     displayYgridLines: $state.displayYgridLines,
-                    thresholdLines: $state.thresholdLines
+                    thresholdLines: $state.thresholdLines,
+                    overrideHistory: $state.overrideHistory,
+                    targetBG: $state.targetBG
                 )
             }
             .padding(.bottom)
@@ -397,7 +384,7 @@ extension Home {
             // Rectangle().fill(colour).frame(maxHeight: 1)
             ZStack {
                 Rectangle().fill(Color.gray.opacity(0.2)).frame(maxHeight: 40)
-                let cancel = fetchedPercent.first?.enabled ?? false
+                let cancel = state.currentOverride != nil
                 HStack(spacing: cancel ? 25 : 15) {
                     Text(selectedProfile().name).foregroundColor(.secondary)
                     if cancel, selectedProfile().isOn {
@@ -412,8 +399,8 @@ extension Home {
                         Image(systemName: "person.3.sequence.fill")
                             .symbolRenderingMode(.palette)
                             .foregroundStyle(
-                                !(fetchedPercent.first?.enabled ?? false) ? .green : .cyan,
-                                !(fetchedPercent.first?.enabled ?? false) ? .cyan : .green,
+                                !(state.currentOverride != nil) ? .green : .cyan,
+                                !(state.currentOverride != nil) ? .cyan : .green,
                                 .purple
                             )
                     }
@@ -435,24 +422,21 @@ extension Home {
             var profileString = ""
             var display: Bool = false
 
-            let duration = (fetchedPercent.first?.duration ?? 0) as Decimal
-            let indefinite = fetchedPercent.first?.indefinite ?? false
+            let duration = (state.currentOverride?.duration ?? 0) as Decimal
+            let indefinite = state.currentOverride?.indefinite ?? false
             let addedMinutes = Int(duration)
-            let date = fetchedPercent.first?.date ?? Date()
+            let date = state.currentOverride?.createdAt ?? Date()
             if date.addingTimeInterval(addedMinutes.minutes.timeInterval) > Date() || indefinite {
                 display.toggle()
             }
 
-            if fetchedPercent.first?.enabled ?? false, !(fetchedPercent.first?.isPreset ?? false), display {
-                profileString = NSLocalizedString("Custom Profile", comment: "Custom but unsaved Profile")
-            } else if !(fetchedPercent.first?.enabled ?? false) || !display {
-                profileString = NSLocalizedString("Normal Profile", comment: "Your normal Profile. Use a short string")
+            if let currentOverride = state.currentOverride, display {
+                profileString = currentOverride.name != nil ? currentOverride.displayName : NSLocalizedString(
+                    "Custom Profile",
+                    comment: "Custom but unsaved Profile"
+                )
             } else {
-                let id_ = fetchedPercent.first?.id ?? ""
-                let profile = fetchedProfiles.filter({ $0.id == id_ }).first
-                if profile != nil {
-                    profileString = profile?.name?.description ?? ""
-                }
+                profileString = NSLocalizedString("Normal Profile", comment: "Your normal Profile. Use a short string")
             }
             return (name: profileString, isOn: display)
         }

--- a/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
@@ -243,6 +243,49 @@ extension NightscoutAPI {
             .eraseToAnyPublisher()
     }
 
+    /// fetch the overrides available in NS as a exercice since the date specified in the parameter
+    /// Limit to exercice with the attribute enteredBy = the name of local app (as defined in NightscoutExercice
+    /// - Parameter sinceDate: the oldest date to fetch exercices
+    /// - Returns: A publisher with a array of NightscoutExercice or error
+    func fetchOverrides(sinceDate: Date? = nil) -> AnyPublisher<[NightscoutExercice], Swift.Error> {
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.port = url.port
+        components.path = Config.treatmentsPath
+        components.queryItems = [
+            URLQueryItem(name: "find[eventType]", value: "Exercice"),
+            URLQueryItem(
+                name: "find[enteredBy]",
+                value: NightscoutExercice.local.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
+            )
+        ]
+        if let date = sinceDate {
+            let dateItem = URLQueryItem(
+                name: "find[created_at][$gt]",
+                value: Formatter.iso8601withFractionalSeconds.string(from: date)
+            )
+            components.queryItems?.append(dateItem)
+        }
+
+        var request = URLRequest(url: components.url!)
+        request.allowsConstrainedNetworkAccess = false
+        request.timeoutInterval = Config.timeout
+
+        if let secret = secret {
+            request.addValue(secret.sha1(), forHTTPHeaderField: "api-secret")
+        }
+
+        return service.run(request)
+            .retry(Config.retryCount)
+            .decode(type: [NightscoutExercice].self, decoder: JSONCoding.decoder)
+            .catch { error -> AnyPublisher<[NightscoutExercice], Swift.Error> in
+                warning(.nightscout, "Override fetching error: \(error.localizedDescription)")
+                return Just([]).setFailureType(to: Swift.Error.self).eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+
     func fetchAnnouncement(sinceDate: Date? = nil) -> AnyPublisher<[Announcement], Swift.Error> {
         var components = URLComponents()
         components.scheme = url.scheme
@@ -439,6 +482,65 @@ extension NightscoutAPI {
         }
         request.httpBody = try! JSONCoding.encoder.encode(profile)
         request.httpMethod = "POST"
+
+        return service.run(request)
+            .retry(Config.retryCount)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
+    /// Upload old, new and updated overrides in NS as a exercice.
+    /// - Parameter overrides: a array of NightscoutExercice to upload
+    /// - Returns: A publisher with only error response.
+    func uploadOverrides(_ overrides: [NightscoutExercice]) -> AnyPublisher<Void, Swift.Error> {
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.port = url.port
+        components.path = Config.treatmentsPath
+
+        var request = URLRequest(url: components.url!)
+        request.allowsConstrainedNetworkAccess = false
+        request.timeoutInterval = Config.timeout
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let secret = secret {
+            request.addValue(secret.sha1(), forHTTPHeaderField: "api-secret")
+        }
+        request.httpBody = try! JSONCoding.encoder.encode(overrides)
+        request.httpMethod = "POST"
+
+        return service.run(request)
+            .retry(Config.retryCount)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
+    /// delete a override in NS as exercice for a specific date
+    /// - Parameter date: the date of the override to delete
+    /// - Returns: A publisher with only error response.
+    func deleteOverride(at date: Date) -> AnyPublisher<Void, Swift.Error> {
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.port = url.port
+        components.path = Config.treatmentsPath
+        components.queryItems = [
+            URLQueryItem(name: "find[eventType]", value: "Exercice"),
+            URLQueryItem(
+                name: "find[created_at][$eq]",
+                value: Formatter.iso8601withFractionalSeconds.string(from: date)
+            )
+        ]
+
+        var request = URLRequest(url: components.url!)
+        request.allowsConstrainedNetworkAccess = false
+        request.timeoutInterval = Config.timeout
+        request.httpMethod = "DELETE"
+
+        if let secret = secret {
+            request.addValue(secret.sha1(), forHTTPHeaderField: "api-secret")
+        }
 
         return service.run(request)
             .retry(Config.retryCount)

--- a/FreeAPSTests/OverrideTests.swift
+++ b/FreeAPSTests/OverrideTests.swift
@@ -1,0 +1,160 @@
+//
+//  OverrideTests.swift
+//  FreeAPSTests
+//
+//  Created by Pierre LAGARDE on 05/05/2024.
+//
+import CoreData
+@testable import FreeAPS
+import Swinject
+import XCTest
+
+final class OverrideTests: XCTestCase, Injectable {
+    var overrideTestStorage: OverrideStorage!
+    let resolver = FreeAPSApp().resolver
+    var coreDataStack: CoreDataStack?
+
+    override func setUp() {
+        coreDataStack = TestCoreData()
+        (resolver as! Container)
+            .register(OverrideStorage.self, name: "testOverrideStorage") { r in
+                BaseOverrideStorage(resolver: r, managedObjectContext: self.coreDataStack!.persistentContainer.viewContext) }
+
+        overrideTestStorage = resolver.resolve(OverrideStorage.self, name: "testOverrideStorage")
+        injectServices(resolver)
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+        overrideTestStorage = nil
+        coreDataStack = nil
+    }
+
+    func testAddOverridePreset() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+
+        // new override preset :
+        let op = OverrideProfil(name: "test 1", percentage: 120, reason: "test 1")
+
+        overrideTestStorage.storeOverridePresets([op])
+        XCTAssertTrue(overrideTestStorage.presets().count == 1)
+        XCTAssertTrue(overrideTestStorage.presets().first?.percentage == 120)
+        XCTAssertNil(overrideTestStorage.presets().first?.date)
+
+        let op2 = OverrideProfil(name: "test 2", percentage: 80, reason: "test 2")
+        let op3 = OverrideProfil(name: "test 3", percentage: 200, reason: "test 3")
+        overrideTestStorage.storeOverridePresets([op2, op3])
+        XCTAssertTrue(overrideTestStorage.presets().count == 3)
+    }
+
+    func testUpdateOverridePreset() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+
+        // new override preset :
+        let op = OverrideProfil(name: "test 1", percentage: 120, reason: "test 1")
+
+        overrideTestStorage.storeOverridePresets([op])
+        var opUpdate = overrideTestStorage.presets().first
+        opUpdate?.percentage = 150
+        overrideTestStorage.storeOverridePresets([opUpdate!])
+        XCTAssertTrue(overrideTestStorage.presets().count == 1)
+        XCTAssertTrue(overrideTestStorage.presets().first?.percentage == 150)
+    }
+
+    func testRemoveOverridePreset() {
+        // new override preset :
+        let op = OverrideProfil(name: "test 1", percentage: 120, reason: "test 1")
+
+        overrideTestStorage.storeOverridePresets([op])
+        XCTAssertTrue(overrideTestStorage.presets().count == 1)
+        let id = overrideTestStorage.presets().first(where: { $0.name == "test 1" })?.id
+        overrideTestStorage.deleteOverridePreset(id!)
+        XCTAssertTrue(overrideTestStorage.presets().isEmpty)
+    }
+
+    func testAddOverride() {
+        let op = OverrideProfil(createdAt: Date(), duration: 20, percentage: 110, reason: "test 1")
+        let op2 = OverrideProfil(
+            createdAt: Date().addingTimeInterval(-10.minutes),
+            duration: 10,
+            percentage: 120,
+            reason: "test 2"
+        )
+        let op3 = OverrideProfil(
+            createdAt: Date().addingTimeInterval(-2.days.timeInterval),
+            percentage: 20,
+            reason: "test 3"
+        )
+
+        overrideTestStorage.storeOverride([op, op2, op3])
+
+        XCTAssertTrue(overrideTestStorage.recent().count == 2)
+        XCTAssertTrue(overrideTestStorage.recent().last!?.duration == 10)
+        XCTAssertTrue(overrideTestStorage.current()?.percentage == 110)
+    }
+
+    func testUpdateOverride() {
+        let op = OverrideProfil(createdAt: Date(), duration: 20, percentage: 110, reason: "test 1")
+
+        overrideTestStorage.storeOverride([op])
+        var opUpdate = overrideTestStorage.current()!
+        opUpdate.duration = nil // force to be indefinate
+        overrideTestStorage.storeOverride([opUpdate])
+        XCTAssertNil(overrideTestStorage.current()?.duration)
+        XCTAssertTrue(overrideTestStorage.current()?.indefinite == true)
+    }
+
+    func testCancelOverride() {
+        let op = OverrideProfil(
+            createdAt: Date().addingTimeInterval(-10.minutes),
+            duration: 20,
+            percentage: 110,
+            reason: "test 1"
+        )
+
+        overrideTestStorage.storeOverride([op])
+        let durationFinal = overrideTestStorage.cancelCurrentOverride()!
+        XCTAssertNil(overrideTestStorage.current())
+        XCTAssertLessThan(durationFinal, 1)
+    }
+
+    func testApplyOverrideProfil() {
+        let op = OverrideProfil(name: "test 1", indefinite: true, percentage: 120, reason: "test 1")
+        overrideTestStorage.storeOverridePresets([op])
+
+//        let ov = OverrideProfil(createdAt: Date(), indefinite: true, percentage: 10, reason: "test 2")
+//        overrideTestStorage.storeOverride([ov])
+
+        let presetId = overrideTestStorage.presets().first?.id
+
+        let date: Date = overrideTestStorage.applyOverridePreset(presetId!)!
+
+        XCTAssertTrue(overrideTestStorage.current()?.percentage == 120)
+        XCTAssertTrue(overrideTestStorage.current()?.createdAt == date)
+
+        let op2 = OverrideProfil(name: "test 2", duration: 20, percentage: 10, reason: "test 2")
+        overrideTestStorage.storeOverridePresets([op2])
+
+        let presetId2 = overrideTestStorage.presets().first(where: { $0.name == "test 2" })!.id
+
+        _ = overrideTestStorage.applyOverridePreset(presetId2)
+
+        XCTAssertTrue(overrideTestStorage.recent().count == 2)
+        XCTAssertTrue(overrideTestStorage.recent().last??.indefinite == false)
+        if let duration = overrideTestStorage.recent().last??.duration {
+            XCTAssertLessThan(duration, 1)
+        } else {
+            XCTAssert(false)
+        }
+        XCTAssertTrue(overrideTestStorage.current()?.percentage == 10)
+    }
+}

--- a/FreeAPSTests/TestCoreData.swift
+++ b/FreeAPSTests/TestCoreData.swift
@@ -1,0 +1,28 @@
+//
+//  TestCoreData.swift
+//  FreeAPSTests
+//
+//  Created by Pierre LAGARDE on 05/05/2024.
+//
+import CoreData
+@testable import FreeAPS
+import Swinject
+import XCTest
+
+final class TestCoreData: CoreDataStack {
+    override init() {
+        super.init()
+        let persistentStoreDescription = NSPersistentStoreDescription()
+        persistentStoreDescription.type = NSInMemoryStoreType
+        let container = NSPersistentContainer(name: CoreDataStack.modelName, managedObjectModel: CoreDataStack.model)
+
+        container.persistentStoreDescriptions = [persistentStoreDescription]
+
+        container.loadPersistentStores { _, error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+        persistentContainer = container
+    }
+}

--- a/Open-iAPS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Open-iAPS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -48,7 +48,7 @@
     {
       "identity" : "swiftcharts",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ivanschuetz/SwiftCharts",
+      "location" : "https://github.com/ivanschuetz/SwiftCharts.git",
       "state" : {
         "branch" : "master",
         "revision" : "c354c1945bb35a1f01b665b22474f6db28cba4a2"


### PR DESCRIPTION
The PR includes a large refactoring of the swift part of override/profile functions :
- Override is stored in override core data, including history
- Override preset is stored in overridepreset core data
- Add the display of the override in main graph
- add the upload of override as a exercice in Nightscout - Fix #145 
- improve the management of indefinate override / stop of indefinate override
- modify the code to respect the Ivan’s patterns of the app : 

> - Use of swiftInject (dependency injection) with the use of protocol class in the code 
> - Use of MVP principes, in particular not use of direct coredata in view class 
> - Use of a proxy model class between coredata and the app to manage changes of core data 
> - Use of the pattern of observe to refresh data/view/uploads
> 

- add a core data unit tests allowing to add tests for coredata with a in-memory datastore for tests.
- test for overrideStorage available

This PR do NOT change the logic with oref and the interface of override informations in oref. This PR do NOT require a update of trio-oref code.

TODO : Changes the shortcuts after merging with PR #144   and add watch for overrides.

| override display | override in NS |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-05-07 at 21 43 34](https://github.com/nightscout/Trio/assets/4339604/b7635c39-79db-4f48-b352-de955c3d4989)| ![CleanShot 2024-05-07 at 21 44 16](https://github.com/nightscout/Trio/assets/4339604/2e6400aa-b93c-463d-a19b-3feed04d055f) | 




