### PR TITLE
Display Pump Status Highlight Message in home view

### DIFF
--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -59,6 +59,7 @@ extension Home {
         @Published var displayYgridLines: Bool = false
         @Published var thresholdLines: Bool = false
         @Published var cgmAvailable: Bool = false
+        @Published var pumpStatutHighlightMessage: String? = nil
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
 
@@ -168,6 +169,7 @@ extension Home {
                     } else {
                         self.setupBattery()
                         self.setupReservoir()
+                        self.displayPumpStatutHighlightMessage()
                     }
                 }
                 .store(in: &lifetime)
@@ -348,6 +350,21 @@ extension Home {
             }
         }
 
+        /// Display the eventual statut message provided by the manager of the pump
+        /// Only display if state is warning or critical message else return nil
+        private func displayPumpStatutHighlightMessage() {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                if let statusHL = self.provider.deviceManager.pumpManager?.pumpStatusHighlight,
+                   statusHL.state == .warning || statusHL.state == .critical
+                {
+                    pumpStatutHighlightMessage = (statusHL.state == .warning ? "⚠️\n" : "‼️\n") + statusHL.localizedMessage
+                } else {
+                    pumpStatutHighlightMessage = nil
+                }
+            }
+        }
+
         private func setupCurrentTempTarget() {
             tempTarget = provider.tempTarget()
         }
@@ -412,6 +429,7 @@ extension Home.StateModel:
         setupBasals()
         setupBoluses()
         setupSuspensions()
+        displayPumpStatutHighlightMessage()
     }
 
     func pumpSettingsDidChange(_: PumpSettings) {
@@ -437,10 +455,12 @@ extension Home.StateModel:
 
     func pumpBatteryDidChange(_: Battery) {
         setupBattery()
+        displayPumpStatutHighlightMessage()
     }
 
     func pumpReservoirDidChange(_: Decimal) {
         setupReservoir()
+        displayPumpStatutHighlightMessage()
     }
 }
 

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -59,7 +59,7 @@ extension Home {
         @Published var displayYgridLines: Bool = false
         @Published var thresholdLines: Bool = false
         @Published var cgmAvailable: Bool = false
-        @Published var pumpStatutHighlightMessage: String? = nil
+        @Published var pumpStatusHighlightMessage: String? = nil
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
 
@@ -169,7 +169,7 @@ extension Home {
                     } else {
                         self.setupBattery()
                         self.setupReservoir()
-                        self.displayPumpStatutHighlightMessage()
+                        self.displaypumpStatusHighlightMessage()
                     }
                 }
                 .store(in: &lifetime)
@@ -352,15 +352,15 @@ extension Home {
 
         /// Display the eventual statut message provided by the manager of the pump
         /// Only display if state is warning or critical message else return nil
-        private func displayPumpStatutHighlightMessage() {
+        private func displaypumpStatusHighlightMessage() {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 if let statusHL = self.provider.deviceManager.pumpManager?.pumpStatusHighlight,
                    statusHL.state == .warning || statusHL.state == .critical
                 {
-                    pumpStatutHighlightMessage = (statusHL.state == .warning ? "⚠️\n" : "‼️\n") + statusHL.localizedMessage
+                    pumpStatusHighlightMessage = (statusHL.state == .warning ? "⚠️\n" : "‼️\n") + statusHL.localizedMessage
                 } else {
-                    pumpStatutHighlightMessage = nil
+                    pumpStatusHighlightMessage = nil
                 }
             }
         }
@@ -429,7 +429,7 @@ extension Home.StateModel:
         setupBasals()
         setupBoluses()
         setupSuspensions()
-        displayPumpStatutHighlightMessage()
+        displaypumpStatusHighlightMessage()
     }
 
     func pumpSettingsDidChange(_: PumpSettings) {
@@ -455,12 +455,12 @@ extension Home.StateModel:
 
     func pumpBatteryDidChange(_: Battery) {
         setupBattery()
-        displayPumpStatutHighlightMessage()
+        displaypumpStatusHighlightMessage()
     }
 
     func pumpReservoirDidChange(_: Decimal) {
         setupReservoir()
-        displayPumpStatutHighlightMessage()
+        displaypumpStatusHighlightMessage()
     }
 }
 

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -350,7 +350,7 @@ extension Home {
             }
         }
 
