### PR TITLE
Cleanup unused code from LA commit

### DIFF
--- a/FreeAPS/Sources/Modules/NotificationsConfig/View/NotificationsConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/NotificationsConfig/View/NotificationsConfigRootView.swift
@@ -34,27 +34,6 @@ extension NotificationsConfig {
             return formatter
         }
 
-        @Environment(\.colorScheme) var colorScheme
-
-        var color: LinearGradient {
-            colorScheme == .dark ? LinearGradient(
-                gradient: Gradient(colors: [
-                    Color("Background_1"),
-                    Color("Background_1"),
-                    Color("Background_2")
-                    // Color("Background_1")
-                ]),
-                startPoint: .top,
-                endPoint: .bottom
-            )
-                :
-                LinearGradient(
-                    gradient: Gradient(colors: [Color.gray.opacity(0.1)]),
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-        }
-
         @ViewBuilder private func liveActivitySection() -> some View {
             if #available(iOS 16.2, *) {
                 Section(
@@ -132,7 +111,7 @@ extension NotificationsConfig {
                 }
 
                 liveActivitySection()
-            }.scrollContentBackground(.hidden).background(color)
+            }.scrollContentBackground(.hidden)
                 .onAppear(perform: configureView)
                 .navigationBarTitle("Notifications")
                 .navigationBarTitleDisplayMode(.automatic)


### PR DESCRIPTION
Removes some lingering that was mistakenly kept from LA cherry picks. The code shouldn't cause any problems, but it did cause an error to be thrown in the Debug Log in Xcode, which no longer happens after applying this PR.