### PR TITLE
“Add pump” button when pump has not been configured

### DIFF
--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -185,6 +185,8 @@ extension Home {
                             setupDelegate: self
                         ).asAny()
                         self.router.mainSecondaryModalView.send(view)
+                    } else if show {
+                        self.router.mainSecondaryModalView.send(self.router.view(for: .pumpConfigDirect))
                     } else {
                         self.router.mainSecondaryModalView.send(nil)
                     }

--- a/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
@@ -24,11 +24,9 @@ struct PumpView: View {
         VStack(alignment: .leading, spacing: 12) {
             if reservoir == nil && battery == nil {
                 VStack(alignment: .center, spacing: 12) {
-                    HStack
-                        {
-                            // no cgm defined so display a generic CGM
-                            Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
-                        }
+                    HStack { // no cgm defined so display a generic CGM
+                        Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
+                    }
                     HStack {
                         Text("Add pump").font(.caption).bold()
                     }

--- a/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
@@ -22,6 +22,19 @@ struct PumpView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
+            if reservoir == nil && battery == nil {
+                VStack(alignment: .center, spacing: 12) {
+                    HStack
+                        {
+                            // no cgm defined so display a generic CGM
+                            Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
+                        }
+                    HStack {
+                        Text("Add pump").font(.caption).bold()
+                    }
+                }.frame(alignment: .top)
+            }
+
             if let reservoir = reservoir {
                 HStack {
                     Image(systemName: "drop.fill")

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -149,9 +149,7 @@ extension Home {
                 timerDate: $state.timerDate
             )
             .onTapGesture {
-                // if state.pumpDisplayState != nil {
                 state.setupPump = true
-                // }
             }
         }
 

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -149,9 +149,9 @@ extension Home {
                 timerDate: $state.timerDate
             )
             .onTapGesture {
-                if state.pumpDisplayState != nil {
-                    state.setupPump = true
-                }
+                // if state.pumpDisplayState != nil {
+                state.setupPump = true
+                // }
             }
         }
 

--- a/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
@@ -4,6 +4,7 @@ import Swinject
 extension PumpConfig {
     struct RootView: BaseView {
         let resolver: Resolver
+        let displayClose: Bool
         @StateObject var state = StateModel()
 
         var body: some View {
@@ -34,6 +35,7 @@ extension PumpConfig {
                 .onAppear(perform: configureView)
                 .navigationTitle("Pump config")
                 .navigationBarTitleDisplayMode(.automatic)
+                .navigationBarItems(leading: displayClose ? Button("Close", action: state.hideModal) : nil)
                 .sheet(isPresented: $state.setupPump) {
                     if let pumpManager = state.provider.apsManager.pumpManager {
                         PumpSettingsView(

--- a/FreeAPS/Sources/Router/Screen.swift
+++ b/FreeAPS/Sources/Router/Screen.swift
@@ -9,6 +9,7 @@ enum Screen: Identifiable, Hashable {
     case nighscoutConfig
     case nighscoutConfigDirect
     case pumpConfig
+    case pumpConfigDirect
     case pumpSettingsEditor
     case basalProfileEditor
     case isfEditor
@@ -53,7 +54,9 @@ extension Screen {
         case .nighscoutConfigDirect:
             NightscoutConfig.RootView(resolver: resolver, displayClose: true)
         case .pumpConfig:
-            PumpConfig.RootView(resolver: resolver)
+            PumpConfig.RootView(resolver: resolver, displayClose: false)
+        case .pumpConfigDirect:
+            PumpConfig.RootView(resolver: resolver, displayClose: true)
         case .pumpSettingsEditor:
             PumpSettingsEditor.RootView(resolver: resolver)
         case .basalProfileEditor:


### PR DESCRIPTION
The PR adds a “pump” icon and “add pump” label in the header of the main view. 
The tap gesture open the view to select a pump. 

Link with #171 to review.
 
![Simulator Screenshot - iPhone 15 - 2024-05-14 at 17 14 04](https://github.com/nightscout/Trio/assets/4339604/73e39f53-9bd6-4e75-a2e3-461f059fccd6)