-        /// Display the eventual statut message provided by the manager of the pump
+        /// Display the eventual status message provided by the manager of the pump
         /// Only display if state is warning or critical message else return nil
         private func displaypumpStatusHighlightMessage() {
             DispatchQueue.main.async { [weak self] in

--- a/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
@@ -6,7 +6,7 @@ struct PumpView: View {
     @Binding var name: String
     @Binding var expiresAtDate: Date?
     @Binding var timerDate: Date
-    @Binding var pumpStatutHighlightMessage: String?
+    @Binding var pumpStatusHighlightMessage: String?
 
     private var reservoirFormatter: NumberFormatter {
         let formatter = NumberFormatter()
@@ -22,67 +22,68 @@ struct PumpView: View {
     }
 
     var body: some View {
-        if let pumpStatutHighlightMessage = pumpStatutHighlightMessage { // display message instead pump info
+        if let pumpStatusHighlightMessage = pumpStatusHighlightMessage { // display message instead pump info
             VStack(alignment: .center) {
-                Text(pumpStatutHighlightMessage).font(.footnote).fontWeight(.bold)
+                Text(pumpStatusHighlightMessage).font(.footnote).fontWeight(.bold)
                     .multilineTextAlignment(.center).frame(maxWidth: /*@START_MENU_TOKEN@*/ .infinity/*@END_MENU_TOKEN@*/)
             }.frame(width: 100)
         } else {
             VStack(alignment: .leading, spacing: 12) {
                 if reservoir == nil && battery == nil {
-                                VStack(alignment: .center, spacing: 12) {
-                                    HStack { // no cgm defined so display a generic CGM
-                                        Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
-                                    }
-                                    HStack {
-                                        Text("Add pump").font(.caption).bold()
-                                    }
-                                }.frame(alignment: .top)
-                            }
-                
-                if let reservoir = reservoir {
-                                HStack {
-                                    Image(systemName: "drop.fill")
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                        .frame(maxHeight: 10)
-                                        .foregroundColor(reservoirColor)
-                                    if reservoir == 0xDEAD_BEEF {
-                                        Text("50+ " + NSLocalizedString("U", comment: "Insulin unit")).font(.footnote)
-                                            .fontWeight(.bold)
-                                    } else {
-                                        Text(
-                                            reservoirFormatter
-                                                .string(from: reservoir as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit")
-                                        )
-                                        .font(.footnote).fontWeight(.bold)
-                                    }
-                                }.frame(alignment: .top)
-                            }
-                            if let battery = battery, battery.display ?? false, expiresAtDate == nil {
-                                HStack {
-                                    Image(systemName: "battery.100")
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                        .frame(maxHeight: 10)
-                                        .foregroundColor(batteryColor)
-                                    Text("\(Int(battery.percent ?? 100)) %").font(.footnote)
-                                        .fontWeight(.bold)
-                                }.frame(alignment: .bottom)
-                            }
-
-                            if let date = expiresAtDate {
-                                HStack {
-                                    Image(systemName: "stopwatch.fill")
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                        .frame(maxHeight: 10)
-                                        .foregroundColor(timerColor)
-                                    Text(remainingTimeString(time: date.timeIntervalSince(timerDate))).font(.footnote)
-                                        .fontWeight(.bold)
-                                }.frame(alignment: .bottom)
-                            }
+                    VStack(alignment: .center, spacing: 12) {
+                        HStack { // no cgm defined so display a generic CGM
+                            Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
                         }
+                        HStack {
+                            Text("Add pump").font(.caption).bold()
+                        }
+                    }.frame(alignment: .top)
+                }
+
+                if let reservoir = reservoir {
+                    HStack {
+                        Image(systemName: "drop.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxHeight: 10)
+                            .foregroundColor(reservoirColor)
+                        if reservoir == 0xDEAD_BEEF {
+                            Text("50+ " + NSLocalizedString("U", comment: "Insulin unit")).font(.footnote)
+                                .fontWeight(.bold)
+                        } else {
+                            Text(
+                                reservoirFormatter
+                                    .string(from: reservoir as NSNumber)! +
+                                    NSLocalizedString(" U", comment: "Insulin unit")
+                            )
+                            .font(.footnote).fontWeight(.bold)
+                        }
+                    }.frame(alignment: .top)
+                }
+                if let battery = battery, battery.display ?? false, expiresAtDate == nil {
+                    HStack {
+                        Image(systemName: "battery.100")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxHeight: 10)
+                            .foregroundColor(batteryColor)
+                        Text("\(Int(battery.percent ?? 100)) %").font(.footnote)
+                            .fontWeight(.bold)
+                    }.frame(alignment: .bottom)
+                }
+
+                if let date = expiresAtDate {
+                    HStack {
+                        Image(systemName: "stopwatch.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxHeight: 10)
+                            .foregroundColor(timerColor)
+                        Text(remainingTimeString(time: date.timeIntervalSince(timerDate))).font(.footnote)
+                            .fontWeight(.bold)
+                    }.frame(alignment: .bottom)
+                }
+            }
         }
     }
 
@@ -165,7 +166,7 @@ struct PumpView: View {
         name: .constant("Pump test"),
         expiresAtDate: .constant(Date().addingTimeInterval(24.hours)),
         timerDate: .constant(Date()),
-        pumpStatutHighlightMessage: .constant("⚠️\n Insulin suspended")
+        pumpStatusHighlightMessage: .constant("⚠️\n Insulin suspended")
     )
 }
 
@@ -176,7 +177,7 @@ struct PumpView: View {
         name: .constant("Pump test"),
         expiresAtDate: .constant(nil),
         timerDate: .constant(Date().addingTimeInterval(-24.hours)),
-        pumpStatutHighlightMessage: .constant(nil)
+        pumpStatusHighlightMessage: .constant(nil)
     )
 }
 
@@ -187,7 +188,7 @@ struct PumpView: View {
         name: .constant("Pump test"),
         expiresAtDate: .constant(Date().addingTimeInterval(2.hours)),
         timerDate: .constant(Date().addingTimeInterval(2.hours)),
-        pumpStatutHighlightMessage: .constant(nil)
+        pumpStatusHighlightMessage: .constant(nil)
     )
 }
 
@@ -198,6 +199,6 @@ struct PumpView: View {
         name: .constant(""),
         expiresAtDate: .constant(nil),
         timerDate: .constant(Date()),
-        pumpStatutHighlightMessage: .constant(nil)
+        pumpStatusHighlightMessage: .constant(nil)
     )
 }

--- a/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
@@ -6,6 +6,7 @@ struct PumpView: View {
     @Binding var name: String
     @Binding var expiresAtDate: Date?
     @Binding var timerDate: Date
+    @Binding var pumpStatutHighlightMessage: String?
 
     private var reservoirFormatter: NumberFormatter {
         let formatter = NumberFormatter()
@@ -21,60 +22,67 @@ struct PumpView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            if reservoir == nil && battery == nil {
-                VStack(alignment: .center, spacing: 12) {
-                    HStack { // no cgm defined so display a generic CGM
-                        Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
-                    }
-                    HStack {
-                        Text("Add pump").font(.caption).bold()
-                    }
-                }.frame(alignment: .top)
-            }
+        if let pumpStatutHighlightMessage = pumpStatutHighlightMessage { // display message instead pump info
+            VStack(alignment: .center) {
+                Text(pumpStatutHighlightMessage).font(.footnote).fontWeight(.bold)
+                    .multilineTextAlignment(.center).frame(maxWidth: /*@START_MENU_TOKEN@*/ .infinity/*@END_MENU_TOKEN@*/)
+            }.frame(width: 100)
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                if reservoir == nil && battery == nil {
+                                VStack(alignment: .center, spacing: 12) {
+                                    HStack { // no cgm defined so display a generic CGM
+                                        Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
+                                    }
+                                    HStack {
+                                        Text("Add pump").font(.caption).bold()
+                                    }
+                                }.frame(alignment: .top)
+                            }
+                
+                if let reservoir = reservoir {
+                                HStack {
+                                    Image(systemName: "drop.fill")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(maxHeight: 10)
+                                        .foregroundColor(reservoirColor)
+                                    if reservoir == 0xDEAD_BEEF {
+                                        Text("50+ " + NSLocalizedString("U", comment: "Insulin unit")).font(.footnote)
+                                            .fontWeight(.bold)
+                                    } else {
+                                        Text(
+                                            reservoirFormatter
+                                                .string(from: reservoir as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit")
+                                        )
+                                        .font(.footnote).fontWeight(.bold)
+                                    }
+                                }.frame(alignment: .top)
+                            }
+                            if let battery = battery, battery.display ?? false, expiresAtDate == nil {
+                                HStack {
+                                    Image(systemName: "battery.100")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(maxHeight: 10)
+                                        .foregroundColor(batteryColor)
+                                    Text("\(Int(battery.percent ?? 100)) %").font(.footnote)
+                                        .fontWeight(.bold)
+                                }.frame(alignment: .bottom)
+                            }
 
-            if let reservoir = reservoir {
-                HStack {
-                    Image(systemName: "drop.fill")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxHeight: 10)
-                        .foregroundColor(reservoirColor)
-                    if reservoir == 0xDEAD_BEEF {
-                        Text("50+ " + NSLocalizedString("U", comment: "Insulin unit")).font(.footnote)
-                            .fontWeight(.bold)
-                    } else {
-                        Text(
-                            reservoirFormatter
-                                .string(from: reservoir as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit")
-                        )
-                        .font(.footnote).fontWeight(.bold)
-                    }
-                }.frame(alignment: .top)
-            }
-            if let battery = battery, battery.display ?? false, expiresAtDate == nil {
-                HStack {
-                    Image(systemName: "battery.100")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxHeight: 10)
-                        .foregroundColor(batteryColor)
-                    Text("\(Int(battery.percent ?? 100)) %").font(.footnote)
-                        .fontWeight(.bold)
-                }.frame(alignment: .bottom)
-            }
-
-            if let date = expiresAtDate {
-                HStack {
-                    Image(systemName: "stopwatch.fill")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxHeight: 10)
-                        .foregroundColor(timerColor)
-                    Text(remainingTimeString(time: date.timeIntervalSince(timerDate))).font(.footnote)
-                        .fontWeight(.bold)
-                }.frame(alignment: .bottom)
-            }
+                            if let date = expiresAtDate {
+                                HStack {
+                                    Image(systemName: "stopwatch.fill")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(maxHeight: 10)
+                                        .foregroundColor(timerColor)
+                                    Text(remainingTimeString(time: date.timeIntervalSince(timerDate))).font(.footnote)
+                                        .fontWeight(.bold)
+                                }.frame(alignment: .bottom)
+                            }
+                        }
         }
     }
 
@@ -148,4 +156,48 @@ struct PumpView: View {
             return .loopGreen
         }
     }
