### PR TITLE
fix importing settings from Nightscout

### DIFF
--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -198,7 +198,7 @@ extension NightscoutConfig {
 
                         let sensitivities = fetchedProfile.sens.map { sensitivity -> InsulinSensitivityEntry in
                             InsulinSensitivityEntry(
-                                sensitivity: self.units == .mmolL ? sensitivity.value : sensitivity.value.asMgdL,
+                                sensitivity: sensitivity.value,
                                 offset: self.offset(sensitivity.time) / 60,
                                 start: sensitivity.time
                             )
@@ -219,8 +219,8 @@ extension NightscoutConfig {
                         let targets = fetchedProfile.target_low
                             .map { target -> BGTargetEntry in
                                 BGTargetEntry(
-                                    low: self.units == .mmolL ? target.value : target.value.asMgdL,
-                                    high: self.units == .mmolL ? target.value : target.value.asMgdL,
+                                    low: target.value,
+                                    high: target.value,
                                     start: target.time,
                                     offset: self.offset(target.time) / 60
                                 ) }


### PR DESCRIPTION
Before this PR, two settings were not imported from Nightscout correctly for me.
My 95 mg/dL target glucose got imported as 72 mg/dL (the lowest allowed)
My 58mg/dL ISF got imported as 9 mg/dL

After applying this PR and building to a fresh now simulator, my settings were imported correctly.

I then reset the simulator and installed this PR again to test with somebody else's Nightscout which uses mmol/L and confirmed target glucose and ISF did get imported correctly as well.