### PR TITLE
update `Max Bolus exceeded` label

### DIFF
--- a/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
@@ -80,10 +80,11 @@ extension Bolus {
                         Button { state.add() }
                         label: {
                             Text(
-                                state.amount < state.maxBolus ? NSLocalizedString("Enact bolus", comment: "") :
+                                state.amount <= state.maxBolus ? NSLocalizedString("Enact bolus", comment: "") :
                                     NSLocalizedString("Max Bolus exceeded!", comment: "")
                                     + " (>"
                                     + formatter.string(from: state.maxBolus as NSNumber)!
+                                    + NSLocalizedString("U", comment: "Insulin unit")
                                     + ")"
                             ) }
                             .disabled(


### PR DESCRIPTION
no longer shows when amount equals max, and adds unit after max bolus amount.