### PR TITLE
LiveActivity.swift: widget URL string "Trio://"

### DIFF
--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -288,7 +288,7 @@ struct LiveActivity: Widget {
                     label.fontWidth(.compressed)
                 }
             }
-            .widgetURL(URL(string: "freeaps-x://"))
+            .widgetURL(URL(string: "Trio://"))
             .keylineTint(Color.purple)
             .contentMargins(.horizontal, 0, for: .minimal)
             .contentMargins(.trailing, 0, for: .compactLeading)


### PR DESCRIPTION
Replaces widgetURL(URL(string: "freeaps-x://"))

Related to #136 