### PR TITLE
Restore identifier

### DIFF
--- a/FreeAPS/Resources/Info.plist
+++ b/FreeAPS/Resources/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>AppGroupID</key>
 	<string>$(APP_GROUP_ID)</string>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER).background-task.critical-event-log</string>
+	</array>
 	<key>CBBundleDisplayName</key>
 	<string>$(APP_DISPLAY_NAME)</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
This reverts a few lines from commit 08e6a801a21d8d742f9cccebb5102913df00a68f.

@avouspierre mentioned it wasn't used now, so it was okay to delete, and it built and worked fine with an Xcode build, but it prevented me from building via GitHub: [failed run](https://github.com/MikePlante1/Trio/actions/runs/9021140115/job/24787839530#step:11:62)

After applying this PR, it built successfully: [successful run](https://github.com/MikePlante1/Trio/actions/runs/9021640129)