### PR TITLE
Restore tests (replaces PR #147)

### DIFF
--- a/FreeAPS.xcodeproj/xcshareddata/xcschemes/Trio.xcscheme
+++ b/FreeAPS.xcodeproj/xcshareddata/xcschemes/Trio.xcscheme
@@ -263,7 +263,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "43CABDFC1C3506F100005705"
@@ -273,7 +273,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C17F50CD291EAC3800555EB5"
@@ -283,7 +283,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "43D8FDD41C728FDF0073BE78"
@@ -293,7 +293,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B4CEE2DF257129780093111B"
@@ -303,7 +303,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C13CC34029C7B73A007F25DE"
@@ -313,7 +313,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "84752E8A26ED0FFE009FD801"
@@ -323,7 +323,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C12ED9C929C7DBA900435701"
@@ -333,7 +333,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "431CE7761F98564200255374"

--- a/FreeAPSTests/CalibrationsTests.swift
+++ b/FreeAPSTests/CalibrationsTests.swift
@@ -30,16 +30,24 @@ class CalibrationsTests: XCTestCase, Injectable {
 
         let calibration2 = Calibration(x: 120.0, y: 130.0)
         calibrationService.addCalibration(calibration2)
+        // The original 4 XCTAsserts() below fail on the initial run,
+        //    but will work on subsequent runs.
+        // Should fix this stuff to not be stateful so that the
+        //    same results are obtained on each run.
+        // Temporary fix comment out original and use XCTAssertEqual
+        //    which allows an accuracy parameter
+        // XCTAssertTrue(calibrationService.slope == 0.8)
+        // XCTAssertTrue(calibrationService.intercept == 37)
+        // XCTAssertTrue(calibrationService.calibrate(value: 80) == 101)
 
-        XCTAssertTrue(calibrationService.slope == 0.8)
-
-        XCTAssertTrue(calibrationService.intercept == 37)
-
-        XCTAssertTrue(calibrationService.calibrate(value: 80) == 101)
+        XCTAssertEqual(calibrationService.slope, 0.95, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.intercept, 16, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.calibrate(value: 80), 92, accuracy: 0.0001)
 
         calibrationService.removeLast()
 
-        XCTAssertTrue(calibrationService.calibrations.count == 1)
+        // XCTAssertTrue(calibrationService.calibrations.count == 1)
+        XCTAssertEqual(calibrationService.calibrations.count, 2)
 
         calibrationService.removeAllCalibrations()
         XCTAssertTrue(calibrationService.calibrations.isEmpty)

--- a/FreeAPSTests/CalibrationsTests.swift
+++ b/FreeAPSTests/CalibrationsTests.swift
@@ -12,6 +12,9 @@ class CalibrationsTests: XCTestCase, Injectable {
     }
 
     func testCreateSimpleCalibration() {
+        // restore state so each test is independent
+        calibrationService.removeAllCalibrations()
+
         let calibration = Calibration(x: 100.0, y: 102.0)
         calibrationService.addCalibration(calibration)
 
@@ -25,29 +28,22 @@ class CalibrationsTests: XCTestCase, Injectable {
     }
 
     func testCreateMultipleCalibration() {
+        // restore state so each test is independent
+        calibrationService.removeAllCalibrations()
+
         let calibration = Calibration(x: 100.0, y: 120)
         calibrationService.addCalibration(calibration)
 
         let calibration2 = Calibration(x: 120.0, y: 130.0)
         calibrationService.addCalibration(calibration2)
-        // The original 4 XCTAsserts() below fail on the initial run,
-        //    but will work on subsequent runs.
-        // Should fix this stuff to not be stateful so that the
-        //    same results are obtained on each run.
-        // Temporary fix comment out original and use XCTAssertEqual
-        //    which allows an accuracy parameter
-        // XCTAssertTrue(calibrationService.slope == 0.8)
-        // XCTAssertTrue(calibrationService.intercept == 37)
-        // XCTAssertTrue(calibrationService.calibrate(value: 80) == 101)
 
-        XCTAssertEqual(calibrationService.slope, 0.95, accuracy: 0.0001)
-        XCTAssertEqual(calibrationService.intercept, 16, accuracy: 0.0001)
-        XCTAssertEqual(calibrationService.calibrate(value: 80), 92, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.slope, 0.8, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.intercept, 37, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.calibrate(value: 80), 101, accuracy: 0.0001)
 
         calibrationService.removeLast()
 
-        // XCTAssertTrue(calibrationService.calibrations.count == 1)
-        XCTAssertEqual(calibrationService.calibrations.count, 2)
+        XCTAssertTrue(calibrationService.calibrations.count == 1)
 
         calibrationService.removeAllCalibrations()
         XCTAssertTrue(calibrationService.calibrations.isEmpty)


### PR DESCRIPTION
There are 2 commits to this PR.
* The first one restores the tests which were changed to "skip".
* The second one should be reviewed - it modifies `testCreateMultipleCalibration` test so it will pass instead of fail

These are notes from @itsmojo:

Regarding having to comment out the 4 tests in CalibrationsTests, the issue seems to be that the expected values are only returned on the first Test run for a given iPhone simulator. After the first run, the values seem to be a consistent values of 0.9500000000000307, 15.999999999996717, 91.99999999999918 & 2 (instead of the 0.8, 37, 101 & 1 in the initial run that are being tested for). So this seems like this is a stateful test which really should be reworked to have consistent results on each run. Also, using XCTAssertTrue() for these tests is not as helpful as using XCTAssertEqual() so that you can see both values on a failure and so an optional accuracy parameter can be used to deal with non exact floating point values like 15.999999999996717.

Note:

The original PR #147 was automatically closed when the Trio repository was made public. This replaces that PR.