+}
+
+#Preview("message") {
+    PumpView(
+        reservoir: .constant(Decimal(10.0)),
+        battery: .constant(nil),
+        name: .constant("Pump test"),
+        expiresAtDate: .constant(Date().addingTimeInterval(24.hours)),
+        timerDate: .constant(Date()),
+        pumpStatutHighlightMessage: .constant("⚠️\n Insulin suspended")
+    )
+}
+
+#Preview("pump reservoir") {
+    PumpView(
+        reservoir: .constant(Decimal(40.0)),
+        battery: .constant(Battery(percent: 50, voltage: 2.0, string: BatteryState.normal, display: true)),
+        name: .constant("Pump test"),
+        expiresAtDate: .constant(nil),
+        timerDate: .constant(Date().addingTimeInterval(-24.hours)),
+        pumpStatutHighlightMessage: .constant(nil)
+    )
+}
+
+#Preview("pump expiration") {
+    PumpView(
+        reservoir: .constant(Decimal(10.0)),
+        battery: .constant(Battery(percent: 50, voltage: 2.0, string: BatteryState.normal, display: false)),
+        name: .constant("Pump test"),
+        expiresAtDate: .constant(Date().addingTimeInterval(2.hours)),
+        timerDate: .constant(Date().addingTimeInterval(2.hours)),
+        pumpStatutHighlightMessage: .constant(nil)
+    )
+}
+
+#Preview("no pump") {
+    PumpView(
+        reservoir: .constant(nil),
+        battery: .constant(nil),
+        name: .constant(""),
+        expiresAtDate: .constant(nil),
+        timerDate: .constant(Date()),
+        pumpStatutHighlightMessage: .constant(nil)
+    )
 }

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -146,7 +146,8 @@ extension Home {
                 battery: $state.battery,
                 name: $state.pumpName,
                 expiresAtDate: $state.pumpExpiresAtDate,
-                timerDate: $state.timerDate
+                timerDate: $state.timerDate,
+                pumpStatutHighlightMessage: $state.pumpStatutHighlightMessage
             )
             .onTapGesture {
                 state.setupPump = true

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -147,7 +147,7 @@ extension Home {
                 name: $state.pumpName,
                 expiresAtDate: $state.pumpExpiresAtDate,
                 timerDate: $state.timerDate,
-                pumpStatutHighlightMessage: $state.pumpStatutHighlightMessage
+                pumpStatusHighlightMessage: $state.pumpStatusHighlightMessage
             )
             .onTapGesture {
                 state.setupPump = true


### PR DESCRIPTION
Display the eventual Pump Statut Highlight Message in home view if state is warning or critical.

fix partially issue #207 with displaying "No pod" in the homeview. 

Example in French : 

| Warning message | Critical message |
|--------|--------|
| ![CleanShot 2024-05-19 at 09 44 58@2x](https://github.com/nightscout/Trio/assets/4339604/afb515b7-32c7-465b-b50f-6676148c41e9) | ![CleanShot 2024-05-19 at 09 44 27@2x](https://github.com/nightscout/Trio/assets/4339604/c14ac5f8-41ac-46d1-8660-221aa63e4136) | 


