### PR TITLE
Override refactor + override in charts + override in Watch 

### DIFF
--- a/Core_Data.xcdatamodeld/Core_Data.xcdatamodel/contents
+++ b/Core_Data.xcdatamodeld/Core_Data.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22757" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22222" systemVersion="23E224" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="BGaverages" representedClassName="BGaverages" syncable="YES" codeGenerationType="class">
         <attribute name="average" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
         <attribute name="average_1" optional="YES" attributeType="Decimal" defaultValueString="0.0"/>
@@ -65,6 +65,7 @@
         <attribute name="isf" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="isfAndCr" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isPreset" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="percentage" optional="YES" attributeType="Double" defaultValueString="100" usesScalarValueType="YES"/>
         <attribute name="smbIsOff" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="smbIsScheduledOff" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		5D16287A969E64D18CE40E44 /* PumpConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F60E97100041040446F44E7 /* PumpConfigStateModel.swift */; };
 		63E890B4D951EAA91C071D5C /* BasalProfileEditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF91130F2FCCC7EBBA11AD /* BasalProfileEditorStateModel.swift */; };
 		642F76A05A4FF530463A9FD0 /* NightscoutConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8782B44544F38F2B2D82C38E /* NightscoutConfigRootView.swift */; };
+		65070A332BFDCB83006F213F /* TidePoolStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65070A322BFDCB83006F213F /* TidePoolStartView.swift */; };
 		6632A0DC746872439A858B44 /* ISFEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BDA519C9B890FD9A5DFCF3 /* ISFEditorDataFlow.swift */; };
 		69A31254F2451C20361D172F /* BolusStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223EC0494F55A91E3EA69EF4 /* BolusStateModel.swift */; };
 		69B9A368029F7EB39F525422 /* CREditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64AA5E04A2761F6EEA6568E1 /* CREditorStateModel.swift */; };
@@ -772,6 +773,7 @@
 		60744C3E9BB3652895C908CC /* DataTableProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableProvider.swift; sourceTree = "<group>"; };
 		618E62C9757B2F95431B5DC0 /* AddCarbsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddCarbsProvider.swift; sourceTree = "<group>"; };
 		64AA5E04A2761F6EEA6568E1 /* CREditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CREditorStateModel.swift; sourceTree = "<group>"; };
+		65070A322BFDCB83006F213F /* TidePoolStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidePoolStartView.swift; sourceTree = "<group>"; };
 		67F94DD2853CF42BA4E30616 /* BasalProfileEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorDataFlow.swift; sourceTree = "<group>"; };
 		680C4420C9A345D46D90D06C /* ManualTempBasalProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalProvider.swift; sourceTree = "<group>"; };
 		6B1A8D012B14D88B00E76752 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
@@ -1287,6 +1289,7 @@
 				3811DE3C25C9D4A100A708ED /* SettingsRootView.swift */,
 				CE1F6DE82BAF37C90064EB8D /* TidePoolConfigView.swift */,
 				DD1DB7CD2BED00CF0048B367 /* SettingsRootViewModel.swift */,
+				65070A322BFDCB83006F213F /* TidePoolStartView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2663,6 +2666,7 @@
 				3811DE1825C9D40400A708ED /* Router.swift in Sources */,
 				CE7950262998056D00FA576E /* CGMSetupView.swift in Sources */,
 				38A0363B25ECF07E00FCBB52 /* GlucoseStorage.swift in Sources */,
+				65070A332BFDCB83006F213F /* TidePoolStartView.swift in Sources */,
 				190EBCC629FF138000BA767D /* StatConfigProvider.swift in Sources */,
 				38E98A2725F52C9300C0CED0 /* CollectionIssueReporter.swift in Sources */,
 				E00EEC0427368630002FF094 /* SecurityAssembly.swift in Sources */,

--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -287,6 +287,11 @@
 		CA370FC152BC98B3D1832968 /* BasalProfileEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8BCB0C37DEB5EC377B9612 /* BasalProfileEditorRootView.swift */; };
 		CC6C406E2ACDD69E009B8058 /* RawFetchedProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6C406D2ACDD69E009B8058 /* RawFetchedProfile.swift */; };
 		CD78BB94E43B249D60CC1A1B /* NotificationsConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22963BD06A9C83959D4914E4 /* NotificationsConfigRootView.swift */; };
+		CE0295982BE65817003D5E97 /* OverrideStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0295972BE65817003D5E97 /* OverrideStorage.swift */; };
+		CE02959B2BE65A40003D5E97 /* OverrideProfil.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE02959A2BE65A40003D5E97 /* OverrideProfil.swift */; };
+		CE02959F2BE7A003003D5E97 /* TestCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE02959E2BE7A003003D5E97 /* TestCoreData.swift */; };
+		CE0295A12BE7A4F9003D5E97 /* OverrideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0295A02BE7A4F9003D5E97 /* OverrideTests.swift */; };
+		CE0BF4B52BEA6CAB004C00DD /* NightscoutExercice.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0BF4B42BEA6CAB004C00DD /* NightscoutExercice.swift */; };
 		CE1F6DD92BADF4620064EB8D /* PluginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */; };
 		CE1F6DDB2BAE08B60064EB8D /* TidepoolManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DDA2BAE08B60064EB8D /* TidepoolManager.swift */; };
 		CE1F6DE72BAF1A180064EB8D /* BuildDetails.plist in Resources */ = {isa = PBXBuildFile; fileRef = CE1F6DE62BAF1A180064EB8D /* BuildDetails.plist */; };
@@ -812,6 +817,11 @@
 		C377490C77661D75E8C50649 /* ManualTempBasalRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalRootView.swift; sourceTree = "<group>"; };
 		C8D1A7CA8C10C4403D4BBFA7 /* BolusDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BolusDataFlow.swift; sourceTree = "<group>"; };
 		CC6C406D2ACDD69E009B8058 /* RawFetchedProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawFetchedProfile.swift; sourceTree = "<group>"; };
+		CE0295972BE65817003D5E97 /* OverrideStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideStorage.swift; sourceTree = "<group>"; };
+		CE02959A2BE65A40003D5E97 /* OverrideProfil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideProfil.swift; sourceTree = "<group>"; };
+		CE02959E2BE7A003003D5E97 /* TestCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCoreData.swift; sourceTree = "<group>"; };
+		CE0295A02BE7A4F9003D5E97 /* OverrideTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideTests.swift; sourceTree = "<group>"; };
+		CE0BF4B42BEA6CAB004C00DD /* NightscoutExercice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutExercice.swift; sourceTree = "<group>"; };
 		CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginManagerTests.swift; sourceTree = "<group>"; };
 		CE1F6DDA2BAE08B60064EB8D /* TidepoolManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolManager.swift; sourceTree = "<group>"; };
 		CE1F6DE62BAF1A180064EB8D /* BuildDetails.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = BuildDetails.plist; sourceTree = "<group>"; };
@@ -1602,6 +1612,7 @@
 				19012CDB291D2CB900FB8210 /* LoopStats.swift */,
 				FE41E4D329463C660047FD55 /* NightscoutStatistics.swift */,
 				FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */,
+				CE0BF4B42BEA6CAB004C00DD /* NightscoutExercice.swift */,
 				191F62672AD6B05A004D7911 /* NightscoutSettings.swift */,
 				1967DFBD29D052C200759F30 /* Icons.swift */,
 				19D4E4EA29FC6A9F00351451 /* TIRforChart.swift */,
@@ -1609,6 +1620,7 @@
 				193F6CDC2A512C8F001240FD /* Loops.swift */,
 				CC6C406D2ACDD69E009B8058 /* RawFetchedProfile.swift */,
 				BDF530D72B40F8AC002CAF43 /* LockScreenView.swift */,
+				CE02959A2BE65A40003D5E97 /* OverrideProfil.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1656,6 +1668,7 @@
 				38F3B2EE25ED8E2A005C48AA /* TempTargetsStorage.swift */,
 				CE82E02428E867BA00473A9C /* AlertStorage.swift */,
 				1956FB202AFF79E200C7B4FF /* CoreDataStorage.swift */,
+				CE0295972BE65817003D5E97 /* OverrideStorage.swift */,
 			);
 			path = Storage;
 			sourceTree = "<group>";
@@ -1830,6 +1843,8 @@
 				38FCF3F825E902C20078B0D1 /* FileStorageTests.swift */,
 				CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */,
 				CEE9A65D2BBC9F6500EB5194 /* CalibrationsTests.swift */,
+				CE02959E2BE7A003003D5E97 /* TestCoreData.swift */,
+				CE0295A02BE7A4F9003D5E97 /* OverrideTests.swift */,
 			);
 			path = FreeAPSTests;
 			sourceTree = "<group>";
@@ -2708,6 +2723,7 @@
 				3883581C25EE79BB00E024B2 /* DecimalTextField.swift in Sources */,
 				6B1A8D2E2B156EEF00E76752 /* LiveActivityBridge.swift in Sources */,
 				38DAB28A260D349500F74C1A /* FetchGlucoseManager.swift in Sources */,
+				CE02959B2BE65A40003D5E97 /* OverrideProfil.swift in Sources */,
 				38F37828261260DC009DB701 /* Color+Extensions.swift in Sources */,
 				3811DE3F25C9D4A100A708ED /* SettingsStateModel.swift in Sources */,
 				CE7CA3582A064E2F004BE681 /* ListStateView.swift in Sources */,
@@ -2747,6 +2763,7 @@
 				E974172296125A5AE99E634C /* PumpConfigRootView.swift in Sources */,
 				CE7CA3522A064973004BE681 /* ListTempPresetsIntent.swift in Sources */,
 				448B6FCB252BD4796E2960C0 /* PumpSettingsEditorDataFlow.swift in Sources */,
+				CE0BF4B52BEA6CAB004C00DD /* NightscoutExercice.swift in Sources */,
 				38E44536274E411700EC9A94 /* Disk.swift in Sources */,
 				2BE9A6FA20875F6F4F9CD461 /* PumpSettingsEditorProvider.swift in Sources */,
 				6B9625766B697D1C98E455A2 /* PumpSettingsEditorStateModel.swift in Sources */,
@@ -2767,6 +2784,7 @@
 				FA630397F76B582C8D8681A7 /* BasalProfileEditorProvider.swift in Sources */,
 				63E890B4D951EAA91C071D5C /* BasalProfileEditorStateModel.swift in Sources */,
 				38FEF3FA2737E42000574A46 /* BaseStateModel.swift in Sources */,
+				CE0295982BE65817003D5E97 /* OverrideStorage.swift in Sources */,
 				CC6C406E2ACDD69E009B8058 /* RawFetchedProfile.swift in Sources */,
 				385CEA8225F23DFD002D6D5B /* NightscoutStatus.swift in Sources */,
 				F90692AA274B7AAE0037068D /* HealthKitManager.swift in Sources */,
@@ -2900,7 +2918,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE02959F2BE7A003003D5E97 /* TestCoreData.swift in Sources */,
 				CEE9A65E2BBC9F6500EB5194 /* CalibrationsTests.swift in Sources */,
+				CE0295A12BE7A4F9003D5E97 /* OverrideTests.swift in Sources */,
 				CE1F6DD92BADF4620064EB8D /* PluginManagerTests.swift in Sources */,
 				38FCF3F925E902C20078B0D1 /* FileStorageTests.swift in Sources */,
 			);

--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -244,7 +244,7 @@
 		5D16287A969E64D18CE40E44 /* PumpConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F60E97100041040446F44E7 /* PumpConfigStateModel.swift */; };
 		63E890B4D951EAA91C071D5C /* BasalProfileEditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF91130F2FCCC7EBBA11AD /* BasalProfileEditorStateModel.swift */; };
 		642F76A05A4FF530463A9FD0 /* NightscoutConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8782B44544F38F2B2D82C38E /* NightscoutConfigRootView.swift */; };
-		65070A332BFDCB83006F213F /* TidePoolStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65070A322BFDCB83006F213F /* TidePoolStartView.swift */; };
+		65070A332BFDCB83006F213F /* TidepoolStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65070A322BFDCB83006F213F /* TidepoolStartView.swift */; };
 		6632A0DC746872439A858B44 /* ISFEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BDA519C9B890FD9A5DFCF3 /* ISFEditorDataFlow.swift */; };
 		69A31254F2451C20361D172F /* BolusStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223EC0494F55A91E3EA69EF4 /* BolusStateModel.swift */; };
 		69B9A368029F7EB39F525422 /* CREditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64AA5E04A2761F6EEA6568E1 /* CREditorStateModel.swift */; };
@@ -296,7 +296,7 @@
 		CE1F6DD92BADF4620064EB8D /* PluginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */; };
 		CE1F6DDB2BAE08B60064EB8D /* TidepoolManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DDA2BAE08B60064EB8D /* TidepoolManager.swift */; };
 		CE1F6DE72BAF1A180064EB8D /* BuildDetails.plist in Resources */ = {isa = PBXBuildFile; fileRef = CE1F6DE62BAF1A180064EB8D /* BuildDetails.plist */; };
-		CE1F6DE92BAF37C90064EB8D /* TidePoolConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DE82BAF37C90064EB8D /* TidePoolConfigView.swift */; };
+		CE1F6DE92BAF37C90064EB8D /* TidepoolConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DE82BAF37C90064EB8D /* TidepoolConfigView.swift */; };
 		CE2FAD3A297D93F0001A872C /* BloodGlucoseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2FAD39297D93F0001A872C /* BloodGlucoseExtensions.swift */; };
 		CE48C86428CA69D5007C0598 /* OmniBLEPumpManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE48C86328CA69D5007C0598 /* OmniBLEPumpManagerExtensions.swift */; };
 		CE48C86628CA6B48007C0598 /* OmniPodManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE48C86528CA6B48007C0598 /* OmniPodManagerExtensions.swift */; };
@@ -773,7 +773,7 @@
 		60744C3E9BB3652895C908CC /* DataTableProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableProvider.swift; sourceTree = "<group>"; };
 		618E62C9757B2F95431B5DC0 /* AddCarbsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddCarbsProvider.swift; sourceTree = "<group>"; };
 		64AA5E04A2761F6EEA6568E1 /* CREditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CREditorStateModel.swift; sourceTree = "<group>"; };
-		65070A322BFDCB83006F213F /* TidePoolStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidePoolStartView.swift; sourceTree = "<group>"; };
+		65070A322BFDCB83006F213F /* TidepoolStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolStartView.swift; sourceTree = "<group>"; };
 		67F94DD2853CF42BA4E30616 /* BasalProfileEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorDataFlow.swift; sourceTree = "<group>"; };
 		680C4420C9A345D46D90D06C /* ManualTempBasalProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalProvider.swift; sourceTree = "<group>"; };
 		6B1A8D012B14D88B00E76752 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
@@ -827,7 +827,7 @@
 		CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginManagerTests.swift; sourceTree = "<group>"; };
 		CE1F6DDA2BAE08B60064EB8D /* TidepoolManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolManager.swift; sourceTree = "<group>"; };
 		CE1F6DE62BAF1A180064EB8D /* BuildDetails.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = BuildDetails.plist; sourceTree = "<group>"; };
-		CE1F6DE82BAF37C90064EB8D /* TidePoolConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidePoolConfigView.swift; sourceTree = "<group>"; };
+		CE1F6DE82BAF37C90064EB8D /* TidepoolConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolConfigView.swift; sourceTree = "<group>"; };
 		CE2FAD39297D93F0001A872C /* BloodGlucoseExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloodGlucoseExtensions.swift; sourceTree = "<group>"; };
 		CE398D012977349800DF218F /* CryptoKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoKit.framework; path = System/Library/Frameworks/CryptoKit.framework; sourceTree = SDKROOT; };
 		CE398D17297C9EE800DF218F /* G7SensorKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = G7SensorKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1287,9 +1287,9 @@
 			isa = PBXGroup;
 			children = (
 				3811DE3C25C9D4A100A708ED /* SettingsRootView.swift */,
-				CE1F6DE82BAF37C90064EB8D /* TidePoolConfigView.swift */,
+				CE1F6DE82BAF37C90064EB8D /* TidepoolConfigView.swift */,
 				DD1DB7CD2BED00CF0048B367 /* SettingsRootViewModel.swift */,
-				65070A322BFDCB83006F213F /* TidePoolStartView.swift */,
+				65070A322BFDCB83006F213F /* TidepoolStartView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2666,7 +2666,7 @@
 				3811DE1825C9D40400A708ED /* Router.swift in Sources */,
 				CE7950262998056D00FA576E /* CGMSetupView.swift in Sources */,
 				38A0363B25ECF07E00FCBB52 /* GlucoseStorage.swift in Sources */,
-				65070A332BFDCB83006F213F /* TidePoolStartView.swift in Sources */,
+				65070A332BFDCB83006F213F /* TidepoolStartView.swift in Sources */,
 				190EBCC629FF138000BA767D /* StatConfigProvider.swift in Sources */,
 				38E98A2725F52C9300C0CED0 /* CollectionIssueReporter.swift in Sources */,
 				E00EEC0427368630002FF094 /* SecurityAssembly.swift in Sources */,
@@ -2680,7 +2680,7 @@
 				38569347270B5DFB0002C50D /* CGMType.swift in Sources */,
 				3821ED4C25DD18BA00BC42AD /* Constants.swift in Sources */,
 				384E803425C385E60086DB71 /* JavaScriptWorker.swift in Sources */,
-				CE1F6DE92BAF37C90064EB8D /* TidePoolConfigView.swift in Sources */,
+				CE1F6DE92BAF37C90064EB8D /* TidepoolConfigView.swift in Sources */,
 				3811DE5D25C9D4D500A708ED /* Publisher.swift in Sources */,
 				E00EEC0727368630002FF094 /* APSAssembly.swift in Sources */,
 				38B4F3AF25E2979F00E76A18 /* IndexedCollection.swift in Sources */,

--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -240,6 +240,9 @@
 		45717281F743594AA9D87191 /* ConfigEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920DDB21E5D0EB813197500D /* ConfigEditorRootView.swift */; };
 		5075C1608E6249A51495C422 /* TargetsEditorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDEA2DC60EDE0A3CA54DC73 /* TargetsEditorProvider.swift */; };
 		53F2382465BF74DB1A967C8B /* PumpConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8630D58BDAD6D9C650B9B39 /* PumpConfigProvider.swift */; };
+		5A2325522BFCBF55003518CA /* NightscoutUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2325512BFCBF55003518CA /* NightscoutUploadView.swift */; };
+		5A2325542BFCBF66003518CA /* NightscoutFetchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2325532BFCBF65003518CA /* NightscoutFetchView.swift */; };
+		5A2325582BFCC168003518CA /* NightscoutConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2325572BFCC168003518CA /* NightscoutConnectView.swift */; };
 		5BFA1C2208114643B77F8CEB /* AddTempTargetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE53A13D26F101B332EFFC8 /* AddTempTargetProvider.swift */; };
 		5D16287A969E64D18CE40E44 /* PumpConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F60E97100041040446F44E7 /* PumpConfigStateModel.swift */; };
 		63E890B4D951EAA91C071D5C /* BasalProfileEditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF91130F2FCCC7EBBA11AD /* BasalProfileEditorStateModel.swift */; };
@@ -766,6 +769,9 @@
 		44080E4709E3AE4B73054563 /* ConfigEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorProvider.swift; sourceTree = "<group>"; };
 		4DD795BA46B193644D48138C /* TargetsEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorRootView.swift; sourceTree = "<group>"; };
 		505E09DC17A0C3D0AF4B66FE /* ISFEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorStateModel.swift; sourceTree = "<group>"; };
+		5A2325512BFCBF55003518CA /* NightscoutUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutUploadView.swift; sourceTree = "<group>"; };
+		5A2325532BFCBF65003518CA /* NightscoutFetchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutFetchView.swift; sourceTree = "<group>"; };
+		5A2325572BFCC168003518CA /* NightscoutConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutConnectView.swift; sourceTree = "<group>"; };
 		5B8A42073A2D03A278914448 /* AddTempTargetDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddTempTargetDataFlow.swift; sourceTree = "<group>"; };
 		5C018D1680307A31C9ED7120 /* CGMStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CGMStateModel.swift; sourceTree = "<group>"; };
 		5D5B4F8B4194BB7E260EF251 /* ConfigEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorStateModel.swift; sourceTree = "<group>"; };
@@ -1883,6 +1889,9 @@
 			isa = PBXGroup;
 			children = (
 				8782B44544F38F2B2D82C38E /* NightscoutConfigRootView.swift */,
+				5A2325512BFCBF55003518CA /* NightscoutUploadView.swift */,
+				5A2325532BFCBF65003518CA /* NightscoutFetchView.swift */,
+				5A2325572BFCC168003518CA /* NightscoutConnectView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2616,6 +2625,7 @@
 				CEE9A6552BBB418300EB5194 /* CalibrationsProvider.swift in Sources */,
 				19F95FF529F10FCF00314DDC /* StatProvider.swift in Sources */,
 				38F3B2EF25ED8E2A005C48AA /* TempTargetsStorage.swift in Sources */,
+				5A2325542BFCBF66003518CA /* NightscoutFetchView.swift in Sources */,
 				19B0EF2128F6D66200069496 /* Statistics.swift in Sources */,
 				3811DF1025CAAAE200A708ED /* APSManager.swift in Sources */,
 				3870FF4725EC187A0088248F /* BloodGlucose.swift in Sources */,
@@ -2736,6 +2746,7 @@
 				38E989DD25F5021400C0CED0 /* PumpStatus.swift in Sources */,
 				38E98A2525F52C9300C0CED0 /* IssueReporter.swift in Sources */,
 				190EBCC429FF136900BA767D /* StatConfigDataFlow.swift in Sources */,
+				5A2325582BFCC168003518CA /* NightscoutConnectView.swift in Sources */,
 				3811DEB025C9D88300A708ED /* BaseKeychain.swift in Sources */,
 				3811DE4325C9D4A100A708ED /* SettingsProvider.swift in Sources */,
 				45252C95D220E796FDB3B022 /* ConfigEditorDataFlow.swift in Sources */,
@@ -2882,6 +2893,7 @@
 				BA00D96F7B2FF169A06FB530 /* CGMStateModel.swift in Sources */,
 				CE94598729E9E4110047C9C6 /* WatchConfigRootView.swift in Sources */,
 				19E1F7E829D082D0005C8D20 /* IconConfigDataFlow.swift in Sources */,
+				5A2325522BFCBF55003518CA /* NightscoutUploadView.swift in Sources */,
 				E3A08AAE59538BC8A8ABE477 /* NotificationsConfigDataFlow.swift in Sources */,
 				1956FB212AFF79E200C7B4FF /* CoreDataStorage.swift in Sources */,
 				0F7A65FBD2CD8D6477ED4539 /* NotificationsConfigProvider.swift in Sources */,

--- a/FreeAPS.xcodeproj/xcshareddata/xcschemes/Trio.xcscheme
+++ b/FreeAPS.xcodeproj/xcshareddata/xcschemes/Trio.xcscheme
@@ -263,7 +263,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "43CABDFC1C3506F100005705"
@@ -273,7 +273,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C17F50CD291EAC3800555EB5"
@@ -283,7 +283,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "43D8FDD41C728FDF0073BE78"
@@ -293,7 +293,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B4CEE2DF257129780093111B"
@@ -303,7 +303,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C13CC34029C7B73A007F25DE"
@@ -313,7 +313,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "84752E8A26ED0FFE009FD801"
@@ -323,7 +323,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "C12ED9C929C7DBA900435701"
@@ -333,7 +333,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "431CE7761F98564200255374"

--- a/FreeAPS/Resources/Assets.xcassets/Colors/Profil.colorset/Contents.json
+++ b/FreeAPS/Resources/Assets.xcassets/Colors/Profil.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.962",
-          "green" : "0.745",
-          "red" : "0.453"
+          "blue" : "0.843",
+          "green" : "0.341",
+          "red" : "0.639"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.988",
-          "green" : "0.588",
-          "red" : "0.118"
+          "alpha" : "0.830",
+          "blue" : "0.981",
+          "green" : "0.618",
+          "red" : "0.948"
         }
       },
       "idiom" : "universal"

--- a/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
+++ b/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
@@ -5,6 +5,7 @@
   "useAutotune" : false,
   "onlyAutotuneBasals" : false,
   "isUploadEnabled" : false,
+  "isDownloadEnabled" : false,
   "useLocalGlucoseSource" : false,
   "localGlucosePort" : 8080,
   "debugOptions" : false,

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -73,6 +73,7 @@ final class BaseAPSManager: APSManager, Injectable {
     @Injected() private var settingsManager: SettingsManager!
     @Injected() private var broadcaster: Broadcaster!
     @Injected() private var healthKitManager: HealthKitManager!
+    @Injected() private var overrideStorage: OverrideStorage!
     @Persisted(key: "lastAutotuneDate") private var lastAutotuneDate = Date()
     @Persisted(key: "lastStartLoopDate") private var lastStartLoopDate: Date = .distantPast
     @Persisted(key: "lastLoopDate") var lastLoopDate: Date = .distantPast {
@@ -359,10 +360,12 @@ final class BaseAPSManager: APSManager, Injectable {
         let now = Date()
         let temp = currentTemp(date: now)
 
+        let eventuelOverride: OverrideProfil? = overrideStorage.current()
+
         let mainPublisher = makeProfiles()
             .flatMap { _ in self.autosens() }
             .flatMap { _ in self.dailyAutotune() }
-            .flatMap { _ in self.openAPS.determineBasal(currentTemp: temp, clock: now) }
+            .flatMap { _ in self.openAPS.determineBasal(currentTemp: temp, clock: now, override: eventuelOverride) }
             .map { suggestion -> Bool in
                 if let suggestion = suggestion {
                     DispatchQueue.main.async {

--- a/FreeAPS/Sources/APS/FetchGlucoseManager.swift
+++ b/FreeAPS/Sources/APS/FetchGlucoseManager.swift
@@ -30,7 +30,7 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
     private let processQueue = DispatchQueue(label: "BaseGlucoseManager.processQueue")
     @Injected() var glucoseStorage: GlucoseStorage!
     @Injected() var nightscoutManager: NightscoutManager!
-    @Injected() var tidePoolService: TidePoolManager!
+    @Injected() var tidepoolService: TidepoolManager!
     @Injected() var apsManager: APSManager!
     @Injected() var settingsManager: SettingsManager!
     @Injected() var healthKitManager: HealthKitManager!
@@ -235,7 +235,7 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
         deviceDataManager.heartbeat(date: Date())
 
         nightscoutManager.uploadGlucose()
-        tidePoolService.uploadGlucose(device: cgmManager?.cgmManagerStatus.device)
+        tidepoolService.uploadGlucose(device: cgmManager?.cgmManagerStatus.device)
 
         let glucoseForHealth = filteredByDate.filter { !glucoseFromHealth.contains($0) }
 

--- a/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
@@ -41,7 +41,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     /// Convert a override Preset Core Data as a Override Profil
     /// - Parameter preset: a override preset in Core Data
     /// - Returns: A override  in Override Profil structure
-    private func overridePresetToOverrideProfil(_ preset: OverridePresets) -> OverrideProfil {
+    private func OverridePresetToOverrideProfil(_ preset: OverridePresets) -> OverrideProfil {
         OverrideProfil(
             id: preset.id ?? UUID().uuidString,
             name: preset.name,
@@ -67,9 +67,9 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     /// Convert a override  Core Data as a Override Profil
     /// - Parameter preset: a override  in Core Data
     /// - Returns: A override  in Override Profil structure
-    private func overrideToOverrideProfil(_ preset: Override) -> OverrideProfil {
+    private func OverrideToOverrideProfil(_ preset: Override) -> OverrideProfil {
         OverrideProfil(
-            id: preset.id ?? UUID().uuidString,
+            id: preset.id!,
             name: preset.name == "" ? nil : preset.name,
             createdAt: preset.date,
             duration: preset.duration as Decimal?,
@@ -95,7 +95,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     /// - Returns: List of override Presets as Override Profil structure
     func presets() -> [OverrideProfil] {
         fetchOverridePreset().compactMap {
-            overridePresetToOverrideProfil($0)
+            OverridePresetToOverrideProfil($0)
         }
     }
 
@@ -142,6 +142,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     ///   - isPresets: definied if targerts is a override preset (true).
     private func storeOverride(_ targets: [OverrideProfil], isPresets: Bool) {
         // store in preset override
+        // processQueue.sync {
         if isPresets {
             let listOverridePresets = fetchOverridePreset()
             _ = targets.compactMap { preset in
@@ -199,13 +200,10 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
             coredataContext.performAndWait {
                 try? coredataContext.save()
             }
-
-            processQueue.async {
-                self.broadcaster.notify(OverrideObserver.self, on: self.processQueue) {
-                    $0.overrideDidUpdate([])
-                }
-            }
+            // update the previous current value
+            _ = current()
         }
+        // }
     }
 
     /// The start date of override data available by recent function
@@ -253,7 +251,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     func recent() -> [OverrideProfil?] {
         if let overrideRecent = fetchOverrides(interval: syncDate()) {
             return overrideRecent.compactMap {
-                overrideToOverrideProfil($0)
+                OverrideToOverrideProfil($0)
             }
         } else {
             return []
@@ -268,7 +266,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
 
         if let overrideRecent = fetchNumberOfOverrides(numbers: 1), let overrideCurrent = overrideRecent.first {
             if overrideCurrent.indefinite {
-                newCurrentOverride = overrideToOverrideProfil(overrideCurrent)
+                newCurrentOverride = OverrideToOverrideProfil(overrideCurrent)
 
             } else if
                 let duration = overrideCurrent.duration as Decimal?,
@@ -277,12 +275,20 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
                 date <= Date(),
                 duration != 0
             {
-                newCurrentOverride = overrideToOverrideProfil(overrideCurrent)
+                newCurrentOverride = OverrideToOverrideProfil(overrideCurrent)
             } else {
                 newCurrentOverride = nil
             }
         } else {
             newCurrentOverride = nil
+        }
+
+        processQueue.sync {
+            if lastCurrentOverride != newCurrentOverride {
+                broadcaster.notify(OverrideObserver.self, on: processQueue) {
+                    $0.overrideDidUpdate([newCurrentOverride])
+                }
+            }
         }
 
         lastCurrentOverride = newCurrentOverride

--- a/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
@@ -1,0 +1,329 @@
+import CoreData
+import Foundation
+import SwiftDate
+import Swinject
+
+/// Observer to register to be informed by a change in the current override
+protocol OverrideObserver {
+    func overrideDidUpdate(_ targets: [OverrideProfil?])
+}
+
+protocol OverrideStorage {
+    func storeOverride(_ targets: [OverrideProfil])
+    func storeOverridePresets(_ targets: [OverrideProfil])
+    func presets() -> [OverrideProfil]
+    func syncDate() -> Date
+    func recent() -> [OverrideProfil?]
+    //  func nightscoutTretmentsNotUploaded() -> [NightscoutTreatment]
+    func current() -> OverrideProfil?
+    func cancelCurrentOverride() -> Decimal?
+    func applyOverridePreset(_ presetId: String) -> Date?
+    func deleteOverridePreset(_ presetId: String)
+}
+
+/// Class to manage the store of override and override preset
+final class BaseOverrideStorage: OverrideStorage, Injectable {
+    private let processQueue = DispatchQueue(label: "BaseOverrideStorage.processQueue")
+    @Injected() private var broadcaster: Broadcaster!
+    @Injected() private var settingsManager: SettingsManager!
+
+    let coredataContext: NSManagedObjectContext
+    private var lastCurrentOverride: OverrideProfil?
+
+    init(
+        resolver: Resolver,
+        managedObjectContext: NSManagedObjectContext = CoreDataStack.shared.persistentContainer.viewContext
+    ) {
+        coredataContext = managedObjectContext
+        injectServices(resolver)
+    }
+
+    /// Convert a override Preset Core Data as a Override Profil
+    /// - Parameter preset: a override preset in Core Data
+    /// - Returns: A override  in Override Profil structure
+    private func OverridePresetToOverrideProfil(_ preset: OverridePresets) -> OverrideProfil {
+        OverrideProfil(
+            id: preset.id ?? UUID().uuidString,
+            name: preset.name,
+            duration: preset.duration as Decimal?,
+            indefinite: preset.indefinite,
+            percentage: preset.percentage,
+            target: preset.target as Decimal?,
+            advancedSettings: preset.advancedSettings,
+            smbIsOff: preset.smbIsOff,
+            isfAndCr: preset.isfAndCr,
+            isf: preset.isf,
+            cr: preset.cr,
+            smbIsScheduledOff: preset.smbIsScheduledOff,
+            start: preset.start as Decimal?,
+            end: preset.end as Decimal?,
+            smbMinutes: preset.smbMinutes as Decimal?,
+            uamMinutes: preset.uamMinutes as Decimal?,
+            enteredBy: OverrideProfil.manual,
+            reason: ""
+        )
+    }
+
+    /// Convert a override  Core Data as a Override Profil
+    /// - Parameter preset: a override  in Core Data
+    /// - Returns: A override  in Override Profil structure
+    private func OverrideToOverrideProfil(_ preset: Override) -> OverrideProfil {
+        OverrideProfil(
+            id: preset.id!,
+            name: preset.name == "" ? nil : preset.name,
+            createdAt: preset.date,
+            duration: preset.duration as Decimal?,
+            indefinite: preset.indefinite,
+            percentage: preset.percentage,
+            target: preset.target as Decimal?,
+            advancedSettings: preset.advancedSettings,
+            smbIsOff: preset.smbIsOff,
+            isfAndCr: preset.isfAndCr,
+            isf: preset.isf,
+            cr: preset.cr,
+            smbIsScheduledOff: preset.smbIsScheduledOff,
+            start: preset.start as Decimal?,
+            end: preset.end as Decimal?,
+            smbMinutes: preset.smbMinutes as Decimal?,
+            uamMinutes: preset.uamMinutes as Decimal?,
+            enteredBy: OverrideProfil.manual,
+            reason: ""
+        )
+    }
+
+    /// Fetch all override presets available in storage core data
+    /// - Returns: List of override Presets as Override Profil structure
+    func presets() -> [OverrideProfil] {
+        fetchOverridePreset().compactMap {
+            OverridePresetToOverrideProfil($0)
+        }
+    }
+
+    /// Fetch all override presets available in storage core data
+    /// - Returns: List of override Presets in core data structure
+    private func fetchOverridePreset() -> [OverridePresets] {
+        coredataContext.performAndWait {
+            let requestPresets = OverridePresets.fetchRequest() as NSFetchRequest<OverridePresets>
+            let results = try? self.coredataContext.fetch(requestPresets)
+            return results ?? []
+        }
+    }
+
+    /// delete a preset override
+    /// - Parameter presetId: the identifier of the preset override
+    func deleteOverridePreset(_ presetId: String) {
+        coredataContext.performAndWait {
+            let requestPresets = OverridePresets.fetchRequest() as NSFetchRequest<OverridePresets>
+            requestPresets.predicate = NSPredicate(
+                format: "id == %@", presetId
+            )
+            let results = try? self.coredataContext.fetch(requestPresets)
+            if let deleteObject = results?.first {
+                self.coredataContext.delete(deleteObject)
+            }
+        }
+    }
+
+    /// Store new or updated override target
+    /// - Parameter targets: List of new or updated override
+    func storeOverride(_ targets: [OverrideProfil]) {
+        storeOverride(targets, isPresets: false)
+    }
+
+    /// Store override preset in Core Data
+    /// - Parameter targets: List of new or updated override preset
+    func storeOverridePresets(_ targets: [OverrideProfil]) {
+        storeOverride(targets, isPresets: true)
+    }
+
+    /// store overrides in Core Data and eventually update the current override event
+    /// - Parameters:
+    ///   - targets: List of new or updated override as a preset or as a target
+    ///   - isPresets: definied if targerts is a override preset (true).
+    private func storeOverride(_ targets: [OverrideProfil], isPresets: Bool) {
+        // store in preset override
+        // processQueue.sync {
+        if isPresets {
+            let listOverridePresets = fetchOverridePreset()
+            _ = targets.compactMap { preset in
+                // find if existing or create a new one
+                let save = listOverridePresets
+                    .first(where: { $0.id == preset.id }) ?? OverridePresets(context: coredataContext)
+                save.id = preset.id
+                save.name = preset.name
+                save.end = preset.end as NSDecimalNumber?
+                save.start = preset.start as NSDecimalNumber?
+                save.advancedSettings = preset.advancedSettings ?? false
+                save.cr = preset.cr ?? false
+                save.duration = preset.duration as NSDecimalNumber?
+                save.indefinite = preset.indefinite ?? true
+                save.isf = preset.isf ?? false
+                save.isfAndCr = preset.isfAndCr ?? false
+                save.percentage = preset.percentage ?? 100.0
+                save.smbIsScheduledOff = preset.smbIsScheduledOff ?? false
+                save.smbIsOff = preset.smbIsOff ?? false
+                save.smbMinutes = (preset.smbMinutes ?? settingsManager.preferences.maxSMBBasalMinutes) as NSDecimalNumber?
+                save.uamMinutes = (preset.uamMinutes ?? settingsManager.preferences.maxUAMSMBBasalMinutes) as NSDecimalNumber?
+                save.target = preset.target as NSDecimalNumber?
+                return save
+            }
+
+            coredataContext.performAndWait {
+                try? coredataContext.save()
+            }
+
+        } else {
+            _ = targets.compactMap { target in
+                // update if existing or create
+                let save = fetchOverrideById(id: target.id) ?? Override(context: coredataContext)
+                save.id = target.id
+                save.date = target.createdAt ?? Date()
+                save.name = target.name ?? ""
+                save.end = target.end as NSDecimalNumber?
+                save.start = target.start as NSDecimalNumber?
+                save.advancedSettings = target.advancedSettings ?? false
+                save.cr = target.cr ?? false
+                save.duration = target.duration as NSDecimalNumber?
+                save.indefinite = target.indefinite ?? true
+                save.isf = target.isf ?? false
+                save.isfAndCr = target.isfAndCr ?? false
+                save.percentage = target.percentage ?? 100.0
+                save.smbIsScheduledOff = target.smbIsScheduledOff ?? false
+                save.smbIsOff = target.smbIsOff ?? false
+                save.smbMinutes = (target.smbMinutes ?? settingsManager.preferences.maxSMBBasalMinutes) as NSDecimalNumber?
+                save.uamMinutes = (target.uamMinutes ?? settingsManager.preferences.maxUAMSMBBasalMinutes) as NSDecimalNumber?
+                save.target = target.target as NSDecimalNumber?
+                save.enabled = false // # TODO: don't use the attribute - compatibility only
+                return save
+            }
+
+            coredataContext.performAndWait {
+                try? coredataContext.save()
+            }
+            // update the previous current value
+            _ = current()
+        }
+        // }
+    }
+
+    /// The start date of override data available by recent function
+    /// - Returns: the oldest date of data returned
+    func syncDate() -> Date {
+        Date().addingTimeInterval(-1.days.timeInterval)
+    }
+
+    private func fetchNumberOfOverrides(numbers: Int) -> [Override]? {
+        coredataContext.performAndWait {
+            let requestOverrides = Override.fetchRequest() as NSFetchRequest<Override>
+            let sortOverride = NSSortDescriptor(key: "date", ascending: false)
+            requestOverrides.sortDescriptors = [sortOverride]
+            requestOverrides.fetchLimit = numbers
+            return try? self.coredataContext.fetch(requestOverrides)
+        }
+    }
+
+    private func fetchOverrides(interval: Date) -> [Override]? {
+        var overrideArray = [Override]()
+        coredataContext.performAndWait {
+            let requestOverrides = Override.fetchRequest() as NSFetchRequest<Override>
+            let sortOverride = NSSortDescriptor(key: "date", ascending: false)
+            requestOverrides.sortDescriptors = [sortOverride]
+            requestOverrides.predicate = NSPredicate(
+                format: "date > %@", interval as NSDate
+            )
+            try? overrideArray = self.coredataContext.fetch(requestOverrides)
+        }
+        return overrideArray
+    }
+
+    private func fetchOverrideById(id: String) -> Override? {
+        coredataContext.performAndWait {
+            let requestOverrides = Override.fetchRequest() as NSFetchRequest<Override>
+            requestOverrides.predicate = NSPredicate(
+                format: "id == %@", id
+            )
+            return try? self.coredataContext.fetch(requestOverrides).first
+        }
+    }
+
+    /// Provides the last 24 hours override stored in the core data
+    /// - Returns: a array of override profil sorted by date
+    func recent() -> [OverrideProfil?] {
+        if let overrideRecent = fetchOverrides(interval: syncDate()) {
+            return overrideRecent.compactMap {
+                OverrideToOverrideProfil($0)
+            }
+        } else {
+            return []
+        }
+    }
+
+    /// Provides the current override or nil if no is current available
+    /// broadcast a observer overrideDidUpdate if the current override has changed since the last current function call
+    /// - Returns: A override profil currently in action
+    func current() -> OverrideProfil? {
+        var newCurrentOverride: OverrideProfil?
+
+        if let overrideRecent = fetchNumberOfOverrides(numbers: 1), let overrideCurrent = overrideRecent.first {
+            if overrideCurrent.indefinite {
+                newCurrentOverride = OverrideToOverrideProfil(overrideCurrent)
+
+            } else if
+                let duration = overrideCurrent.duration as Decimal?,
+                let date = overrideCurrent.date,
+                (Date().timeIntervalSinceReferenceDate - date.timeIntervalSinceReferenceDate).minutes < Double(duration),
+                date <= Date(),
+                duration != 0
+            {
+                newCurrentOverride = OverrideToOverrideProfil(overrideCurrent)
+            } else {
+                newCurrentOverride = nil
+            }
+        } else {
+            newCurrentOverride = nil
+        }
+
+        processQueue.sync {
+            if lastCurrentOverride != newCurrentOverride {
+                broadcaster.notify(OverrideObserver.self, on: processQueue) {
+                    $0.overrideDidUpdate([newCurrentOverride])
+                }
+            }
+        }
+
+        lastCurrentOverride = newCurrentOverride
+
+        return newCurrentOverride
+    }
+
+    /// Cancel the current override
+    /// - Returns: the final duration of the event
+    func cancelCurrentOverride() -> Decimal? {
+        guard var currentOverride = current() else { return nil }
+
+        currentOverride
+            .duration =
+            Decimal(
+                (Date().timeIntervalSinceReferenceDate - currentOverride.createdAt!.timeIntervalSinceReferenceDate)
+                    .minutes
+            )
+
+        storeOverride([currentOverride])
+
+        return currentOverride.duration
+    }
+
+    /// Apply a override preset as the current override
+    /// - Parameter presetId: the identifier of the preset override
+    /// - Returns: the date of the creation/start of the current override event
+    func applyOverridePreset(_ presetId: String) -> Date? {
+        guard var preset = presets().first(where: { $0.id == presetId }) else { return nil }
+
+        // cancel the eventual current override
+        _ = cancelCurrentOverride()
+
+        preset.createdAt = Date()
+        storeOverride([preset])
+        return preset.createdAt
+    }
+}

--- a/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
@@ -127,6 +127,10 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     /// Store new or updated override target
     /// - Parameter targets: List of new or updated override
     func storeOverride(_ targets: [OverrideProfil]) {
+        // if recent, close it before apply new override
+        if current() != nil {
+            _ = cancelCurrentOverride()
+        }
         storeOverride(targets, isPresets: false)
     }
 
@@ -308,7 +312,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
                     .minutes
             )
 
-        storeOverride([currentOverride])
+        storeOverride([currentOverride], isPresets: false)
 
         return currentOverride.duration
     }
@@ -319,10 +323,10 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     func applyOverridePreset(_ presetId: String) -> Date? {
         guard var preset = presets().first(where: { $0.id == presetId }) else { return nil }
 
-        // cancel the eventual current override
-        _ = cancelCurrentOverride()
-
+        // delete the target preset id to not use as a identifier of the new override
+        preset.id = UUID().uuidString
         preset.createdAt = Date()
+
         storeOverride([preset])
         return preset.createdAt
     }

--- a/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
@@ -69,7 +69,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     /// - Returns: A override  in Override Profil structure
     private func OverrideToOverrideProfil(_ preset: Override) -> OverrideProfil {
         OverrideProfil(
-            id: preset.id!,
+            id: preset.id ?? UUID().uuidString,
             name: preset.name == "" ? nil : preset.name,
             createdAt: preset.date,
             duration: preset.duration as Decimal?,

--- a/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/OverrideStorage.swift
@@ -41,7 +41,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     /// Convert a override Preset Core Data as a Override Profil
     /// - Parameter preset: a override preset in Core Data
     /// - Returns: A override  in Override Profil structure
-    private func OverridePresetToOverrideProfil(_ preset: OverridePresets) -> OverrideProfil {
+    private func overridePresetToOverrideProfil(_ preset: OverridePresets) -> OverrideProfil {
         OverrideProfil(
             id: preset.id ?? UUID().uuidString,
             name: preset.name,
@@ -67,7 +67,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     /// Convert a override  Core Data as a Override Profil
     /// - Parameter preset: a override  in Core Data
     /// - Returns: A override  in Override Profil structure
-    private func OverrideToOverrideProfil(_ preset: Override) -> OverrideProfil {
+    private func overrideToOverrideProfil(_ preset: Override) -> OverrideProfil {
         OverrideProfil(
             id: preset.id ?? UUID().uuidString,
             name: preset.name == "" ? nil : preset.name,
@@ -95,7 +95,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     /// - Returns: List of override Presets as Override Profil structure
     func presets() -> [OverrideProfil] {
         fetchOverridePreset().compactMap {
-            OverridePresetToOverrideProfil($0)
+            overridePresetToOverrideProfil($0)
         }
     }
 
@@ -251,7 +251,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
     func recent() -> [OverrideProfil?] {
         if let overrideRecent = fetchOverrides(interval: syncDate()) {
             return overrideRecent.compactMap {
-                OverrideToOverrideProfil($0)
+                overrideToOverrideProfil($0)
             }
         } else {
             return []
@@ -266,7 +266,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
 
         if let overrideRecent = fetchNumberOfOverrides(numbers: 1), let overrideCurrent = overrideRecent.first {
             if overrideCurrent.indefinite {
-                newCurrentOverride = OverrideToOverrideProfil(overrideCurrent)
+                newCurrentOverride = overrideToOverrideProfil(overrideCurrent)
 
             } else if
                 let duration = overrideCurrent.duration as Decimal?,
@@ -275,7 +275,7 @@ final class BaseOverrideStorage: OverrideStorage, Injectable {
                 date <= Date(),
                 duration != 0
             {
-                newCurrentOverride = OverrideToOverrideProfil(overrideCurrent)
+                newCurrentOverride = overrideToOverrideProfil(overrideCurrent)
             } else {
                 newCurrentOverride = nil
             }

--- a/FreeAPS/Sources/Assemblies/NetworkAssembly.swift
+++ b/FreeAPS/Sources/Assemblies/NetworkAssembly.swift
@@ -8,6 +8,6 @@ final class NetworkAssembly: Assembly {
         }
 
         container.register(NightscoutManager.self) { r in BaseNightscoutManager(resolver: r) }
-        container.register(TidePoolManager.self) { r in BaseTidePoolManager(resolver: r) }
+        container.register(TidepoolManager.self) { r in BaseTidepoolManager(resolver: r) }
     }
 }

--- a/FreeAPS/Sources/Assemblies/StorageAssembly.swift
+++ b/FreeAPS/Sources/Assemblies/StorageAssembly.swift
@@ -1,3 +1,4 @@
+import CoreData
 import Foundation
 import Swinject
 
@@ -15,5 +16,6 @@ final class StorageAssembly: Assembly {
         container.register(SettingsManager.self) { r in BaseSettingsManager(resolver: r) }
         container.register(Keychain.self) { _ in BaseKeychain() }
         container.register(AlertHistoryStorage.self) { r in BaseAlertHistoryStorage(resolver: r) }
+        container.register(OverrideStorage.self) { r in BaseOverrideStorage(resolver: r) }
     }
 }

--- a/FreeAPS/Sources/Helpers/Color+Extensions.swift
+++ b/FreeAPS/Sources/Helpers/Color+Extensions.swift
@@ -63,4 +63,5 @@ extension Color {
     static let lemon = Color("Lemon")
     static let minus = Color("minus")
     static let darkGray = Color("darkGray")
+    static let profil = Color("Profil")
 }

--- a/FreeAPS/Sources/Helpers/CoreDataStack.swift
+++ b/FreeAPS/Sources/Helpers/CoreDataStack.swift
@@ -2,12 +2,20 @@ import CoreData
 import Foundation
 
 class CoreDataStack: ObservableObject {
+    public static let modelName = "Core_Data"
+
+    public static let model: NSManagedObjectModel = {
+        // swiftlint:disable force_unwrapping
+        let modelURL = Bundle.main.url(forResource: modelName, withExtension: "momd")!
+        return NSManagedObjectModel(contentsOf: modelURL)!
+    }()
+
     init() {}
 
     static let shared = CoreDataStack()
 
     lazy var persistentContainer: NSPersistentContainer = {
-        let container = NSPersistentContainer(name: "Core_Data")
+        let container = NSPersistentContainer(name: CoreDataStack.modelName)
 
         container.loadPersistentStores(completionHandler: { _, error in
             guard let error = error as NSError? else { return }

--- a/FreeAPS/Sources/Localizations/Main/ar.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ar.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Skip Bolus screen after carbs";
 
 /* Allow remote control from NS */
-"Remote control" = "Remote control";
+"Remote Control" = "Remote Control";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/ca.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ca.lproj/Localizable.strings
@@ -312,7 +312,7 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Skip Bolus screen after carbs";
 
 /* Allow remote control from NS */
-"Remote control" = "Remote control";
+"Remote Control" = "Remote Control";
 
 /* Add Medtronic pump */
 "Add Medtronic" = "Add Medtronic";

--- a/FreeAPS/Sources/Localizations/Main/da.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/da.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Skip Bolus skærm efter kulhydrater";
 
 /* Allow remote control from NS */
-"Remote control" = "Fjernkontrol";
+"Remote Control" = "Fjernkontrol";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nKontroller nu alle dine nye indstillinger grundigt:\n\n* Basal Indstillinger\n * Kulhydratratios\n * Glukose Mål\n * Insulin Følsomhed\n * VIA\n\n i Trio Indstillinger > Konfiguration.\n\nDårlige eller ugyldige profilindstillinger kan have katastrofale effekter.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nKontroller nu alle dine nye indstillinger grundigt:\n\n* Basal Indstillinger\n * Kulhydratratios\n * Glukose Mål\n * Insulin Følsomhed\n * VIA\n\n i Trio Indstillinger > Konfiguration.\n\nDårlige eller ugyldige profilindstillinger kan have katastrofale effekter.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Dette vil erstatte nogle eller alle dine aktuelle pumpeindstillinger. Er du sikker på, at du vil importere profilindstillinger fra Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Überspringe Bolus-Vorschlag nach Kohlenhydrateingabe";
 
 /* Allow remote control from NS */
-"Remote control" = "Fernbedienung";
+"Remote Control" = "Fernbedienung";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nBitte überprüfen Sie jetzt alle Ihre neuen Einstellungen gründlich:\n\n* Basaleinstellungen\n * Carb Ratios\n * Glukose-Ziele\n * Insulinempfindlichkeiten\n * DIA\n\n in Trio-Einstellungen > Konfiguration.\n\nSchlechte oder ungültige Profileinstellungen können abscheuliche Effekte haben.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nBitte überprüfen Sie jetzt alle Ihre neuen Einstellungen gründlich:\n\n* Basaleinstellungen\n * Carb Ratios\n * Glukose-Ziele\n * Insulinempfindlichkeiten\n * DIA\n\n in Trio-Einstellungen > Konfiguration.\n\nSchlechte oder ungültige Profileinstellungen können abscheuliche Effekte haben.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Dies wird einige oder alle deine aktuellen Pumpeneinstellungen ersetzen. Bist du sicher, dass du die Profileinstellungen von Nightscout importieren möchtest?";

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Skip Bolus screen after carbs";
 
 /* Allow remote control from NS */
-"Remote control" = "Remote control";
+"Remote Control" = "Remote Control";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/es.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/es.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Saltar pantalla de bolo después de carbohidratos";
 
 /* Allow remote control from NS */
-"Remote control" = "Control a distancia";
+"Remote Control" = "Control a distancia";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/fi.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/fi.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Skip Bolus screen after carbs";
 
 /* Allow remote control from NS */
-"Remote control" = "Remote control";
+"Remote Control" = "Remote Control";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/fr.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/fr.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Ignorer l'écran du Bolus après les glucides";
 
 /* Allow remote control from NS */
-"Remote control" = "Contrôle à distance";
+"Remote Control" = "Contrôle à distance";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nVeuillez maintenant vérifier soigneusement tous vos nouveaux paramètres:\n\n* Paramètres basaux\n * Ratios glucidiques\n * Objectifs glycémiques\n * Sensibilité à l'insuline\n * DIA\n\n dans Trio Paramètres > Configuration.\n\nDes paramètres de profil incorrects ou invalides peuvent avoir des effets désastreux.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nVeuillez maintenant vérifier soigneusement tous vos nouveaux paramètres:\n\n* Paramètres basaux\n * Ratios glucidiques\n * Objectifs glycémiques\n * Sensibilité à l'insuline\n * DIA\n\n dans Trio Paramètres > Configuration.\n\nDes paramètres de profil incorrects ou invalides peuvent avoir des effets désastreux.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Cette opération remplacera tout ou partie des paramètres actuels de la pompe. Êtes-vous sûr de vouloir importer les paramètres de profil de Nightscout ?";

--- a/FreeAPS/Sources/Localizations/Main/he.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/he.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Skip Bolus screen after carbs";
 
 /* Allow remote control from NS */
-"Remote control" = "Remote control";
+"Remote Control" = "Remote Control";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/hu.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/hu.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Bólus képernyő kihagyása szénhidrát után";
 
 /* Allow remote control from NS */
-"Remote control" = "Távirányítás";
+"Remote Control" = "Távirányítás";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nMost kérlek alaposan nézd át a beállításokat:\n\n* Bázis Ceállítások\n * Szénhidrát Arány\n * Cukorszint Célpont\n * Inzulin Érzékenység\n * DIA\n\n Trio beállítások > Konfiguráció.\n\nHelytelen vagy rossz beállításoknak halálos következményei lehetnek.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nMost kérlek alaposan nézd át a beállításokat:\n\n* Bázis Ceállítások\n * Szénhidrát Arány\n * Cukorszint Célpont\n * Inzulin Érzékenység\n * DIA\n\n Trio beállítások > Konfiguráció.\n\nHelytelen vagy rossz beállításoknak halálos következményei lehetnek.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Ez átállítja valamely, vagy az összes pumpa beállítását. Biztos vagy benne, hogy szeretnéd importálni a beállításokat a Nightscout-ból?";

--- a/FreeAPS/Sources/Localizations/Main/it.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/it.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Salta la schermata del Bolo dopo i carboidrati";
 
 /* Allow remote control from NS */
-"Remote control" = "Controllo remoto";
+"Remote Control" = "Controllo remoto";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nOra verifica attentamente tutte le nuove impostazioni:\n\n* Impostazioni basali\n * Rapporti carboidrati\n * Obiettivi glucosio\n * Sensibilità insulinica\n * DIA\n\n in Impostazioni Trio > Configurazione.\n\nImpostazioni del profilo errate o non valide potrebbero avere effetti disastrosi.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nOra verifica attentamente tutte le nuove impostazioni:\n\n* Impostazioni basali\n * Rapporti carboidrati\n * Obiettivi glucosio\n * Sensibilità insulinica\n * DIA\n\n in Impostazioni Trio > Configurazione.\n\nImpostazioni del profilo errate o non valide potrebbero avere effetti disastrosi.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Questo sostituirà alcune o tutte le impostazioni attuali del microinfusore. Sei sicuro di voler importare le impostazioni del profilo da Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/nb.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/nb.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Hopp over Bolus-skjerm etter karbo";
 
 /* Allow remote control from NS */
-"Remote control" = "Fjernstyring";
+"Remote Control" = "Fjernstyring";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nGå nøye gjennom alle de nye innstillingene:\n\n* Basalprofil\n * Karbohydratforhold\n * Blodsukkermål\n * Insulinfølsomhet\n\n i Trio Innstillinger > Oppsett.\n\nFeil eller ugyldige profilinnstillinger kan ha katastrofale følger.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nGå nøye gjennom alle de nye innstillingene:\n\n* Basalprofil\n * Karbohydratforhold\n * Blodsukkermål\n * Insulinfølsomhet\n\n i Trio Innstillinger > Oppsett.\n\nFeil eller ugyldige profilinnstillinger kan ha katastrofale følger.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Dette vil erstatte alle eller deler av dine nåværende pumpeinnstillinger. Er du sikker på at du vil importere profilinnstillinger fra Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/nl.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/nl.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Sla bolusscherm over na koolhydraten";
 
 /* Allow remote control from NS */
-"Remote control" = "Afstandsbediening";
+"Remote Control" = "Afstandsbediening";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nCheck nu al je nieuwe instellingen:\n\n* Basaal instellingen\n * Koolhydraat ratio's\n * Doel glucose waarde\n * Insuline sensitiviteit\n * DIA\n\n in Trio instellingen > Configuratie.\n\nSlechte of ongeldige profielinstellingen kunnen  desastreuze effecten hebben!";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nCheck nu al je nieuwe instellingen:\n\n* Basaal instellingen\n * Koolhydraat ratio's\n * Doel glucose waarde\n * Insuline sensitiviteit\n * DIA\n\n in Trio instellingen > Configuratie.\n\nSlechte of ongeldige profielinstellingen kunnen  desastreuze effecten hebben!";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Dit zal enkele of al je huidige pomp instellingen vervangen. Weet je zeker dat je de profielinstellingen uit Nightscout wilt importeren?";

--- a/FreeAPS/Sources/Localizations/Main/pl.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pl.lproj/Localizable.strings
@@ -359,10 +359,10 @@ Połączono z Nightscout!";
 "Skip Bolus screen after carbs" = "Skip Bolus screen after carbs";
 
 /* Allow remote control from NS */
-"Remote control" = "Remote control";
+"Remote Control" = "Remote control";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/pt-BR.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pt-BR.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Pular tela de bolus depois de carbo";
 
 /* Allow remote control from NS */
-"Remote control" = "Controle remoto";
+"Remote Control" = "Controle remoto";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/pt-PT.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pt-PT.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Pular tela de bolus depois de carbo";
 
 /* Allow remote control from NS */
-"Remote control" = "Controle remoto";
+"Remote Control" = "Controle remoto";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Пропустить экран болюса после ввода углеводов";
 
 /* Allow remote control from NS */
-"Remote control" = "Удаленное управление";
+"Remote Control" = "Удаленное управление";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nПожалуйста, проверьте все ваши новые настройки:\n\n* Настройки базала\n * Углеводные коэффициенты\n * Целевой диапазон\n * Чувствительность к инсулину\n\n в настройках Trio Настройки > Конфигурация.\n\nНекорректные настройки профиля могут привести к катастрофическим последствиям.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nПожалуйста, проверьте все ваши новые настройки:\n\n* Настройки базала\n * Углеводные коэффициенты\n * Целевой диапазон\n * Чувствительность к инсулину\n\n в настройках Trio Настройки > Конфигурация.\n\nНекорректные настройки профиля могут привести к катастрофическим последствиям.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Это заменит некоторые или все ваши текущие настройки помпы. Вы уверены, что хотите импортировать настройки профиля из Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/sk.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sk.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Preskočiť pridanie dávky po sacharidoch";
 
 /* Allow remote control from NS */
-"Remote control" = "Vzdialené ovládanie";
+"Remote Control" = "Vzdialené ovládanie";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\\Teraz dôkladne skontrolujte všetky nové nastavenia:\n\n* Bazálne nastavenia\n * Pomery uhľohydrátov\n * Cieľové hodnoty glukózy\n * Citlivosť na inzulín\n * DIA\n\n v Trio Nastavenia > Konfigurácia.\n\nZlé alebo neplatné nastavenia profilu by mohli mať škodlivé účinky.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nTeraz dôkladne skontrolujte všetky nové nastavenia:\n\n* Bazálne nastavenia\n * Pomery uhľohydrátov\n * Cieľové hodnoty glukózy\n * Citlivosť na inzulín\n * DIA\n\n v Trio Nastavenia > Konfigurácia.\n\nZlé alebo neplatné nastavenia profilu by mohli mať škodlivé účinky.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Tým sa nahradia niektoré alebo všetky aktuálne nastavenia čerpadla. Ste si istí, že chcete importovať nastavenia profilu z programu Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Hoppa över Bolusfönster vid tillagda kolhydrater";
 
 /* Allow remote control from NS */
-"Remote control" = "Fjärrstyrning";
+"Remote Control" = "Fjärrstyrning";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nKontrollera nu alla dina nya pumpinställningar noga:\n\n* Basalinställningar\n * Insulinkvoter\n * Målvärden\n * Insulinkänslighet\n\n i Inställningar > Konfiguration.\n\nDåliga eller ogiltiga pumpinställningar kan gå katastrofala följder.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nKontrollera nu alla dina nya pumpinställningar noga:\n\n* Basalinställningar\n * Insulinkvoter\n * Målvärden\n * Insulinkänslighet\n\n i Inställningar > Konfiguration.\n\nDåliga eller ogiltiga pumpinställningar kan gå katastrofala följder.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Detta kommer att ersätta alla eller vissa av dina pumpinställningar. Är du säker att du vill fortsätta med import av inställningar?";

--- a/FreeAPS/Sources/Localizations/Main/tr.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/tr.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Karbonhidrattan sonra Bolus ekranını atla";
 
 /* Allow remote control from NS */
-"Remote control" = "Uzaktan kontrol";
+"Remote Control" = "Uzaktan kontrol";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/uk.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/uk.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Пропустити екран Болюсу після вводу вуглеводів";
 
 /* Allow remote control from NS */
-"Remote control" = "Віддалене керування";
+"Remote Control" = "Віддалене керування";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nТепер уважно перевірте всі ваші нові налаштування:\n\n* Базальні параметри\n * Вуглеводні співвідношення\n * Цільові показники глюкози\n * Чутливість до інсуліну\n\n у меню «Налаштування Trio» > «Конфігурація».\n\nПоганий або недійсний профіль налаштування можуть мати згубні наслідки.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nТепер уважно перевірте всі ваші нові налаштування:\n\n* Базальні параметри\n * Вуглеводні співвідношення\n * Цільові показники глюкози\n * Чутливість до інсуліну\n\n у меню «Налаштування Trio» > «Конфігурація».\n\nПоганий або недійсний профіль налаштування можуть мати згубні наслідки.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Це замінить деякі або всі поточні налаштування Помпи. Ви впевнені, що бажаєте імпортувати налаштування профілю з Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/vi.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/vi.lproj/Localizable.strings
@@ -357,10 +357,10 @@ Enact a temp Basal or a temp target */
 "Skip Bolus screen after carbs" = "Bỏ qua màn hình bolus sau carbs";
 
 /* Allow remote control from NS */
-"Remote control" = "Điều khiển từ xa";
+"Remote Control" = "Điều khiển từ xa";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\n Bây giờ xin hãy xác minh lại tất cả các cài đặt của bạn kỹ lưỡng:\n\n* Cài đặt liều nền\n * Tỷ lệ Carb\n * Mục tiêu đường huyết \n * Độ nhạy của Insulin\n * Thời gian hoạt động của insulin\n\n trong Trio Cài đặt > Cấu hình.\n\n Cấu hình không hợp lệ hoặc tồi có thể có tác động thảm họa.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\n Bây giờ xin hãy xác minh lại tất cả các cài đặt của bạn kỹ lưỡng:\n\n* Cài đặt liều nền\n * Tỷ lệ Carb\n * Mục tiêu đường huyết \n * Độ nhạy của Insulin\n * Thời gian hoạt động của insulin\n\n trong Trio Cài đặt > Cấu hình.\n\n Cấu hình không hợp lệ hoặc tồi có thể có tác động thảm họa.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "Việc này có thể thay thế một vài hoặc tất cả những cấu hình bơm hiện tại của bạn. Bạn có chắc bạn muốn nhập cấu hình từ Nightscout?";

--- a/FreeAPS/Sources/Localizations/Main/zh-Hans.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/zh-Hans.lproj/Localizable.strings
@@ -356,11 +356,11 @@ Enact a temp Basal or a temp target */
 /* Do you want to show bolus screen after added carbs? */
 "Skip Bolus screen after carbs" = "添加碳水后跳过大剂量操作";
 
-/* Allow remote control from NS */
-"Remote control" = "远程控制";
+/* Allow Remote control from NS */
+"Remote Control" = "远程控制";
 
 /* Imported Profiles Alert */
-"\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects." = "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.";
+"\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects." = "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.";
 
 /* Profile Import Alert */
 "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?" = "This will replace some or all of your current pump settings. Are you sure you want to import profile settings from Nightscout?";

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -6,6 +6,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var allowAnnouncements: Bool = false
     var useAutotune: Bool = false
     var isUploadEnabled: Bool = false
+    var isDownloadEnabled: Bool = false
     var useLocalGlucoseSource: Bool = false
     var localGlucosePort: Int = 8080
     var debugOptions: Bool = false
@@ -71,6 +72,10 @@ extension FreeAPSSettings: Decodable {
 
         if let isUploadEnabled = try? container.decode(Bool.self, forKey: .isUploadEnabled) {
             settings.isUploadEnabled = isUploadEnabled
+        }
+
+        if let isDownloadEnabled = try? container.decode(Bool.self, forKey: .isDownloadEnabled) {
+            settings.isDownloadEnabled = isDownloadEnabled
         }
 
         if let useLocalGlucoseSource = try? container.decode(Bool.self, forKey: .useLocalGlucoseSource) {

--- a/FreeAPS/Sources/Models/NightscoutExercice.swift
+++ b/FreeAPS/Sources/Models/NightscoutExercice.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// A structure to descrive a Override as a exercice for NightScout
+struct NightscoutExercice: JSON, Hashable, Equatable {
+    var duration: Int?
+    var eventType: EventType
+    var createdAt: Date?
+    var enteredBy: String?
+    var notes: String?
+
+    static let local = "Trio"
+
+    static let empty = NightscoutExercice(from: "{}")!
+
+    static func == (lhs: NightscoutExercice, rhs: NightscoutExercice) -> Bool {
+        (lhs.createdAt ?? Date()) == (rhs.createdAt ?? Date())
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(createdAt ?? Date())
+    }
+}
+
+extension NightscoutExercice {
+    private enum CodingKeys: String, CodingKey {
+        case duration
+        case eventType
+        case createdAt = "created_at"
+        case enteredBy
+        case notes
+    }
+}

--- a/FreeAPS/Sources/Models/OverrideProfil.swift
+++ b/FreeAPS/Sources/Models/OverrideProfil.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct OverrideProfil: JSON, Identifiable, Equatable, Hashable {
+    var id = UUID().uuidString
+    var name: String? = nil
+    var createdAt: Date? = nil
+    var duration: Decimal? = nil {
+        didSet {
+            indefinite = (duration == nil)
+        }
+    }
+
+    var indefinite: Bool? = false
+    var percentage: Double? = 100
+    var target: Decimal? = 0
+    var advancedSettings: Bool? = false
+    var smbIsOff: Bool? = false
+    var isfAndCr: Bool? = false
+    var isf: Bool? = false
+    var cr: Bool? = false
+    var smbIsScheduledOff: Bool? = false
+    var start: Decimal? = 0
+    var end: Decimal? = 0
+
+    var smbMinutes: Decimal? = nil
+    var uamMinutes: Decimal? = nil
+    var enteredBy: String? = OverrideProfil.manual
+    var reason: String?
+
+    static let manual = "Trio"
+    static let custom = "Temp override"
+    static let cancel = "Cancel"
+
+    var displayName: String {
+        if let name = name, name != "" {
+            return name
+        } else {
+            return OverrideProfil.custom
+        }
+    }
+
+    static func == (lhs: OverrideProfil, rhs: OverrideProfil) -> Bool {
+        lhs.createdAt == rhs.createdAt && lhs.indefinite == rhs.indefinite && lhs.duration == rhs.duration
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func cancel(at date: Date) -> OverrideProfil {
+        OverrideProfil(
+            name: OverrideProfil.cancel,
+            createdAt: date,
+            duration: nil,
+            indefinite: false,
+            percentage: 100.0,
+            target: 0,
+            advancedSettings: false,
+            smbIsOff: false,
+            isfAndCr: false,
+            isf: false,
+            cr: false,
+            smbIsScheduledOff: false,
+            start: 0,
+            end: 0,
+            smbMinutes: nil,
+            uamMinutes: nil,
+            enteredBy: OverrideProfil.manual,
+            reason: OverrideProfil.cancel
+        )
+    }
+}
+
+extension OverrideProfil {
+    private enum CodingKeys: String, CodingKey {
+        case id = "_id"
+        case name
+        case createdAt
+        case advancedSettings
+        case cr
+        case duration
+        case end
+        case indefinite
+        case isf
+        case isfAndCr
+        case percentage
+        case smbIsScheduledOff
+        case smbIsOff
+        case smbMinutes
+        case start
+        case target
+        case uamMinutes
+        case enteredBy
+        case reason
+    }
+}

--- a/FreeAPS/Sources/Models/PumpHistoryEvent.swift
+++ b/FreeAPS/Sources/Models/PumpHistoryEvent.swift
@@ -70,6 +70,7 @@ enum EventType: String, JSON {
     case nsAnnouncement = "Announcement"
     case nsSensorChange = "Sensor Start"
     case nsExternalInsulin = "External Insulin"
+    case nsExercice = "Exercice"
 }
 
 enum TempType: String, JSON {

--- a/FreeAPS/Sources/Modules/DataTable/DataTableProvider.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableProvider.swift
@@ -8,7 +8,7 @@ extension DataTable {
         @Injected() var carbsStorage: CarbsStorage!
         @Injected() var nightscoutManager: NightscoutManager!
         @Injected() var healthkitManager: HealthKitManager!
-        @Injected() var tidePoolManager: TidePoolManager!
+        @Injected() var tidepoolManager: TidepoolManager!
 
         func pumpHistory() -> [PumpHistoryEvent] {
             pumpHistoryStorage.recent()
@@ -33,10 +33,10 @@ extension DataTable {
         }
 
         func deleteCarbs(_ treatement: Treatment) {
-            // need to start with tidePool because Nightscout delete data
+            // need to start with tidepool because Nightscout delete data
             // probably to revise the logic
             // TODO:
-            tidePoolManager.deleteCarbs(
+            tidepoolManager.deleteCarbs(
                 at: treatement.date,
                 isFPU: treatement.isFPU,
                 fpuID: treatement.fpuID,
@@ -52,8 +52,8 @@ extension DataTable {
         }
 
         func deleteInsulin(_ treatement: Treatment) {
-            // delete tidePoolManager before NS - TODO
-            tidePoolManager.deleteInsulin(at: treatement.date)
+            // delete tidepoolManager before NS - TODO
+            tidepoolManager.deleteInsulin(at: treatement.date)
             nightscoutManager.deleteInsulin(at: treatement.date)
             if let id = treatement.idPumpEvent {
                 healthkitManager.deleteInsulin(syncID: id)

--- a/FreeAPS/Sources/Modules/Home/HomeProvider.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeProvider.swift
@@ -18,6 +18,12 @@ extension Home {
             storage.retrieve(OpenAPS.Enact.enacted, as: Suggestion.self)
         }
 
+        var profile: BGTargets {
+            storage.retrieve(OpenAPS.Settings.bgTargets, as: BGTargets.self)
+                ?? BGTargets(from: OpenAPS.defaults(for: OpenAPS.Settings.bgTargets))
+                ?? BGTargets(units: .mmolL, userPrefferedUnits: .mmolL, targets: [])
+        }
+
         func heartbeatNow() {
             apsManager.heartbeat(date: Date())
         }

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -60,14 +60,11 @@ extension Home {
         @Published var displayYgridLines: Bool = false
         @Published var thresholdLines: Bool = false
         @Published var cgmAvailable: Bool = false
-        @Published var currentOverride: OverrideProfil?
         @Published var overrideHistory: [OverrideProfil?] = []
         @Published var targetBG: BGTargets?
         @Published var pumpStatutHighlightMessage: String? = nil
         @Published var pumpStatusHighlightMessage: String? = nil
         @Published var currentOverride: OverrideProfil?
-        @Published var overrideHistory: [OverrideProfil?] = []
-        @Published var targetBG: BGTargets?
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
 
@@ -82,7 +79,7 @@ extension Home {
             setupCarbs()
             setupBattery()
             setupReservoir()
-            setupOverride()
+            setupOverride(overrideStorage.recent(), overrideStorage.current())
 
             suggestion = provider.suggestion
             enactedSuggestion = provider.enactedSuggestion
@@ -224,12 +221,12 @@ extension Home {
             _ = overrideStorage.cancelCurrentOverride()
         }
 
-        func setupOverride() {
+        func setupOverride(_ targets: [OverrideProfil?], _ current: OverrideProfil?) {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 self.targetBG = self.provider.profile
-                self.currentOverride = self.overrideStorage.current()
-                self.overrideHistory = self.overrideStorage.recent()
+                self.currentOverride = current
+                self.overrideHistory = targets
             }
         }
 
@@ -414,8 +411,8 @@ extension Home.StateModel:
     PumpReservoirObserver,
     OverrideObserver
 {
-    func overrideDidUpdate(_: [OverrideProfil?]) {
-        setupOverride()
+    func overrideDidUpdate(_ targets: [OverrideProfil?], current: OverrideProfil?) {
+        setupOverride(targets, current)
     }
 
     func glucoseDidUpdate(_: [BloodGlucose]) {

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -64,6 +64,7 @@ extension Home {
         @Published var overrideHistory: [OverrideProfil?] = []
         @Published var targetBG: BGTargets?
         @Published var pumpStatutHighlightMessage: String? = nil
+        @Published var pumpStatusHighlightMessage: String? = nil
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
 
@@ -177,7 +178,7 @@ extension Home {
                     } else {
                         self.setupBattery()
                         self.setupReservoir()
-                        self.displayPumpStatutHighlightMessage()
+                        self.displaypumpStatusHighlightMessage()
                     }
                 }
                 .store(in: &lifetime)
@@ -364,15 +365,15 @@ extension Home {
 
         /// Display the eventual statut message provided by the manager of the pump
         /// Only display if state is warning or critical message else return nil
-        private func displayPumpStatutHighlightMessage() {
+        private func displaypumpStatusHighlightMessage() {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 if let statusHL = self.provider.deviceManager.pumpManager?.pumpStatusHighlight,
                    statusHL.state == .warning || statusHL.state == .critical
                 {
-                    pumpStatutHighlightMessage = (statusHL.state == .warning ? "⚠️\n" : "‼️\n") + statusHL.localizedMessage
+                    pumpStatusHighlightMessage = (statusHL.state == .warning ? "⚠️\n" : "‼️\n") + statusHL.localizedMessage
                 } else {
-                    pumpStatutHighlightMessage = nil
+                    pumpStatusHighlightMessage = nil
                 }
             }
         }
@@ -446,7 +447,7 @@ extension Home.StateModel:
         setupBasals()
         setupBoluses()
         setupSuspensions()
-        displayPumpStatutHighlightMessage()
+        displaypumpStatusHighlightMessage()
     }
 
     func pumpSettingsDidChange(_: PumpSettings) {
@@ -472,12 +473,12 @@ extension Home.StateModel:
 
     func pumpBatteryDidChange(_: Battery) {
         setupBattery()
-        displayPumpStatutHighlightMessage()
+        displaypumpStatusHighlightMessage()
     }
 
     func pumpReservoirDidChange(_: Decimal) {
         setupReservoir()
-        displayPumpStatutHighlightMessage()
+        displaypumpStatusHighlightMessage()
     }
 }
 

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -65,6 +65,9 @@ extension Home {
         @Published var targetBG: BGTargets?
         @Published var pumpStatutHighlightMessage: String? = nil
         @Published var pumpStatusHighlightMessage: String? = nil
+        @Published var currentOverride: OverrideProfil?
+        @Published var overrideHistory: [OverrideProfil?] = []
+        @Published var targetBG: BGTargets?
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
 

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -363,7 +363,7 @@ extension Home {
             }
         }
 
-        /// Display the eventual statut message provided by the manager of the pump
+        /// Display the eventual status message provided by the manager of the pump
         /// Only display if state is warning or critical message else return nil
         private func displaypumpStatusHighlightMessage() {
             DispatchQueue.main.async { [weak self] in

--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -455,9 +455,9 @@ struct MainChartView: View {
     private func overridesView(fullSize: CGSize) -> some View {
         ZStack {
             overridesPath
-                .fill(Color.profil.opacity(0.5))
+                .fill(Color.purple.opacity(0.5))
             overridesPath
-                .stroke(Color.profil.opacity(0.5), lineWidth: 1)
+                .stroke(Color.purple.opacity(0.5), lineWidth: 1)
         }
         .onChange(of: glucose) { _ in
             calculateOverridesRects(fullSize: fullSize)

--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -455,9 +455,9 @@ struct MainChartView: View {
     private func overridesView(fullSize: CGSize) -> some View {
         ZStack {
             overridesPath
-                .fill(Color.purple.opacity(0.5))
+                .fill(Color.profil.opacity(0.5))
             overridesPath
-                .stroke(Color.purple.opacity(0.5), lineWidth: 1)
+                .stroke(Color.profil.opacity(0.5), lineWidth: 1)
         }
         .onChange(of: glucose) { _ in
             calculateOverridesRects(fullSize: fullSize)

--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -31,6 +31,7 @@ struct MainChartView: View {
         static let bolusScale: CGFloat = 2.5
         static let carbsSize: CGFloat = 10
         static let carbsScale: CGFloat = 0.3
+        static let overrideNoTargetDefault: Decimal = 50
     }
 
     @Binding var glucose: [BloodGlucose]
@@ -53,6 +54,8 @@ struct MainChartView: View {
     @Binding var displayXgridLines: Bool
     @Binding var displayYgridLines: Bool
     @Binding var thresholdLines: Bool
+    @Binding var overrideHistory: [OverrideProfil?]
+    @Binding var targetBG: BGTargets?
 
     @State var didAppearTrigger = false
     @State private var glucoseDots: [CGRect] = []
@@ -63,6 +66,7 @@ struct MainChartView: View {
     @State private var tempBasalPath = Path()
     @State private var regularBasalPath = Path()
     @State private var tempTargetsPath = Path()
+    @State private var overridesPath = Path()
     @State private var suspensionsPath = Path()
     @State private var carbsDots: [DotInfo] = []
     @State private var carbsPath = Path()
@@ -155,6 +159,7 @@ struct MainChartView: View {
             ScrollViewReader { scroll in
                 ZStack(alignment: .top) {
                     tempTargetsView(fullSize: fullSize).drawingGroup()
+                    overridesView(fullSize: fullSize).drawingGroup()
                     basalView(fullSize: fullSize).drawingGroup()
 
                     mainView(fullSize: fullSize).id(Config.endID)
@@ -444,6 +449,24 @@ struct MainChartView: View {
         }
         .onChange(of: didAppearTrigger) { _ in
             calculateTempTargetsRects(fullSize: fullSize)
+        }
+    }
+
+    private func overridesView(fullSize: CGSize) -> some View {
+        ZStack {
+            overridesPath
+                .fill(Color.purple.opacity(0.5))
+            overridesPath
+                .stroke(Color.purple.opacity(0.5), lineWidth: 1)
+        }
+        .onChange(of: glucose) { _ in
+            calculateOverridesRects(fullSize: fullSize)
+        }
+        .onChange(of: overrideHistory) { _ in
+            calculateOverridesRects(fullSize: fullSize)
+        }
+        .onChange(of: didAppearTrigger) { _ in
+            calculateOverridesRects(fullSize: fullSize)
         }
     }
 
@@ -801,6 +824,58 @@ extension MainChartView {
 
             DispatchQueue.main.async {
                 tempTargetsPath = path
+            }
+        }
+    }
+
+    private func calculateOverridesRects(fullSize: CGSize) {
+        calculationQueue.async {
+            let rects = overrideHistory.enumerated().compactMap { (index, override) -> CGRect? in
+                if let override = override {
+                    let x0 = timeToXCoordinate(override.createdAt!.timeIntervalSince1970, fullSize: fullSize)
+                    var y0: CGFloat
+                    if override.target != nil, override.target! > 0 {
+                        y0 = glucoseToYCoordinate(Int(override.target!), fullSize: fullSize)
+                    } else if let targetBG = targetBG {
+                        // find the targetBG at the beginning
+                        let bestOffset = override.createdAt!.hour * 60 + override.createdAt!.minute
+                        let targetItemBG = targetBG.targets.sorted(by: { $0.offset < $1.offset })
+                            .last(where: { $0.offset < bestOffset })?.low ?? Config.overrideNoTargetDefault
+                        y0 = glucoseToYCoordinate(Int(targetItemBG), fullSize: fullSize)
+                    } else {
+                        y0 = glucoseToYCoordinate(Int(Config.overrideNoTargetDefault), fullSize: fullSize)
+                    }
+
+                    // only the first override could be indefinite
+                    let x1 = override.indefinite! && index == 0 ?
+                        timeToXCoordinate(Date().timeIntervalSince1970, fullSize: fullSize)
+                        :
+                        timeToXCoordinate(
+                            override.createdAt!.timeIntervalSince1970 + Int(override.duration ?? 0).minutes.timeInterval,
+                            fullSize: fullSize
+                        )
+                    let widthRect = override.indefinite! && index == 0 ?
+                        x1 - x0 + additionalWidth(viewWidth: fullSize.width)
+                        :
+                        x1 - x0
+
+                    return CGRect(
+                        x: x0,
+                        y: y0 - 3,
+                        width: widthRect,
+                        height: 6
+                    )
+                } else {
+                    return nil
+                }
+            }
+
+            let path = Path { path in
+                path.addRects(rects)
+            }
+
+            DispatchQueue.main.async {
+                overridesPath = path
             }
         }
     }

--- a/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
@@ -6,7 +6,7 @@ struct PumpView: View {
     @Binding var name: String
     @Binding var expiresAtDate: Date?
     @Binding var timerDate: Date
-    @Binding var pumpStatutHighlightMessage: String?
+    @Binding var pumpStatusHighlightMessage: String?
 
     private var reservoirFormatter: NumberFormatter {
         let formatter = NumberFormatter()
@@ -22,67 +22,68 @@ struct PumpView: View {
     }
 
     var body: some View {
-        if let pumpStatutHighlightMessage = pumpStatutHighlightMessage { // display message instead pump info
+        if let pumpStatusHighlightMessage = pumpStatusHighlightMessage { // display message instead pump info
             VStack(alignment: .center) {
-                Text(pumpStatutHighlightMessage).font(.footnote).fontWeight(.bold)
+                Text(pumpStatusHighlightMessage).font(.footnote).fontWeight(.bold)
                     .multilineTextAlignment(.center).frame(maxWidth: /*@START_MENU_TOKEN@*/ .infinity/*@END_MENU_TOKEN@*/)
             }.frame(width: 100)
         } else {
             VStack(alignment: .leading, spacing: 12) {
                 if reservoir == nil && battery == nil {
-                                VStack(alignment: .center, spacing: 12) {
-                                    HStack { // no cgm defined so display a generic CGM
-                                        Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
-                                    }
-                                    HStack {
-                                        Text("Add pump").font(.caption).bold()
-                                    }
-                                }.frame(alignment: .top)
-                            }
-                
-                if let reservoir = reservoir {
-                                HStack {
-                                    Image(systemName: "drop.fill")
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                        .frame(maxHeight: 10)
-                                        .foregroundColor(reservoirColor)
-                                    if reservoir == 0xDEAD_BEEF {
-                                        Text("50+ " + NSLocalizedString("U", comment: "Insulin unit")).font(.footnote)
-                                            .fontWeight(.bold)
-                                    } else {
-                                        Text(
-                                            reservoirFormatter
-                                                .string(from: reservoir as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit")
-                                        )
-                                        .font(.footnote).fontWeight(.bold)
-                                    }
-                                }.frame(alignment: .top)
-                            }
-                            if let battery = battery, battery.display ?? false, expiresAtDate == nil {
-                                HStack {
-                                    Image(systemName: "battery.100")
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                        .frame(maxHeight: 10)
-                                        .foregroundColor(batteryColor)
-                                    Text("\(Int(battery.percent ?? 100)) %").font(.footnote)
-                                        .fontWeight(.bold)
-                                }.frame(alignment: .bottom)
-                            }
-
-                            if let date = expiresAtDate {
-                                HStack {
-                                    Image(systemName: "stopwatch.fill")
-                                        .resizable()
-                                        .aspectRatio(contentMode: .fit)
-                                        .frame(maxHeight: 10)
-                                        .foregroundColor(timerColor)
-                                    Text(remainingTimeString(time: date.timeIntervalSince(timerDate))).font(.footnote)
-                                        .fontWeight(.bold)
-                                }.frame(alignment: .bottom)
-                            }
+                    VStack(alignment: .center, spacing: 12) {
+                        HStack { // no cgm defined so display a generic CGM
+                            Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
                         }
+                        HStack {
+                            Text("Add pump").font(.caption).bold()
+                        }
+                    }.frame(alignment: .top)
+                }
+
+                if let reservoir = reservoir {
+                    HStack {
+                        Image(systemName: "drop.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxHeight: 10)
+                            .foregroundColor(reservoirColor)
+                        if reservoir == 0xDEAD_BEEF {
+                            Text("50+ " + NSLocalizedString("U", comment: "Insulin unit")).font(.footnote)
+                                .fontWeight(.bold)
+                        } else {
+                            Text(
+                                reservoirFormatter
+                                    .string(from: reservoir as NSNumber)! +
+                                    NSLocalizedString(" U", comment: "Insulin unit")
+                            )
+                            .font(.footnote).fontWeight(.bold)
+                        }
+                    }.frame(alignment: .top)
+                }
+                if let battery = battery, battery.display ?? false, expiresAtDate == nil {
+                    HStack {
+                        Image(systemName: "battery.100")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxHeight: 10)
+                            .foregroundColor(batteryColor)
+                        Text("\(Int(battery.percent ?? 100)) %").font(.footnote)
+                            .fontWeight(.bold)
+                    }.frame(alignment: .bottom)
+                }
+
+                if let date = expiresAtDate {
+                    HStack {
+                        Image(systemName: "stopwatch.fill")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxHeight: 10)
+                            .foregroundColor(timerColor)
+                        Text(remainingTimeString(time: date.timeIntervalSince(timerDate))).font(.footnote)
+                            .fontWeight(.bold)
+                    }.frame(alignment: .bottom)
+                }
+            }
         }
     }
 
@@ -165,7 +166,7 @@ struct PumpView: View {
         name: .constant("Pump test"),
         expiresAtDate: .constant(Date().addingTimeInterval(24.hours)),
         timerDate: .constant(Date()),
-        pumpStatutHighlightMessage: .constant("⚠️\n Insulin suspended")
+        pumpStatusHighlightMessage: .constant("⚠️\n Insulin suspended")
     )
 }
 
@@ -176,7 +177,7 @@ struct PumpView: View {
         name: .constant("Pump test"),
         expiresAtDate: .constant(nil),
         timerDate: .constant(Date().addingTimeInterval(-24.hours)),
-        pumpStatutHighlightMessage: .constant(nil)
+        pumpStatusHighlightMessage: .constant(nil)
     )
 }
 
@@ -187,7 +188,7 @@ struct PumpView: View {
         name: .constant("Pump test"),
         expiresAtDate: .constant(Date().addingTimeInterval(2.hours)),
         timerDate: .constant(Date().addingTimeInterval(2.hours)),
-        pumpStatutHighlightMessage: .constant(nil)
+        pumpStatusHighlightMessage: .constant(nil)
     )
 }
 
@@ -198,6 +199,6 @@ struct PumpView: View {
         name: .constant(""),
         expiresAtDate: .constant(nil),
         timerDate: .constant(Date()),
-        pumpStatutHighlightMessage: .constant(nil)
+        pumpStatusHighlightMessage: .constant(nil)
     )
 }

--- a/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
@@ -6,6 +6,7 @@ struct PumpView: View {
     @Binding var name: String
     @Binding var expiresAtDate: Date?
     @Binding var timerDate: Date
+    @Binding var pumpStatutHighlightMessage: String?
 
     private var reservoirFormatter: NumberFormatter {
         let formatter = NumberFormatter()
@@ -21,60 +22,67 @@ struct PumpView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            if reservoir == nil && battery == nil {
-                VStack(alignment: .center, spacing: 12) {
-                    HStack { // no cgm defined so display a generic CGM
-                        Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
-                    }
-                    HStack {
-                        Text("Add pump").font(.caption).bold()
-                    }
-                }.frame(alignment: .top)
-            }
+        if let pumpStatutHighlightMessage = pumpStatutHighlightMessage { // display message instead pump info
+            VStack(alignment: .center) {
+                Text(pumpStatutHighlightMessage).font(.footnote).fontWeight(.bold)
+                    .multilineTextAlignment(.center).frame(maxWidth: /*@START_MENU_TOKEN@*/ .infinity/*@END_MENU_TOKEN@*/)
+            }.frame(width: 100)
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                if reservoir == nil && battery == nil {
+                                VStack(alignment: .center, spacing: 12) {
+                                    HStack { // no cgm defined so display a generic CGM
+                                        Image(systemName: "keyboard.onehanded.left").font(.body).imageScale(.large)
+                                    }
+                                    HStack {
+                                        Text("Add pump").font(.caption).bold()
+                                    }
+                                }.frame(alignment: .top)
+                            }
+                
+                if let reservoir = reservoir {
+                                HStack {
+                                    Image(systemName: "drop.fill")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(maxHeight: 10)
+                                        .foregroundColor(reservoirColor)
+                                    if reservoir == 0xDEAD_BEEF {
+                                        Text("50+ " + NSLocalizedString("U", comment: "Insulin unit")).font(.footnote)
+                                            .fontWeight(.bold)
+                                    } else {
+                                        Text(
+                                            reservoirFormatter
+                                                .string(from: reservoir as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit")
+                                        )
+                                        .font(.footnote).fontWeight(.bold)
+                                    }
+                                }.frame(alignment: .top)
+                            }
+                            if let battery = battery, battery.display ?? false, expiresAtDate == nil {
+                                HStack {
+                                    Image(systemName: "battery.100")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(maxHeight: 10)
+                                        .foregroundColor(batteryColor)
+                                    Text("\(Int(battery.percent ?? 100)) %").font(.footnote)
+                                        .fontWeight(.bold)
+                                }.frame(alignment: .bottom)
+                            }
 
-            if let reservoir = reservoir {
-                HStack {
-                    Image(systemName: "drop.fill")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxHeight: 10)
-                        .foregroundColor(reservoirColor)
-                    if reservoir == 0xDEAD_BEEF {
-                        Text("50+ " + NSLocalizedString("U", comment: "Insulin unit")).font(.footnote)
-                            .fontWeight(.bold)
-                    } else {
-                        Text(
-                            reservoirFormatter
-                                .string(from: reservoir as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit")
-                        )
-                        .font(.footnote).fontWeight(.bold)
-                    }
-                }.frame(alignment: .top)
-            }
-            if let battery = battery, battery.display ?? false, expiresAtDate == nil {
-                HStack {
-                    Image(systemName: "battery.100")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxHeight: 10)
-                        .foregroundColor(batteryColor)
-                    Text("\(Int(battery.percent ?? 100)) %").font(.footnote)
-                        .fontWeight(.bold)
-                }.frame(alignment: .bottom)
-            }
-
-            if let date = expiresAtDate {
-                HStack {
-                    Image(systemName: "stopwatch.fill")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(maxHeight: 10)
-                        .foregroundColor(timerColor)
-                    Text(remainingTimeString(time: date.timeIntervalSince(timerDate))).font(.footnote)
-                        .fontWeight(.bold)
-                }.frame(alignment: .bottom)
-            }
+                            if let date = expiresAtDate {
+                                HStack {
+                                    Image(systemName: "stopwatch.fill")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(maxHeight: 10)
+                                        .foregroundColor(timerColor)
+                                    Text(remainingTimeString(time: date.timeIntervalSince(timerDate))).font(.footnote)
+                                        .fontWeight(.bold)
+                                }.frame(alignment: .bottom)
+                            }
+                        }
         }
     }
 
@@ -148,4 +156,48 @@ struct PumpView: View {
             return .loopGreen
         }
     }
+}
+
+#Preview("message") {
+    PumpView(
+        reservoir: .constant(Decimal(10.0)),
+        battery: .constant(nil),
+        name: .constant("Pump test"),
+        expiresAtDate: .constant(Date().addingTimeInterval(24.hours)),
+        timerDate: .constant(Date()),
+        pumpStatutHighlightMessage: .constant("⚠️\n Insulin suspended")
+    )
+}
+
+#Preview("pump reservoir") {
+    PumpView(
+        reservoir: .constant(Decimal(40.0)),
+        battery: .constant(Battery(percent: 50, voltage: 2.0, string: BatteryState.normal, display: true)),
+        name: .constant("Pump test"),
+        expiresAtDate: .constant(nil),
+        timerDate: .constant(Date().addingTimeInterval(-24.hours)),
+        pumpStatutHighlightMessage: .constant(nil)
+    )
+}
+
+#Preview("pump expiration") {
+    PumpView(
+        reservoir: .constant(Decimal(10.0)),
+        battery: .constant(Battery(percent: 50, voltage: 2.0, string: BatteryState.normal, display: false)),
+        name: .constant("Pump test"),
+        expiresAtDate: .constant(Date().addingTimeInterval(2.hours)),
+        timerDate: .constant(Date().addingTimeInterval(2.hours)),
+        pumpStatutHighlightMessage: .constant(nil)
+    )
+}
+
+#Preview("no pump") {
+    PumpView(
+        reservoir: .constant(nil),
+        battery: .constant(nil),
+        name: .constant(""),
+        expiresAtDate: .constant(nil),
+        timerDate: .constant(Date()),
+        pumpStatutHighlightMessage: .constant(nil)
+    )
 }

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -131,7 +131,7 @@ extension Home {
                 name: $state.pumpName,
                 expiresAtDate: $state.pumpExpiresAtDate,
                 timerDate: $state.timerDate,
-                pumpStatutHighlightMessage: $state.pumpStatutHighlightMessage
+                pumpStatusHighlightMessage: $state.pumpStatusHighlightMessage
             )
             .onTapGesture {
                 state.setupPump = true

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -130,7 +130,8 @@ extension Home {
                 battery: $state.battery,
                 name: $state.pumpName,
                 expiresAtDate: $state.pumpExpiresAtDate,
-                timerDate: $state.timerDate
+                timerDate: $state.timerDate,
+                pumpStatutHighlightMessage: $state.pumpStatutHighlightMessage
             )
             .onTapGesture {
                 state.setupPump = true

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -15,27 +15,11 @@ extension Home {
         @Environment(\.managedObjectContext) var moc
         @Environment(\.colorScheme) var colorScheme
 
-        @FetchRequest(
-            entity: Override.entity(),
-            sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)]
-        ) var fetchedPercent: FetchedResults<Override>
-
-        @FetchRequest(
-            entity: OverridePresets.entity(),
-            sortDescriptors: [NSSortDescriptor(key: "name", ascending: true)], predicate: NSPredicate(
-                format: "name != %@", "" as String
-            )
-        ) var fetchedProfiles: FetchedResults<OverridePresets>
-
+        // * TODO: To remove with #154 https://github.com/nightscout/Open-iAPS/issues/154
         @FetchRequest(
             entity: TempTargets.entity(),
             sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)]
         ) var sliderTTpresets: FetchedResults<TempTargets>
-
-        @FetchRequest(
-            entity: TempTargetsSlider.entity(),
-            sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)]
-        ) var enactedSliderTT: FetchedResults<TempTargetsSlider>
 
         private var numberFormatter: NumberFormatter {
             let formatter = NumberFormatter()
@@ -196,6 +180,7 @@ extension Home {
             let rawString = (tirFormatter.string(from: (tempTarget.targetBottom ?? 0) as NSNumber) ?? "") + " " + state.units
                 .rawValue
 
+            // * TODO: To remove with #154 https://github.com/nightscout/Open-iAPS/issues/154
             var string = ""
             if sliderTTpresets.first?.active ?? false {
                 let hbt = sliderTTpresets.first?.hbt ?? 0
@@ -208,12 +193,12 @@ extension Home {
         }
 
         var overrideString: String? {
-            guard fetchedPercent.first?.enabled ?? false else {
+            guard state.currentOverride != nil else {
                 return nil
             }
-            var percentString = "\((fetchedPercent.first?.percentage ?? 100).formatted(.number)) %"
-            var target = (fetchedPercent.first?.target ?? 100) as Decimal
-            let indefinite = (fetchedPercent.first?.indefinite ?? false)
+            var percentString = "\((state.currentOverride?.percentage ?? 100).formatted(.number)) %"
+            var target = (state.currentOverride?.target ?? 100) as Decimal
+            let indefinite = (state.currentOverride?.indefinite ?? false)
             let unit = state.units.rawValue
             if state.units == .mmolL {
                 target = target.asMmolL
@@ -222,16 +207,16 @@ extension Home {
             if tempTargetString != nil || target == 0 { targetString = "" }
             percentString = percentString == "100 %" ? "" : percentString
 
-            let duration = (fetchedPercent.first?.duration ?? 0) as Decimal
+            let duration = state.currentOverride?.duration ?? 0
             let addedMinutes = Int(duration)
-            let date = fetchedPercent.first?.date ?? Date()
+            let date = state.currentOverride?.createdAt ?? Date()
             var newDuration: Decimal = 0
 
             if date.addingTimeInterval(addedMinutes.minutes.timeInterval) > Date() {
                 newDuration = Decimal(Date().distance(to: date.addingTimeInterval(addedMinutes.minutes.timeInterval)).minutes)
             }
 
-            var durationString = indefinite ?
+            let durationString = indefinite ?
                 "" : newDuration >= 1 ?
                 (newDuration.formatted(.number.grouping(.never).rounded().precision(.fractionLength(0))) + " min") :
                 (
@@ -246,12 +231,12 @@ extension Home {
             }
 
             let smbToggleString = (
-                (fetchedPercent.first?.smbIsOff ?? false) || fetchedPercent.first?.smbIsScheduledOff ?? false
+                (state.currentOverride?.smbIsOff ?? false) || state.currentOverride?.smbIsScheduledOff ?? false
             ) ?
                 " \u{20e0}" : ""
-            let smbScheduleString = (fetchedPercent.first?.smbIsScheduledOff ?? false) &&
-                !(fetchedPercent.first?.smbIsOff ?? false) ?
-                " \(fetchedPercent.first?.start ?? 0)-\(fetchedPercent.first?.end ?? 0)" : ""
+            let smbScheduleString = (state.currentOverride?.smbIsScheduledOff ?? false) &&
+                !(state.currentOverride?.smbIsOff ?? false) ?
+                " \(state.currentOverride?.start ?? 0)-\(state.currentOverride?.end ?? 0)" : ""
             let comma1 = (percentString == "" || (targetString == "" && durationString == "" && smbToggleString == ""))
                 ? "" : " , "
             let comma2 = (targetString == "" || (durationString == "" && smbToggleString == ""))
@@ -383,7 +368,9 @@ extension Home {
                     screenHours: $state.screenHours,
                     displayXgridLines: $state.displayXgridLines,
                     displayYgridLines: $state.displayYgridLines,
-                    thresholdLines: $state.thresholdLines
+                    thresholdLines: $state.thresholdLines,
+                    overrideHistory: $state.overrideHistory,
+                    targetBG: $state.targetBG
                 )
             }
             .padding(.bottom)
@@ -395,7 +382,7 @@ extension Home {
             // Rectangle().fill(colour).frame(maxHeight: 1)
             ZStack {
                 Rectangle().fill(Color.gray.opacity(0.2)).frame(maxHeight: 40)
-                let cancel = fetchedPercent.first?.enabled ?? false
+                let cancel = state.currentOverride != nil
                 HStack(spacing: cancel ? 25 : 15) {
                     Text(selectedProfile().name).foregroundColor(.secondary)
                     if cancel, selectedProfile().isOn {
@@ -410,8 +397,8 @@ extension Home {
                         Image(systemName: "person.3.sequence.fill")
                             .symbolRenderingMode(.palette)
                             .foregroundStyle(
-                                !(fetchedPercent.first?.enabled ?? false) ? .green : .cyan,
-                                !(fetchedPercent.first?.enabled ?? false) ? .cyan : .green,
+                                !(state.currentOverride != nil) ? .green : .cyan,
+                                !(state.currentOverride != nil) ? .cyan : .green,
                                 .purple
                             )
                     }
@@ -433,24 +420,21 @@ extension Home {
             var profileString = ""
             var display: Bool = false
 
-            let duration = (fetchedPercent.first?.duration ?? 0) as Decimal
-            let indefinite = fetchedPercent.first?.indefinite ?? false
+            let duration = (state.currentOverride?.duration ?? 0) as Decimal
+            let indefinite = state.currentOverride?.indefinite ?? false
             let addedMinutes = Int(duration)
-            let date = fetchedPercent.first?.date ?? Date()
+            let date = state.currentOverride?.createdAt ?? Date()
             if date.addingTimeInterval(addedMinutes.minutes.timeInterval) > Date() || indefinite {
                 display.toggle()
             }
 
-            if fetchedPercent.first?.enabled ?? false, !(fetchedPercent.first?.isPreset ?? false), display {
-                profileString = NSLocalizedString("Custom Profile", comment: "Custom but unsaved Profile")
-            } else if !(fetchedPercent.first?.enabled ?? false) || !display {
-                profileString = NSLocalizedString("Normal Profile", comment: "Your normal Profile. Use a short string")
+            if let currentOverride = state.currentOverride, display {
+                profileString = currentOverride.name != nil ? currentOverride.displayName : NSLocalizedString(
+                    "Custom Profile",
+                    comment: "Custom but unsaved Profile"
+                )
             } else {
-                let id_ = fetchedPercent.first?.id ?? ""
-                let profile = fetchedProfiles.filter({ $0.id == id_ }).first
-                if profile != nil {
-                    profileString = profile?.name?.description ?? ""
-                }
+                profileString = NSLocalizedString("Normal Profile", comment: "Your normal Profile. Use a short string")
             }
             return (name: profileString, isOn: display)
         }

--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -22,6 +22,7 @@ extension NightscoutConfig {
         @Published var connecting = false
         @Published var backfilling = false
         @Published var isUploadEnabled = false // Allow uploads
+        @Published var isDownloadEnabled = false // Allow downloads
         @Published var uploadGlucose = true // Upload Glucose
         @Published var changeUploadGlucose = true // if plugin, need to be change in CGM configuration
         @Published var useLocalSource = false
@@ -43,6 +44,7 @@ extension NightscoutConfig {
 
             subscribeSetting(\.allowAnnouncements, on: $allowAnnouncements) { allowAnnouncements = $0 }
             subscribeSetting(\.isUploadEnabled, on: $isUploadEnabled) { isUploadEnabled = $0 }
+            subscribeSetting(\.isDownloadEnabled, on: $isDownloadEnabled) { isDownloadEnabled = $0 }
             subscribeSetting(\.useLocalGlucoseSource, on: $useLocalSource) { useLocalSource = $0 }
             subscribeSetting(\.localGlucosePort, on: $localPort.map(Int.init)) { localPort = Decimal($0) }
             subscribeSetting(\.uploadGlucose, on: $uploadGlucose, initial: { uploadGlucose = $0 })

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
@@ -24,12 +24,34 @@ extension NightscoutConfig {
                 NavigationLink("Fetch and Remote Control", destination: NightscoutFetchView(state: state))
 
                 Section(
-                    header: Text("Import Settings"),
-                    footer: Text(
-                        "Importing settings from Nightscout will overwrite these settings in Trio Settings -> Configuration:\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose"
-                    )
+                    header: Text("Import Settings from Nightscout"),
+                    footer: VStack(alignment: .leading, spacing: 2) {
+                        Text(
+                            "Importing settings from Nightscout will overwrite these settings in Trio Settings -> Configuration:"
+                        )
+                        HStack {
+                            Text("•")
+                            Text("DIA (Pump settings)")
+                        }
+                        HStack {
+                            Text("•")
+                            Text("Basal Profile")
+                        }
+                        HStack {
+                            Text("•")
+                            Text("Insulin Sensitivities")
+                        }
+                        HStack {
+                            Text("•")
+                            Text("Carb Ratios")
+                        }
+                        HStack {
+                            Text("•")
+                            Text("Target Glucose")
+                        }
+                    }
                 ) {
-                    Button("Import settings from Nightscout") {
+                    Button("Import settings") {
                         importAlert = Alert(
                             title: Text("Import settings?"),
                             message: Text(

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
@@ -29,26 +29,11 @@ extension NightscoutConfig {
                         Text(
                             "Importing settings from Nightscout will overwrite these settings in Trio Settings -> Configuration:"
                         )
-                        HStack {
-                            Text("•")
-                            Text("DIA (Pump settings)")
-                        }
-                        HStack {
-                            Text("•")
-                            Text("Basal Profile")
-                        }
-                        HStack {
-                            Text("•")
-                            Text("Insulin Sensitivities")
-                        }
-                        HStack {
-                            Text("•")
-                            Text("Carb Ratios")
-                        }
-                        HStack {
-                            Text("•")
-                            Text("Target Glucose")
-                        }
+                        Text(" • ") + Text("DIA (Pump settings)")
+                        Text(" • ") + Text("Basal Profile")
+                        Text(" • ") + Text("Insulin Sensitivities")
+                        Text(" • ") + Text("Carb Ratios")
+                        Text(" • ") + Text("Target Glucose")
                     }
                 ) {
                     Button("Import settings") {

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
@@ -67,8 +67,9 @@ extension NightscoutConfig {
                     if state.isUploadEnabled {
                         Toggle("Glucose", isOn: $state.uploadGlucose).disabled(!state.changeUploadGlucose)
                     }
+                    Toggle("Download", isOn: $state.isDownloadEnabled)
                 } header: {
-                    Text("Allow Uploads")
+                    Text("Allow Up- and downloads")
                 }
 
                 Section {

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
@@ -7,72 +7,28 @@ extension NightscoutConfig {
         let resolver: Resolver
         let displayClose: Bool
         @StateObject var state = StateModel()
-        @State var importAlert: Alert?
-        @State var isImportAlertPresented = false
-        @State var importedHasRun = false
+        @State private var importAlert: Alert?
+        @State private var isImportAlertPresented = false
+        @State private var importedHasRun = false
 
         @FetchRequest(
             entity: ImportError.entity(),
-            sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)], predicate: NSPredicate(
-                format: "date > %@", Date().addingTimeInterval(-1.minutes.timeInterval) as NSDate
-            )
+            sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)],
+            predicate: NSPredicate(format: "date > %@", Date().addingTimeInterval(-1.minutes.timeInterval) as NSDate)
         ) var fetchedErrors: FetchedResults<ImportError>
-
-        private var portFormater: NumberFormatter {
-            let formatter = NumberFormatter()
-            formatter.allowsFloats = false
-            return formatter
-        }
 
         var body: some View {
             Form {
-                Section {
-                    TextField("URL", text: $state.url)
-                        .disableAutocorrection(true)
-                        .textContentType(.URL)
-                        .autocapitalization(.none)
-                        .keyboardType(.URL)
-                    SecureField("API secret", text: $state.secret)
-                        .disableAutocorrection(true)
-                        .autocapitalization(.none)
-                        .textContentType(.password)
-                        .keyboardType(.asciiCapable)
-                    if !state.message.isEmpty {
-                        Text(state.message)
-                    }
-                    if state.connecting {
-                        HStack {
-                            Text("Connecting...")
-                            Spacer()
-                            ProgressView()
-                        }
-                    }
-                }
+                NavigationLink("Connect", destination: NightscoutConnectView(state: state))
+                NavigationLink("Upload", destination: NightscoutUploadView(state: state))
+                NavigationLink("Fetch and Remote Control", destination: NightscoutFetchView(state: state))
 
-                Section {
-                    Button("Connect") { state.connect() }
-                        .disabled(state.url.isEmpty || state.connecting)
-                    Button("Delete") { state.delete() }.foregroundColor(.red).disabled(state.connecting)
-                }
-
-                Section {
-                    Button("Open Nighstcout") {
-                        UIApplication.shared.open(URL(string: state.url)!, options: [:], completionHandler: nil)
-                    }
-                    .disabled(state.url.isEmpty || state.connecting)
-                }
-
-                Section {
-                    Toggle("Upload", isOn: $state.isUploadEnabled)
-                    if state.isUploadEnabled {
-                        Toggle("Glucose", isOn: $state.uploadGlucose).disabled(!state.changeUploadGlucose)
-                    }
-                    Toggle("Download", isOn: $state.isDownloadEnabled)
-                } header: {
-                    Text("Allow Up- and downloads")
-                }
-
-                Section {
+                Section(
+                    header: Text("Import Settings"),
+                    footer: Text(
+                        "Importing settings from Nightscout will overwrite these settings in Trio Settings -> Configuration:\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose"
+                    )
+                ) {
                     Button("Import settings from Nightscout") {
                         importAlert = Alert(
                             title: Text("Import settings?"),
@@ -95,50 +51,38 @@ extension NightscoutConfig {
                         )
                         isImportAlertPresented.toggle()
                     }.disabled(state.url.isEmpty || state.connecting)
-
-                } header: { Text("Import from Nightscout") }
-
-                    .alert(isPresented: $importedHasRun) {
-                        Alert(
-                            title: Text((fetchedErrors.first?.error ?? "").count < 4 ? "Settings imported" : "Import Error"),
-                            message: Text(
-                                (fetchedErrors.first?.error ?? "").count < 4 ?
-                                    NSLocalizedString(
-                                        "\nNow please verify all of your new settings thoroughly:\n\n* Basal Settings\n * Carb Ratios\n * Glucose Targets\n * Insulin Sensitivities\n * DIA\n\n in Trio Settings > Configuration.\n\nBad or invalid profile settings could have disatrous effects.",
-                                        comment: "Imported Profiles Alert"
-                                    ) :
-                                    NSLocalizedString(fetchedErrors.first?.error ?? "", comment: "Import Error")
-                            ),
-                            primaryButton: .destructive(
-                                Text("OK")
-                            ),
-                            secondaryButton: .cancel()
-                        )
-                    }
-
-                Section {
-                    Toggle("Use local glucose server", isOn: $state.useLocalSource)
-                    HStack {
-                        Text("Port")
-                        DecimalTextField("", value: $state.localPort, formatter: portFormater)
-                    }
-                } header: { Text("Local glucose source") }
+                        .alert(isPresented: $importedHasRun) {
+                            Alert(
+                                title: Text((fetchedErrors.first?.error ?? "").count < 4 ? "Settings imported" : "Import Error"),
+                                message: Text(
+                                    (fetchedErrors.first?.error ?? "").count < 4 ?
+                                        NSLocalizedString(
+                                            "\nNow please verify all of your new settings thoroughly: \n\n • DIA (Pump settings)\n • Basal Profile\n • Insulin Sensitivities\n • Carb Ratios\n • Target Glucose\n\n in Trio Settings -> Configuration.\n\nBad or invalid profile settings could have disastrous effects.",
+                                            comment: "Imported Profiles Alert"
+                                        ) :
+                                        NSLocalizedString(fetchedErrors.first?.error ?? "", comment: "Import Error")
+                                ),
+                                primaryButton: .destructive(
+                                    Text("OK")
+                                ),
+                                secondaryButton: .cancel()
+                            )
+                        }
+                }
                 Section {
                     Button("Backfill glucose") { state.backfillGlucose() }
                         .disabled(state.url.isEmpty || state.connecting || state.backfilling)
+                } header: { Text("Backfill glucose from Nightscout")
                 }
-
-                Section {
-                    Toggle("Remote control", isOn: $state.allowAnnouncements)
-                } header: { Text("Allow Remote control of Trio") }
             }
-            .onAppear(perform: configureView)
             .navigationBarTitle("Nightscout Config")
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarItems(leading: displayClose ? Button("Close", action: state.hideModal) : nil)
             .alert(isPresented: $isImportAlertPresented) {
                 importAlert!
             }
+
+            .onAppear(perform: configureView)
         }
     }
 }

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConnectView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConnectView.swift
@@ -35,7 +35,7 @@ struct NightscoutConnectView: View {
                 }
             }
             Section {
-                Button("Connect") { state.connect() }
+                Button("Connect to Nightscout") { state.connect() }
                     .disabled(state.url.isEmpty || state.connecting)
                 Button("Delete") { state.delete() }.foregroundColor(.red).disabled(state.connecting)
             }

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConnectView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConnectView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct NightscoutConnectView: View {
+    @ObservedObject var state: NightscoutConfig.StateModel
+    @State private var portFormater: NumberFormatter
+
+    init(state: NightscoutConfig.StateModel) {
+        self.state = state
+        portFormater = NumberFormatter()
+        portFormater.allowsFloats = false
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("URL", text: $state.url)
+                    .disableAutocorrection(true)
+                    .textContentType(.URL)
+                    .autocapitalization(.none)
+                    .keyboardType(.URL)
+                SecureField("API secret", text: $state.secret)
+                    .disableAutocorrection(true)
+                    .autocapitalization(.none)
+                    .textContentType(.password)
+                    .keyboardType(.asciiCapable)
+                if !state.message.isEmpty {
+                    Text(state.message)
+                }
+                if state.connecting {
+                    HStack {
+                        Text("Connecting...")
+                        Spacer()
+                        ProgressView()
+                    }
+                }
+            }
+            Section {
+                Button("Connect") { state.connect() }
+                    .disabled(state.url.isEmpty || state.connecting)
+                Button("Delete") { state.delete() }.foregroundColor(.red).disabled(state.connecting)
+            }
+            Section {
+                Button("Open Nightscout") {
+                    UIApplication.shared.open(URL(string: state.url)!, options: [:], completionHandler: nil)
+                }
+                .disabled(state.url.isEmpty || state.connecting)
+            }
+            Section {
+                Toggle("Use local glucose server", isOn: $state.useLocalSource)
+                HStack {
+                    Text("Port")
+                    DecimalTextField("", value: $state.localPort, formatter: portFormater)
+                }
+            } header: { Text("Local glucose source") }
+        }
+        .navigationTitle("Connect")
+    }
+}

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutFetchView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutFetchView.swift
@@ -1,0 +1,35 @@
+
+import SwiftUI
+
+struct NightscoutFetchView: View {
+    @ObservedObject var state: NightscoutConfig.StateModel
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Fetch Treatments", isOn: $state.isDownloadEnabled)
+                    .onChange(of: state.isDownloadEnabled) { newValue in
+                        if !newValue {
+                            state.allowAnnouncements = false
+                        }
+                    }
+            } header: {
+                Text("Allow Fetching from Nightscout")
+            } footer: {
+                Text(
+                    "The Fetch Treatments toggle enables fetching of carbs and temp targets entered in Careportal or by another uploading device than Trio."
+                )
+            }
+            Section {
+                Toggle("Remote Control", isOn: $state.allowAnnouncements)
+                    .disabled(!state.isDownloadEnabled)
+            } header: { Text("Allow Remote control of Trio")
+            } footer: {
+                Text(
+                    "Fetch Treatments needs to be allowed to be able to toggle on Remote Control.\n\nWhen enabled you allow these remote functions through announcements from Nightscout:\n • Suspend/Resume Pump\n • Opening/Closing Loop\n • Set Temp Basal\n • Enact Bolus."
+                )
+            }
+        }
+        .navigationTitle("Fetch and Remote")
+    }
+}

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutFetchView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutFetchView.swift
@@ -25,22 +25,10 @@ struct NightscoutFetchView: View {
                 footer: VStack(alignment: .leading, spacing: 2) {
                     Text("Fetch Treatments needs to be allowed to be able to toggle on Remote Control.")
                     Text("\nWhen enabled you allow these remote functions through announcements from Nightscout:")
-                    HStack {
-                        Text("•")
-                        Text("Suspend/Resume Pump")
-                    }
-                    HStack {
-                        Text("•")
-                        Text("Opening/Closing Loop")
-                    }
-                    HStack {
-                        Text("•")
-                        Text("Set Temp Basal")
-                    }
-                    HStack {
-                        Text("•")
-                        Text("Enact Bolus")
-                    }
+                    Text(" • ") + Text("Suspend/Resume Pump")
+                    Text(" • ") + Text("Opening/Closing Loop")
+                    Text(" • ") + Text("Set Temp Basal")
+                    Text(" • ") + Text("Enact Bolus")
                 }
             )
                 {

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutFetchView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutFetchView.swift
@@ -20,15 +20,33 @@ struct NightscoutFetchView: View {
                     "The Fetch Treatments toggle enables fetching of carbs and temp targets entered in Careportal or by another uploading device than Trio."
                 )
             }
-            Section {
-                Toggle("Remote Control", isOn: $state.allowAnnouncements)
-                    .disabled(!state.isDownloadEnabled)
-            } header: { Text("Allow Remote control of Trio")
-            } footer: {
-                Text(
-                    "Fetch Treatments needs to be allowed to be able to toggle on Remote Control.\n\nWhen enabled you allow these remote functions through announcements from Nightscout:\n • Suspend/Resume Pump\n • Opening/Closing Loop\n • Set Temp Basal\n • Enact Bolus."
-                )
-            }
+            Section(
+                header: Text("Allow Remote control of Trio"),
+                footer: VStack(alignment: .leading, spacing: 2) {
+                    Text("Fetch Treatments needs to be allowed to be able to toggle on Remote Control.")
+                    Text("\nWhen enabled you allow these remote functions through announcements from Nightscout:")
+                    HStack {
+                        Text("•")
+                        Text("Suspend/Resume Pump")
+                    }
+                    HStack {
+                        Text("•")
+                        Text("Opening/Closing Loop")
+                    }
+                    HStack {
+                        Text("•")
+                        Text("Set Temp Basal")
+                    }
+                    HStack {
+                        Text("•")
+                        Text("Enact Bolus")
+                    }
+                }
+            )
+                {
+                    Toggle("Remote Control", isOn: $state.allowAnnouncements)
+                        .disabled(!state.isDownloadEnabled)
+                }
         }
         .navigationTitle("Fetch and Remote")
     }

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutUploadView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutUploadView.swift
@@ -1,0 +1,24 @@
+
+import SwiftUI
+
+struct NightscoutUploadView: View {
+    @ObservedObject var state: NightscoutConfig.StateModel
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Upload Treatments and Settings", isOn: $state.isUploadEnabled)
+
+                Toggle("Upload Glucose", isOn: $state.uploadGlucose).disabled(!state.changeUploadGlucose)
+
+            } header: {
+                Text("Allow Uploading to Nightscout")
+            } footer: {
+                Text(
+                    "The Upload Treatments toggle enables uploading of carbs, temp targets, device status, preferences and settings.\n\nThe Upload Glucose enables uploading of CGM readings."
+                )
+            }
+        }
+        .navigationTitle("Upload")
+    }
+}

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutUploadView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutUploadView.swift
@@ -6,18 +6,20 @@ struct NightscoutUploadView: View {
 
     var body: some View {
         Form {
-            Section {
-                Toggle("Upload Treatments and Settings", isOn: $state.isUploadEnabled)
+            Section(
+                header: Text("Allow Uploading to Nightscout"),
+                footer: VStack(alignment: .leading, spacing: 2) {
+                    Text(
+                        "The Upload Treatments toggle enables uploading of carbs, temp targets, device status, preferences and settings."
+                    )
+                    Text("\nThe Upload Glucose toggle enables uploading of CGM readings.")
+                }
+            )
+                {
+                    Toggle("Upload Treatments and Settings", isOn: $state.isUploadEnabled)
 
-                Toggle("Upload Glucose", isOn: $state.uploadGlucose).disabled(!state.changeUploadGlucose)
-
-            } header: {
-                Text("Allow Uploading to Nightscout")
-            } footer: {
-                Text(
-                    "The Upload Treatments toggle enables uploading of carbs, temp targets, device status, preferences and settings.\n\nThe Upload Glucose enables uploading of CGM readings."
-                )
-            }
+                    Toggle("Upload Glucose", isOn: $state.uploadGlucose).disabled(!state.changeUploadGlucose)
+                }
         }
         .navigationTitle("Upload")
     }

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
@@ -63,39 +63,23 @@ extension OverrideProfilesConfig {
         }
 
         func savePreset() {
-            coredataContext.perform { [self] in
-                let saveOverride = OverridePresets(context: self.coredataContext)
-                saveOverride.duration = self.duration as NSDecimalNumber
-                saveOverride.indefinite = self._indefinite
-                saveOverride.percentage = self.percentage
-                saveOverride.smbIsOff = self.smbIsOff
-                saveOverride.name = self.profileName
-                self.profileName = ""
-                id = UUID().uuidString
-                self.isPreset.toggle()
-                saveOverride.id = id
-                saveOverride.date = Date()
-                if override_target {
-                    saveOverride.target = (
-                        units == .mmolL
-                            ? target.asMgdL
-                            : target
-                    ) as NSDecimalNumber
-                } else { saveOverride.target = 0 }
-
-                if advancedSettings {
-                    saveOverride.advancedSettings = true
-
-                    if !isfAndCr {
-                        saveOverride.isfAndCr = false
-                        saveOverride.isf = isf
-                        saveOverride.cr = cr
-                    } else { saveOverride.isfAndCr = true }
-                    if smbIsScheduledOff {
-                        saveOverride.smbIsScheduledOff = true
-                        saveOverride.start = start as NSDecimalNumber
-                        saveOverride.end = end as NSDecimalNumber
-                    } else { smbIsScheduledOff = false }
+            let overridePresetToSave = OverrideProfil(
+                name: profileName,
+                duration: _indefinite ? nil : duration,
+                indefinite: _indefinite,
+                percentage: percentage,
+                target: override_target ? (units == .mmolL ? target.asMgdL : target) : 0,
+                advancedSettings: advancedSettings,
+                smbIsOff: smbIsOff,
+                isfAndCr: isfAndCr,
+                isf: isfAndCr ? false : isf,
+                cr: isfAndCr ? false : cr,
+                smbIsScheduledOff: smbIsScheduledOff,
+                start: smbIsScheduledOff ? start : nil,
+                end: smbIsScheduledOff ? end : nil,
+                smbMinutes: smbMinutes,
+                uamMinutes: uamMinutes
+            )
 
             overrideStorage.storeOverridePresets([overridePresetToSave])
             presets = overrideStorage.presets()

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
@@ -13,7 +13,6 @@ extension OverrideProfilesConfig {
         @Published var profileName: String = ""
         @Published var isPreset: Bool = false
         @Published var presets: [OverrideProfil] = []
-//        @Published var selection: OverrideProfil?
         @Published var advancedSettings: Bool = false
         @Published var isfAndCr: Bool = true
         @Published var isf: Bool = true
@@ -85,48 +84,96 @@ extension OverrideProfilesConfig {
             presets = overrideStorage.presets()
         }
 
+        func updatePreset(_ presetId: String) {
+            let overridePresetToSave = OverrideProfil(
+                id: presetId,
+                name: profileName,
+                duration: _indefinite ? nil : duration,
+                indefinite: _indefinite,
+                percentage: percentage,
+                target: override_target ? (units == .mmolL ? target.asMgdL : target) : 0,
+                advancedSettings: advancedSettings,
+                smbIsOff: smbIsOff,
+                isfAndCr: isfAndCr,
+                isf: isfAndCr ? false : isf,
+                cr: isfAndCr ? false : cr,
+                smbIsScheduledOff: smbIsScheduledOff,
+                start: smbIsScheduledOff ? start : nil,
+                end: smbIsScheduledOff ? end : nil,
+                smbMinutes: smbMinutes,
+                uamMinutes: uamMinutes
+            )
+
+            overrideStorage.storeOverridePresets([overridePresetToSave])
+            presets = overrideStorage.presets()
+        }
+
         func selectProfile(id_: String) {
             guard id_ != "" else { return }
             _ = overrideStorage.applyOverridePreset(id_)
         }
 
-        func savedSettings() {
+        func reset() {
+            percentage = 100
+            isEnabled = false
+            _indefinite = true
+            duration = 0
+            target = 0
+            override_target = false
+            smbIsOff = false
+            id = ""
+            profileName = ""
+            advancedSettings = false
+            isfAndCr = true
+            isf = true
+            cr = true
+            smbIsScheduledOff = false
+            start = 0
+            end = 23
+            smbMinutes = defaultSmbMinutes
+            uamMinutes = defaultUamMinutes
+        }
+
+        func displayCurrentOverride() {
             guard let currentOverride = overrideStorage.current() else {
                 isEnabled = false
                 return
             }
-
             isEnabled = true
-            percentage = currentOverride.percentage ?? 100
-            _indefinite = currentOverride.indefinite ?? true
-            duration = currentOverride.duration ?? 0
-            smbIsOff = currentOverride.smbIsOff ?? false
-            advancedSettings = currentOverride.advancedSettings ?? false
-            isfAndCr = currentOverride.isfAndCr ?? true
-            smbIsScheduledOff = currentOverride.smbIsScheduledOff ?? false
+            displayOverrideProfil(profil: currentOverride)
+        }
+
+        func displayOverrideProfil(profil: OverrideProfil) {
+            percentage = profil.percentage ?? 100
+            _indefinite = profil.indefinite ?? true
+            duration = profil.duration ?? 0
+            smbIsOff = profil.smbIsOff ?? false
+            advancedSettings = profil.advancedSettings ?? false
+            isfAndCr = profil.isfAndCr ?? true
+            smbIsScheduledOff = profil.smbIsScheduledOff ?? false
 
             if advancedSettings {
                 if !isfAndCr {
-                    isf = currentOverride.isf ?? false
-                    cr = currentOverride.cr ?? false
+                    isf = profil.isf ?? false
+                    cr = profil.cr ?? false
                 }
                 if smbIsScheduledOff {
-                    start = currentOverride.start ?? 0
-                    end = currentOverride.end ?? 0
+                    start = profil.start ?? 0
+                    end = profil.end ?? 0
                 }
 
-                smbMinutes = currentOverride.smbMinutes ?? defaultSmbMinutes
-                uamMinutes = currentOverride.uamMinutes ?? defaultUamMinutes
+                smbMinutes = profil.smbMinutes ?? defaultSmbMinutes
+                uamMinutes = profil.uamMinutes ?? defaultUamMinutes
             }
 
-            let overrideTarget = currentOverride.target ?? 0
+            let overrideTarget = profil.target ?? 0
             if overrideTarget != 0 {
                 override_target = true
                 target = units == .mmolL ? overrideTarget.asMmolL : overrideTarget
             }
             if !_indefinite {
-                let durationOverride = currentOverride.duration ?? 0
-                let date = currentOverride.createdAt ?? Date()
+                let durationOverride = profil.duration ?? 0
+                let date = profil.createdAt ?? Date()
                 duration = max(0, durationOverride + Decimal(Date().distance(to: date).minutes))
             }
         }

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
@@ -63,23 +63,39 @@ extension OverrideProfilesConfig {
         }
 
         func savePreset() {
-            let overridePresetToSave = OverrideProfil(
-                name: profileName,
-                duration: _indefinite ? nil : duration,
-                indefinite: _indefinite,
-                percentage: percentage,
-                target: override_target ? (units == .mmolL ? target.asMgdL : target) : 0,
-                advancedSettings: advancedSettings,
-                smbIsOff: smbIsOff,
-                isfAndCr: isfAndCr,
-                isf: isfAndCr ? false : isf,
-                cr: isfAndCr ? false : cr,
-                smbIsScheduledOff: smbIsScheduledOff,
-                start: smbIsScheduledOff ? start : nil,
-                end: smbIsScheduledOff ? end : nil,
-                smbMinutes: smbMinutes,
-                uamMinutes: uamMinutes
-            )
+            coredataContext.perform { [self] in
+                let saveOverride = OverridePresets(context: self.coredataContext)
+                saveOverride.duration = self.duration as NSDecimalNumber
+                saveOverride.indefinite = self._indefinite
+                saveOverride.percentage = self.percentage
+                saveOverride.smbIsOff = self.smbIsOff
+                saveOverride.name = self.profileName
+                self.profileName = ""
+                id = UUID().uuidString
+                self.isPreset.toggle()
+                saveOverride.id = id
+                saveOverride.date = Date()
+                if override_target {
+                    saveOverride.target = (
+                        units == .mmolL
+                            ? target.asMgdL
+                            : target
+                    ) as NSDecimalNumber
+                } else { saveOverride.target = 0 }
+
+                if advancedSettings {
+                    saveOverride.advancedSettings = true
+
+                    if !isfAndCr {
+                        saveOverride.isfAndCr = false
+                        saveOverride.isf = isf
+                        saveOverride.cr = cr
+                    } else { saveOverride.isfAndCr = true }
+                    if smbIsScheduledOff {
+                        saveOverride.smbIsScheduledOff = true
+                        saveOverride.start = start as NSDecimalNumber
+                        saveOverride.end = end as NSDecimalNumber
+                    } else { smbIsScheduledOff = false }
 
             overrideStorage.storeOverridePresets([overridePresetToSave])
             presets = overrideStorage.presets()

--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
@@ -4,14 +4,12 @@ import SwiftUI
 extension PreferencesEditor {
     final class StateModel: BaseStateModel<Provider>, PreferencesSettable { private(set) var preferences = Preferences()
         @Published var unitsIndex = 1
-        @Published var allowAnnouncements = false
         @Published var insulinReqPercentage: Decimal = 70
         @Published var skipBolusScreenAfterCarbs = false
         @Published var sections: [FieldSection] = []
 
         override func subscribe() {
             preferences = provider.preferences
-            subscribeSetting(\.allowAnnouncements, on: $allowAnnouncements) { allowAnnouncements = $0 }
             subscribeSetting(\.insulinReqPercentage, on: $insulinReqPercentage) { insulinReqPercentage = $0 }
             subscribeSetting(\.skipBolusScreenAfterCarbs, on: $skipBolusScreenAfterCarbs) { skipBolusScreenAfterCarbs = $0 }
 

--- a/FreeAPS/Sources/Modules/PreferencesEditor/View/PreferencesEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/View/PreferencesEditorRootView.swift
@@ -27,9 +27,6 @@ extension PreferencesEditor {
                         Text("mg/dL").tag(0)
                         Text("mmol/L").tag(1)
                     }
-
-                    Toggle("Remote control", isOn: $state.allowAnnouncements)
-
                     HStack {
                         Text("Recommended Bolus Percentage")
                         DecimalTextField("", value: $state.insulinReqPercentage, formatter: formatter)

--- a/FreeAPS/Sources/Modules/Settings/SettingsProvider.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsProvider.swift
@@ -1,5 +1,5 @@
 extension Settings {
     final class Provider: BaseProvider, SettingsProvider {
-        @Injected() var tidePoolManager: TidePoolManager!
+        @Injected() var tidepoolManager: TidepoolManager!
     }
 }

--- a/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
@@ -14,7 +14,7 @@ extension Settings {
         @Published var debugOptions = false
         @Published var animatedBackground = false
         @Published var serviceUIType: ServiceUI.Type?
-        @Published var setupTidePool = false
+        @Published var setupTidepool = false
 
         private(set) var buildNumber = ""
         private(set) var versionNumber = ""
@@ -75,7 +75,7 @@ extension Settings.StateModel: SettingsObserver {
 extension Settings.StateModel: ServiceOnboardingDelegate {
     func serviceOnboarding(didCreateService service: Service) {
         debug(.nightscout, "Service with identifier \(service.pluginIdentifier) created")
-        provider.tidePoolManager.addTidePoolService(service: service)
+        provider.tidepoolManager.addTidepoolService(service: service)
     }
 
     func serviceOnboarding(didOnboardService service: Service) {
@@ -86,7 +86,7 @@ extension Settings.StateModel: ServiceOnboardingDelegate {
 
 extension Settings.StateModel: CompletionDelegate {
     func completionNotifyingDidComplete(_: CompletionNotifying) {
-        setupTidePool = false
-        provider.tidePoolManager.forceUploadData(device: fetchCgmManager.cgmManager?.cgmManagerStatus.device)
+        setupTidepool = false
+        provider.tidepoolManager.forceUploadData(device: fetchCgmManager.cgmManager?.cgmManagerStatus.device)
     }
 }

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -29,7 +29,7 @@ extension Settings {
                 Section {
                     Text("Nightscout").navigationLink(to: .nighscoutConfig, from: self)
 
-                    NavigationLink(destination: TidePoolStartView(state: state)) {
+                    NavigationLink(destination: TidepoolStartView(state: state)) {
                         Text("Tidepool")
                     }
                     if HKHealthStore.isHealthDataAvailable() {

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -29,10 +29,9 @@ extension Settings {
                 Section {
                     Text("Nightscout").navigationLink(to: .nighscoutConfig, from: self)
 
-                    Text("TidePool")
-                        .onTapGesture {
-                            state.setupTidePool = true
-                        }
+                    NavigationLink(destination: TidePoolStartView(state: state)) {
+                        Text("Tidepool")
+                    }
                     if HKHealthStore.isHealthDataAvailable() {
                         Text("Apple Health").navigationLink(to: .healthkit, from: self)
                     }
@@ -129,26 +128,6 @@ extension Settings {
             }
             .sheet(isPresented: $showShareSheet) {
                 ShareSheet(activityItems: state.logItems())
-            }
-            .sheet(isPresented: $state.setupTidePool) {
-                if let serviceUIType = state.serviceUIType,
-                   let pluginHost = state.provider.tidePoolManager.getTidePoolPluginHost()
-                {
-                    if let serviceUI = state.provider.tidePoolManager.getTidePoolServiceUI() {
-                        TidePoolSettingsView(
-                            serviceUI: serviceUI,
-                            serviceOnBoardDelegate: self.state,
-                            serviceDelegate: self.state
-                        )
-                    } else {
-                        TidePoolSetupView(
-                            serviceUIType: serviceUIType,
-                            pluginHost: pluginHost,
-                            serviceOnBoardDelegate: self.state,
-                            serviceDelegate: self.state
-                        )
-                    }
-                }
             }
             .onAppear(perform: configureView)
             .navigationTitle("Settings")

--- a/FreeAPS/Sources/Modules/Settings/View/TidePoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidePoolStartView.swift
@@ -7,13 +7,11 @@ struct TidePoolStartView: View {
     var body: some View {
         Form {
             Section {
-                Text("Tidepool")
+                Text("Connect to Tidepool")
                     .onTapGesture {
                         state.setupTidePool = true
                     }
 
-            } header: {
-                Text("Connect to Tidepool")
             } footer: {
                 Text(
                     "When connected, uploading of carbs, bolus, basal and glucose from Trio to your Tidepool account is enabled. \n\nUse your Tidepool credentials to login. If you dont already have a Tidepool account, you can sign up for one on the login page."

--- a/FreeAPS/Sources/Modules/Settings/View/TidePoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidePoolStartView.swift
@@ -1,0 +1,45 @@
+
+import SwiftUI
+
+struct TidePoolStartView: View {
+    @ObservedObject var state: Settings.StateModel
+
+    var body: some View {
+        Form {
+            Section {
+                Text("Tidepool")
+                    .onTapGesture {
+                        state.setupTidePool = true
+                    }
+
+            } header: {
+                Text("Connect to Tidepool")
+            } footer: {
+                Text(
+                    "When connected, uploading of carbs, bolus, basal and glucose from Trio to your Tidepool account is enabled. \n\nUse your Tidepool credentials to login. If you dont already have a Tidepool account, you can sign up for one on the login page."
+                )
+            }
+        }
+        .sheet(isPresented: $state.setupTidePool) {
+            if let serviceUIType = state.serviceUIType,
+               let pluginHost = state.provider.tidePoolManager.getTidePoolPluginHost()
+            {
+                if let serviceUI = state.provider.tidePoolManager.getTidePoolServiceUI() {
+                    TidePoolSettingsView(
+                        serviceUI: serviceUI,
+                        serviceOnBoardDelegate: self.state,
+                        serviceDelegate: self.state
+                    )
+                } else {
+                    TidePoolSetupView(
+                        serviceUIType: serviceUIType,
+                        pluginHost: pluginHost,
+                        serviceOnBoardDelegate: self.state,
+                        serviceDelegate: self.state
+                    )
+                }
+            }
+        }
+        .navigationTitle("Tidepool")
+    }
+}

--- a/FreeAPS/Sources/Modules/Settings/View/TidepoolConfigView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidepoolConfigView.swift
@@ -3,13 +3,13 @@ import LoopKit
 import LoopKitUI
 import SwiftUI
 
-struct TidePoolSetupView: UIViewControllerRepresentable {
+struct TidepoolSetupView: UIViewControllerRepresentable {
     let serviceUIType: ServiceUI.Type
     let pluginHost: PluginHost
     let serviceOnBoardDelegate: ServiceOnboardingDelegate
     let serviceDelegate: CompletionDelegate
 
-    func makeUIViewController(context _: UIViewControllerRepresentableContext<TidePoolSetupView>) -> UIViewController {
+    func makeUIViewController(context _: UIViewControllerRepresentableContext<TidepoolSetupView>) -> UIViewController {
         let result = serviceUIType.setupViewController(
             colorPalette: .default,
             pluginHost: pluginHost
@@ -26,20 +26,20 @@ struct TidePoolSetupView: UIViewControllerRepresentable {
         }
     }
 
-    func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<TidePoolSetupView>) {}
+    func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<TidepoolSetupView>) {}
 }
 
-struct TidePoolSettingsView: UIViewControllerRepresentable {
+struct TidepoolSettingsView: UIViewControllerRepresentable {
     let serviceUI: ServiceUI
     let serviceOnBoardDelegate: ServiceOnboardingDelegate
     let serviceDelegate: CompletionDelegate?
 
-    func makeUIViewController(context _: UIViewControllerRepresentableContext<TidePoolSettingsView>) -> UIViewController {
+    func makeUIViewController(context _: UIViewControllerRepresentableContext<TidepoolSettingsView>) -> UIViewController {
         var vc = serviceUI.settingsViewController(colorPalette: .default)
         vc.completionDelegate = serviceDelegate
         vc.serviceOnboardingDelegate = serviceOnBoardDelegate
         return vc
     }
 
-    func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<TidePoolSettingsView>) {}
+    func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<TidepoolSettingsView>) {}
 }

--- a/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
@@ -6,38 +6,41 @@ struct TidepoolStartView: View {
 
     var body: some View {
         Form {
-            Section {
-                Text("Connect to Tidepool")
-                    .onTapGesture {
-                        state.setupTidepool = true
-                    }
-
-            } footer: {
-                Text(
-                    "When connected, uploading of carbs, bolus, basal and glucose from Trio to your Tidepool account is enabled. \n\nUse your Tidepool credentials to login. If you dont already have a Tidepool account, you can sign up for one on the login page."
-                )
-            }
-        }
-        .sheet(isPresented: $state.setupTidepool) {
-            if let serviceUIType = state.serviceUIType,
-               let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
-            {
-                if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
-                    TidepoolSettingsView(
-                        serviceUI: serviceUI,
-                        serviceOnBoardDelegate: self.state,
-                        serviceDelegate: self.state
+            Section(
+                header: Text("Connect to Tidepool"),
+                footer: VStack(alignment: .leading, spacing: 2) {
+                    Text(
+                        "When connected, uploading of carbs, bolus, basal and glucose from Trio to your Tidepool account is enabled."
                     )
-                } else {
-                    TidepoolSetupView(
-                        serviceUIType: serviceUIType,
-                        pluginHost: pluginHost,
-                        serviceOnBoardDelegate: self.state,
-                        serviceDelegate: self.state
+                    Text(
+                        "\nUse your Tidepool credentials to login. If you dont already have a Tidepool account, you can sign up for one on the login page."
                     )
                 }
-            }
+            )
+                {
+                    Button("Connect to Tidepool") { state.setupTidepool = true }
+                }
+                .sheet(isPresented: $state.setupTidepool) {
+                    if let serviceUIType = state.serviceUIType,
+                       let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
+                    {
+                        if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
+                            TidepoolSettingsView(
+                                serviceUI: serviceUI,
+                                serviceOnBoardDelegate: self.state,
+                                serviceDelegate: self.state
+                            )
+                        } else {
+                            TidepoolSetupView(
+                                serviceUIType: serviceUIType,
+                                pluginHost: pluginHost,
+                                serviceOnBoardDelegate: self.state,
+                                serviceDelegate: self.state
+                            )
+                        }
+                    }
+                }
+                .navigationTitle("Tidepool")
         }
-        .navigationTitle("Tidepool")
     }
 }

--- a/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
@@ -1,7 +1,7 @@
 
 import SwiftUI
 
-struct TidePoolStartView: View {
+struct TidepoolStartView: View {
     @ObservedObject var state: Settings.StateModel
 
     var body: some View {
@@ -9,7 +9,7 @@ struct TidePoolStartView: View {
             Section {
                 Text("Connect to Tidepool")
                     .onTapGesture {
-                        state.setupTidePool = true
+                        state.setupTidepool = true
                     }
 
             } footer: {
@@ -18,18 +18,18 @@ struct TidePoolStartView: View {
                 )
             }
         }
-        .sheet(isPresented: $state.setupTidePool) {
+        .sheet(isPresented: $state.setupTidepool) {
             if let serviceUIType = state.serviceUIType,
-               let pluginHost = state.provider.tidePoolManager.getTidePoolPluginHost()
+               let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
             {
-                if let serviceUI = state.provider.tidePoolManager.getTidePoolServiceUI() {
-                    TidePoolSettingsView(
+                if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
+                    TidepoolSettingsView(
                         serviceUI: serviceUI,
                         serviceOnBoardDelegate: self.state,
                         serviceDelegate: self.state
                     )
                 } else {
-                    TidePoolSetupView(
+                    TidepoolSetupView(
                         serviceUIType: serviceUIType,
                         pluginHost: pluginHost,
                         serviceOnBoardDelegate: self.state,

--- a/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
@@ -20,27 +20,27 @@ struct TidepoolStartView: View {
                 {
                     Button("Connect to Tidepool") { state.setupTidepool = true }
                 }
-                .sheet(isPresented: $state.setupTidepool) {
-                    if let serviceUIType = state.serviceUIType,
-                       let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
-                    {
-                        if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
-                            TidepoolSettingsView(
-                                serviceUI: serviceUI,
-                                serviceOnBoardDelegate: self.state,
-                                serviceDelegate: self.state
-                            )
-                        } else {
-                            TidepoolSetupView(
-                                serviceUIType: serviceUIType,
-                                pluginHost: pluginHost,
-                                serviceOnBoardDelegate: self.state,
-                                serviceDelegate: self.state
-                            )
-                        }
-                    }
-                }
                 .navigationTitle("Tidepool")
+        }
+        .sheet(isPresented: $state.setupTidepool) {
+            if let serviceUIType = state.serviceUIType,
+               let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
+            {
+                if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
+                    TidepoolSettingsView(
+                        serviceUI: serviceUI,
+                        serviceOnBoardDelegate: self.state,
+                        serviceDelegate: self.state
+                    )
+                } else {
+                    TidepoolSetupView(
+                        serviceUIType: serviceUIType,
+                        pluginHost: pluginHost,
+                        serviceOnBoardDelegate: self.state,
+                        serviceDelegate: self.state
+                    )
+                }
+            }
         }
     }
 }

--- a/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
@@ -243,6 +243,49 @@ extension NightscoutAPI {
             .eraseToAnyPublisher()
     }
 
+    /// fetch the overrides available in NS as a exercice since the date specified in the parameter
+    /// Limit to exercice with the attribute enteredBy = the name of local app (as defined in NightscoutExercice
+    /// - Parameter sinceDate: the oldest date to fetch exercices
+    /// - Returns: A publisher with a array of NightscoutExercice or error
+    func fetchOverrides(sinceDate: Date? = nil) -> AnyPublisher<[NightscoutExercice], Swift.Error> {
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.port = url.port
+        components.path = Config.treatmentsPath
+        components.queryItems = [
+            URLQueryItem(name: "find[eventType]", value: "Exercice"),
+            URLQueryItem(
+                name: "find[enteredBy]",
+                value: NightscoutExercice.local.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
+            )
+        ]
+        if let date = sinceDate {
+            let dateItem = URLQueryItem(
+                name: "find[created_at][$gt]",
+                value: Formatter.iso8601withFractionalSeconds.string(from: date)
+            )
+            components.queryItems?.append(dateItem)
+        }
+
+        var request = URLRequest(url: components.url!)
+        request.allowsConstrainedNetworkAccess = false
+        request.timeoutInterval = Config.timeout
+
+        if let secret = secret {
+            request.addValue(secret.sha1(), forHTTPHeaderField: "api-secret")
+        }
+
+        return service.run(request)
+            .retry(Config.retryCount)
+            .decode(type: [NightscoutExercice].self, decoder: JSONCoding.decoder)
+            .catch { error -> AnyPublisher<[NightscoutExercice], Swift.Error> in
+                warning(.nightscout, "Override fetching error: \(error.localizedDescription)")
+                return Just([]).setFailureType(to: Swift.Error.self).eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+
     func fetchAnnouncement(sinceDate: Date? = nil) -> AnyPublisher<[Announcement], Swift.Error> {
         var components = URLComponents()
         components.scheme = url.scheme
@@ -415,6 +458,65 @@ extension NightscoutAPI {
         }
         request.httpBody = try! JSONCoding.encoder.encode(profile)
         request.httpMethod = "POST"
+
+        return service.run(request)
+            .retry(Config.retryCount)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
+    /// Upload old, new and updated overrides in NS as a exercice.
+    /// - Parameter overrides: a array of NightscoutExercice to upload
+    /// - Returns: A publisher with only error response.
+    func uploadOverrides(_ overrides: [NightscoutExercice]) -> AnyPublisher<Void, Swift.Error> {
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.port = url.port
+        components.path = Config.treatmentsPath
+
+        var request = URLRequest(url: components.url!)
+        request.allowsConstrainedNetworkAccess = false
+        request.timeoutInterval = Config.timeout
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let secret = secret {
+            request.addValue(secret.sha1(), forHTTPHeaderField: "api-secret")
+        }
+        request.httpBody = try! JSONCoding.encoder.encode(overrides)
+        request.httpMethod = "POST"
+
+        return service.run(request)
+            .retry(Config.retryCount)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
+    /// delete a override in NS as exercice for a specific date
+    /// - Parameter date: the date of the override to delete
+    /// - Returns: A publisher with only error response.
+    func deleteOverride(at date: Date) -> AnyPublisher<Void, Swift.Error> {
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.port = url.port
+        components.path = Config.treatmentsPath
+        components.queryItems = [
+            URLQueryItem(name: "find[eventType]", value: "Exercice"),
+            URLQueryItem(
+                name: "find[created_at][$eq]",
+                value: Formatter.iso8601withFractionalSeconds.string(from: date)
+            )
+        ]
+
+        var request = URLRequest(url: components.url!)
+        request.allowsConstrainedNetworkAccess = false
+        request.timeoutInterval = Config.timeout
+        request.httpMethod = "DELETE"
+
+        if let secret = secret {
+            request.addValue(secret.sha1(), forHTTPHeaderField: "api-secret")
+        }
 
         return service.run(request)
             .retry(Config.retryCount)

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -650,14 +650,13 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
     }
 
     /// Upload all new and updated override as a exercice in NS
-    private func uploadOverride() {
-        let overrides = overrideStorage.recent()
-        guard !overrides.isEmpty, let nightscout = nightscoutAPI, isUploadEnabled else {
+    private func uploadOverride(_ targets: [OverrideProfil?]) {
+        guard !targets.isEmpty, let nightscout = nightscoutAPI, isUploadEnabled else {
             return
         }
 
         processQueue.async {
-            let exercices = overrides.compactMap { override -> NightscoutExercice? in
+            let exercices = targets.compactMap { override -> NightscoutExercice? in
                 if let override = override {
                     return NightscoutExercice(
                         duration: override
@@ -718,7 +717,7 @@ extension BaseNightscoutManager: TempTargetsObserver {
 }
 
 extension BaseNightscoutManager: OverrideObserver {
-    func overrideDidUpdate(_: [OverrideProfil?]) {
-        uploadOverride()
+    func overrideDidUpdate(_ targets: [OverrideProfil?], current _: OverrideProfil?) {
+        uploadOverride(targets)
     }
 }

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -46,6 +46,10 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
         settingsManager.settings.isUploadEnabled
     }
 
+    private var isDownloadEnabled: Bool {
+        settingsManager.settings.isDownloadEnabled
+    }
+
     private var isUploadGlucoseEnabled: Bool {
         settingsManager.settings.uploadGlucose
     }
@@ -143,7 +147,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
     }
 
     func fetchCarbs() -> AnyPublisher<[CarbsEntry], Never> {
-        guard let nightscout = nightscoutAPI, isNetworkReachable else {
+        guard let nightscout = nightscoutAPI, isNetworkReachable, isDownloadEnabled else {
             return Just([]).eraseToAnyPublisher()
         }
 
@@ -154,7 +158,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
     }
 
     func fetchTempTargets() -> AnyPublisher<[TempTarget], Never> {
-        guard let nightscout = nightscoutAPI, isNetworkReachable else {
+        guard let nightscout = nightscoutAPI, isNetworkReachable, isDownloadEnabled else {
             return Just([]).eraseToAnyPublisher()
         }
 
@@ -179,7 +183,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
     }
 
     func fetchAnnouncements() -> AnyPublisher<[Announcement], Never> {
-        guard let nightscout = nightscoutAPI, isNetworkReachable else {
+        guard let nightscout = nightscoutAPI, isNetworkReachable, isDownloadEnabled else {
             return Just([]).eraseToAnyPublisher()
         }
 

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -15,6 +15,7 @@ protocol NightscoutManager: GlucoseSource {
     func uploadGlucose()
     func uploadPreferences(_ preferences: Preferences)
     func uploadProfileAndSettings(_: Bool)
+
     var cgmURL: URL? { get }
 }
 
@@ -30,6 +31,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
     @Injected() private var broadcaster: Broadcaster!
     @Injected() private var reachabilityManager: ReachabilityManager!
     @Injected() var healthkitManager: HealthKitManager!
+    @Injected() private var overrideStorage: OverrideStorage!
 
     private let processQueue = DispatchQueue(label: "BaseNetworkManager.processQueue")
     private var ping: TimeInterval?
@@ -67,6 +69,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
         broadcaster.register(PumpHistoryObserver.self, observer: self)
         broadcaster.register(CarbsObserver.self, observer: self)
         broadcaster.register(TempTargetsObserver.self, observer: self)
+        broadcaster.register(OverrideObserver.self, observer: self)
         _ = reachabilityManager.startListening(onQueue: processQueue) { status in
             debug(.nightscout, "Network status: \(status)")
         }
@@ -157,6 +160,20 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
 
         let since = tempTargetsStorage.syncDate()
         return nightscout.fetchTempTargets(sinceDate: since)
+            .replaceError(with: [])
+            .eraseToAnyPublisher()
+    }
+
+    /// Fetch all overrides available in NS as a exercice
+    /// Limit to exercice with the attribute enteredBy = the name of local app (as defined in NightscoutExercice
+    /// - Returns: a publisher of a array of NightscoutExercice.
+    func fetchOverride() -> AnyPublisher<[NightscoutExercice], Never> {
+        guard let nightscout = nightscoutAPI, isNetworkReachable else {
+            return Just([]).eraseToAnyPublisher()
+        }
+
+        let since = overrideStorage.syncDate()
+        return nightscout.fetchOverrides(sinceDate: since)
             .replaceError(with: [])
             .eraseToAnyPublisher()
     }
@@ -627,6 +644,55 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
                 .store(in: &self.lifetime)
         }
     }
+
+    /// Upload all new and updated override as a exercice in NS
+    private func uploadOverride() {
+        let overrides = overrideStorage.recent()
+        guard !overrides.isEmpty, let nightscout = nightscoutAPI, isUploadEnabled else {
+            return
+        }
+
+        processQueue.async {
+            let exercices = overrides.compactMap { override -> NightscoutExercice? in
+                if let override = override {
+                    return NightscoutExercice(
+                        duration: override
+                            .indefinite! ?
+                            Int(Date().timeIntervalSinceReferenceDate - override.createdAt!.timeIntervalSinceReferenceDate + 60) :
+                            Int(override.duration ?? 0),
+                        // by default if indefinite = + 60 minutes
+                        eventType: EventType.nsExercice,
+                        createdAt: override.createdAt,
+                        enteredBy: NightscoutExercice.local,
+                        notes: override.displayName
+                    )
+                } else {
+                    return nil
+                }
+            }
+
+            exercices.chunks(ofCount: 100)
+                .map { chunk -> AnyPublisher<Void, Error> in
+                    nightscout.uploadOverrides(Array(chunk))
+                }
+                .reduce(
+                    Just(()).setFailureType(to: Error.self)
+                        .eraseToAnyPublisher()
+                ) { (result, next) -> AnyPublisher<Void, Error> in
+                    Publishers.Concatenate(prefix: result, suffix: next).eraseToAnyPublisher()
+                }
+                .dropFirst()
+                .sink { completion in
+                    switch completion {
+                    case .finished:
+                        debug(.nightscout, "Overrides uploaded")
+                    case let .failure(error):
+                        debug(.nightscout, error.localizedDescription)
+                    }
+                } receiveValue: {}
+                .store(in: &self.lifetime)
+        }
+    }
 }
 
 extension BaseNightscoutManager: PumpHistoryObserver {
@@ -644,5 +710,11 @@ extension BaseNightscoutManager: CarbsObserver {
 extension BaseNightscoutManager: TempTargetsObserver {
     func tempTargetsDidUpdate(_: [TempTarget]) {
         uploadTempTargets()
+    }
+}
+
+extension BaseNightscoutManager: OverrideObserver {
+    func overrideDidUpdate(_: [OverrideProfil?]) {
+        uploadOverride()
     }
 }

--- a/FreeAPS/Sources/Services/Network/TidepoolManager.swift
+++ b/FreeAPS/Sources/Services/Network/TidepoolManager.swift
@@ -54,7 +54,7 @@ final class BaseTidepoolManager: TidepoolManager, Injectable {
         }
     }
 
-    /// allows to acces to tidepoolService as a simple ServiceUI
+    /// allows access to tidepoolService as a simple ServiceUI
     func getTidepoolServiceUI() -> ServiceUI? {
         if let tidepoolService = self.tidepoolService {
             return tidepoolService as! any ServiceUI as ServiceUI

--- a/FreeAPS/Sources/Services/Network/TidepoolManager.swift
+++ b/FreeAPS/Sources/Services/Network/TidepoolManager.swift
@@ -5,10 +5,10 @@ import LoopKit
 import LoopKitUI
 import Swinject
 
-protocol TidePoolManager {
-    func addTidePoolService(service: Service)
-    func getTidePoolServiceUI() -> ServiceUI?
-    func getTidePoolPluginHost() -> PluginHost?
+protocol TidepoolManager {
+    func addTidepoolService(service: Service)
+    func getTidepoolServiceUI() -> ServiceUI?
+    func getTidepoolPluginHost() -> PluginHost?
     func deleteCarbs(at date: Date, isFPU: Bool?, fpuID: String?, syncID: String)
     func deleteInsulin(at date: Date)
 //    func uploadStatus()
@@ -18,7 +18,7 @@ protocol TidePoolManager {
 //    func uploadProfileAndSettings(_: Bool)
 }
 
-final class BaseTidePoolManager: TidePoolManager, Injectable {
+final class BaseTidepoolManager: TidepoolManager, Injectable {
     @Injected() private var broadcaster: Broadcaster!
     @Injected() private var pluginManager: PluginManager!
     @Injected() private var glucoseStorage: GlucoseStorage!
@@ -27,53 +27,53 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     @Injected() private var pumpHistoryStorage: PumpHistoryStorage!
 
     private let processQueue = DispatchQueue(label: "BaseNetworkManager.processQueue")
-    private var tidePoolService: RemoteDataService? {
+    private var tidepoolService: RemoteDataService? {
         didSet {
-            if let tidePoolService = tidePoolService {
-                rawTidePoolManager = tidePoolService.rawValue
+            if let tidepoolService = tidepoolService {
+                rawTidepoolManager = tidepoolService.rawValue
             } else {
-                rawTidePoolManager = nil
+                rawTidepoolManager = nil
             }
         }
     }
 
-    @PersistedProperty(key: "TidePoolState") var rawTidePoolManager: Service.RawValue?
+    @PersistedProperty(key: "TidepoolState") var rawTidepoolManager: Service.RawValue?
 
     init(resolver: Resolver) {
         injectServices(resolver)
-        loadTidePoolManager()
+        loadTidepoolManager()
         subscribe()
     }
 
-    /// load the TidePool Remote Data Service if available
-    fileprivate func loadTidePoolManager() {
-        if let rawTidePoolManager = rawTidePoolManager {
-            tidePoolService = tidePoolServiceFromRaw(rawTidePoolManager)
-            tidePoolService?.serviceDelegate = self
-            tidePoolService?.stateDelegate = self
+    /// load the Tidepool Remote Data Service if available
+    fileprivate func loadTidepoolManager() {
+        if let rawTidepoolManager = rawTidepoolManager {
+            tidepoolService = tidepoolServiceFromRaw(rawTidepoolManager)
+            tidepoolService?.serviceDelegate = self
+            tidepoolService?.stateDelegate = self
         }
     }
 
-    /// allows to acces to tidePoolService as a simple ServiceUI
-    func getTidePoolServiceUI() -> ServiceUI? {
-        if let tidePoolService = self.tidePoolService {
-            return tidePoolService as! any ServiceUI as ServiceUI
+    /// allows to acces to tidepoolService as a simple ServiceUI
+    func getTidepoolServiceUI() -> ServiceUI? {
+        if let tidepoolService = self.tidepoolService {
+            return tidepoolService as! any ServiceUI as ServiceUI
         } else {
             return nil
         }
     }
 
-    /// get the pluginHost of TidePool
-    func getTidePoolPluginHost() -> PluginHost? {
+    /// get the pluginHost of Tidepool
+    func getTidepoolPluginHost() -> PluginHost? {
         self as PluginHost
     }
 
-    func addTidePoolService(service: Service) {
-        tidePoolService = service as! any RemoteDataService as RemoteDataService
+    func addTidepoolService(service: Service) {
+        tidepoolService = service as! any RemoteDataService as RemoteDataService
     }
 
-    /// load the TidePool Remote Data Service from raw storage
-    private func tidePoolServiceFromRaw(_ rawValue: [String: Any]) -> RemoteDataService? {
+    /// load the Tidepool Remote Data Service from raw storage
+    private func tidepoolServiceFromRaw(_ rawValue: [String: Any]) -> RemoteDataService? {
         guard let rawState = rawValue["state"] as? Service.RawStateValue,
               let serviceType = pluginManager.getServiceTypeByIdentifier("TidepoolService")
         else {
@@ -97,15 +97,15 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     func uploadCarbs() {
         let carbs: [CarbsEntry] = carbsStorage.recent()
 
-        guard !carbs.isEmpty, let tidePoolService = self.tidePoolService else { return }
+        guard !carbs.isEmpty, let tidepoolService = self.tidepoolService else { return }
 
         processQueue.async {
-            carbs.chunks(ofCount: tidePoolService.carbDataLimit ?? 100).forEach { chunk in
+            carbs.chunks(ofCount: tidepoolService.carbDataLimit ?? 100).forEach { chunk in
 
                 let syncCarb: [SyncCarbObject] = Array(chunk).map {
                     $0.convertSyncCarb()
                 }
-                tidePoolService.uploadCarbData(created: syncCarb, updated: [], deleted: []) { result in
+                tidepoolService.uploadCarbData(created: syncCarb, updated: [], deleted: []) { result in
                     switch result {
                     case let .failure(error):
                         debug(.nightscout, "Error synchronizing carbs data: \(String(describing: error))")
@@ -118,7 +118,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     }
 
     func deleteCarbs(at date: Date, isFPU: Bool?, fpuID: String?, syncID _: String) {
-        guard let tidePoolService = self.tidePoolService else { return }
+        guard let tidepoolService = self.tidepoolService else { return }
 
         processQueue.async {
             var carbsToDelete: [CarbsEntry] = []
@@ -135,7 +135,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
                 d.convertSyncCarb(operation: .delete)
             }
 
-            tidePoolService.uploadCarbData(created: [], updated: [], deleted: syncCarb) { result in
+            tidepoolService.uploadCarbData(created: [], updated: [], deleted: syncCarb) { result in
                 switch result {
                 case let .failure(error):
                     debug(.nightscout, "Error synchronizing carbs data: \(String(describing: error))")
@@ -149,7 +149,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     func deleteInsulin(at d: Date) {
         let allValues = storage.retrieve(OpenAPS.Monitor.pumpHistory, as: [PumpHistoryEvent].self) ?? []
 
-        guard !allValues.isEmpty, let tidePoolService = self.tidePoolService else { return }
+        guard !allValues.isEmpty, let tidepoolService = self.tidepoolService else { return }
 
         var doseDataToDelete: [DoseEntry] = []
 
@@ -166,7 +166,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
             ))
 
         processQueue.async {
-            tidePoolService.uploadDoseData(created: [], deleted: doseDataToDelete) { result in
+            tidepoolService.uploadDoseData(created: [], deleted: doseDataToDelete) { result in
                 switch result {
                 case let .failure(error):
                     debug(.nightscout, "Error synchronizing Dose delete data: \(String(describing: error))")
@@ -179,7 +179,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
 
     func uploadDose() {
         let events = pumpHistoryStorage.recent()
-        guard !events.isEmpty, let tidePoolService = self.tidePoolService else { return }
+        guard !events.isEmpty, let tidepoolService = self.tidepoolService else { return }
 
         let eventsBasal = events.filter { $0.type == .tempBasal || $0.type == .tempBasalDuration }
             .sorted { $0.timestamp < $1.timestamp }
@@ -297,7 +297,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
         }
 
         processQueue.async {
-            tidePoolService.uploadDoseData(created: doseDataBasal + boluses, deleted: []) { result in
+            tidepoolService.uploadDoseData(created: doseDataBasal + boluses, deleted: []) { result in
                 switch result {
                 case let .failure(error):
                     debug(.nightscout, "Error synchronizing Dose data: \(String(describing: error))")
@@ -306,7 +306,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
                 }
             }
 
-            tidePoolService.uploadPumpEventData(pumpEvents) { result in
+            tidepoolService.uploadPumpEventData(pumpEvents) { result in
                 switch result {
                 case let .failure(error):
                     debug(.nightscout, "Error synchronizing Pump Event data: \(String(describing: error))")
@@ -320,19 +320,19 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     func uploadGlucose(device: HKDevice?) {
         let glucose: [BloodGlucose] = glucoseStorage.recent()
 
-        guard !glucose.isEmpty, let tidePoolService = self.tidePoolService else { return }
+        guard !glucose.isEmpty, let tidepoolService = self.tidepoolService else { return }
 
         let glucoseWithoutCorrectID = glucose.filter { UUID(uuidString: $0._id) != nil }
 
         processQueue.async {
-            glucoseWithoutCorrectID.chunks(ofCount: tidePoolService.glucoseDataLimit ?? 100)
+            glucoseWithoutCorrectID.chunks(ofCount: tidepoolService.glucoseDataLimit ?? 100)
                 .forEach { chunk in
                     // all glucose attached with the current device ;-(
 
                     let chunkStoreGlucose = Array(chunk).map {
                         $0.convertStoredGlucoseSample(device: device)
                     }
-                    tidePoolService.uploadGlucoseData(chunkStoreGlucose) { result in
+                    tidepoolService.uploadGlucoseData(chunkStoreGlucose) { result in
                         switch result {
                         case let .failure(error):
                             debug(.nightscout, "Error synchronizing glucose data: \(String(describing: error))")
@@ -345,7 +345,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
         }
     }
 
-    /// force to uploads all data in TidePool Service
+    /// force to uploads all data in Tidepool Service
     func forceUploadData(device: HKDevice?) {
         uploadDose()
         uploadCarbs()
@@ -353,23 +353,23 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     }
 }
 
-extension BaseTidePoolManager: PumpHistoryObserver {
+extension BaseTidepoolManager: PumpHistoryObserver {
     func pumpHistoryDidUpdate(_: [PumpHistoryEvent]) {
         uploadDose()
     }
 }
 
-extension BaseTidePoolManager: CarbsObserver {
+extension BaseTidepoolManager: CarbsObserver {
     func carbsDidUpdate(_: [CarbsEntry]) {
         uploadCarbs()
     }
 }
 
-extension BaseTidePoolManager: TempTargetsObserver {
+extension BaseTidepoolManager: TempTargetsObserver {
     func tempTargetsDidUpdate(_: [TempTarget]) {}
 }
 
-extension BaseTidePoolManager: ServiceDelegate {
+extension BaseTidepoolManager: ServiceDelegate {
     var hostIdentifier: String {
         "com.loopkit.Loop" // To check
     }
@@ -404,11 +404,11 @@ extension BaseTidePoolManager: ServiceDelegate {
     func deliverRemoteBolus(amountInUnits _: Double) async throws {}
 }
 
-extension BaseTidePoolManager: StatefulPluggableDelegate {
+extension BaseTidepoolManager: StatefulPluggableDelegate {
     func pluginDidUpdateState(_: LoopKit.StatefulPluggable) {}
 
     func pluginWantsDeletion(_: LoopKit.StatefulPluggable) {
-        tidePoolService = nil
+        tidepoolService = nil
     }
 }
 

--- a/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
+++ b/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
@@ -5,6 +5,13 @@ import WatchConnectivity
 
 protocol WatchManager {}
 
+enum TypeUpdate {
+    case BGandISF
+    case tempTarget
+    case override
+    case all
+}
+
 final class BaseWatchManager: NSObject, WatchManager, Injectable {
     private let session: WCSession
     private var state = WatchState()
@@ -54,137 +61,157 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
             return data
         }
 
-        configureState()
+        updateState(.all)
     }
 
-    private func configureState() {
+    private func updateState(_ typeUpdate: TypeUpdate, _ currentOverride: OverrideProfil? = nil) {
         processQueue.async {
-            let glucoseValues = self.glucoseText()
-            self.state.glucose = glucoseValues.glucose
-            self.state.trend = glucoseValues.trend
-            self.state.delta = glucoseValues.delta
-            self.state.trendRaw = self.glucoseStorage.recent().last?.direction?.rawValue
-            self.state.glucoseDate = self.glucoseStorage.recent().last?.dateString
-            self.state.glucoseDateInterval = self.state.glucoseDate.map { UInt64($0.timeIntervalSince1970) }
-            self.state.lastLoopDate = self.enactedSuggestion?.recieved == true ? self.enactedSuggestion?.deliverAt : self
-                .apsManager.lastLoopDate
-            self.state.lastLoopDateInterval = self.state.lastLoopDate.map {
-                guard $0.timeIntervalSince1970 > 0 else { return 0 }
-                return UInt64($0.timeIntervalSince1970)
+            switch typeUpdate {
+            case .BGandISF:
+                self.updateBGandISF()
+            case .override:
+                self.state.tempTargets = self.updateOverride(currentOverride)
+            case .tempTarget:
+                self.state.tempTargets = self.updateTempTarget()
+            case .all:
+                self.updateBGandISF()
+                self.state.tempTargets = self.updateOverride(currentOverride) + self.updateTempTarget()
             }
-            self.state.bolusIncrement = self.settingsManager.preferences.bolusIncrement
-            self.state.maxCOB = self.settingsManager.preferences.maxCOB
-            self.state.maxBolus = self.settingsManager.pumpSettings.maxBolus
-            self.state.carbsRequired = self.suggestion?.carbsReq
-
-            var insulinRequired = self.suggestion?.insulinReq ?? 0
-            var double: Decimal = 2
-            if (self.suggestion?.cob ?? 0) > 0 {
-                if self.suggestion?.manualBolusErrorString == 0 {
-                    insulinRequired = self.suggestion?.insulinForManualBolus ?? 0
-                    double = 1
-                }
-            }
-
-            self.state.bolusRecommended = self.apsManager
-                .roundBolus(amount: max(insulinRequired * (self.settingsManager.settings.insulinReqPercentage / 100) * double, 0))
-
-            self.state.iob = self.suggestion?.iob
-            self.state.cob = self.suggestion?.cob
-            self.state.bolusAfterCarbs = !self.settingsManager.settings.skipBolusScreenAfterCarbs
-            self.state.displayOnWatch = self.settingsManager.settings.displayOnWatch
-            self.state.displayFatAndProteinOnWatch = self.settingsManager.settings.displayFatAndProteinOnWatch
-            let eBG = self.evetualBGStraing()
-            self.state.eventualBG = eBG.map { "⇢ " + $0 }
-            self.state.eventualBGRaw = eBG
-
-            self.state.isf = self.suggestion?.isf
-
-            // add temp preset
-            var presetTempTargetSelected: Bool = false
-            var tempTargetPresetArray = self.tempTargetsStorage.presets()
-                .map { target -> TempTargetWatchPreset in
-                    let untilDate = self.tempTargetsStorage.current().flatMap { currentTarget -> Date? in
-                        guard currentTarget.id == target.id else { return nil }
-                        let date = currentTarget.createdAt.addingTimeInterval(TimeInterval(currentTarget.duration * 60))
-                        return date > Date() ? date : nil
-                    }
-                    if untilDate != nil { presetTempTargetSelected = true }
-                    return TempTargetWatchPreset(
-                        name: target.displayName,
-                        id: target.id,
-                        description: self.descriptionForTarget(target),
-                        until: untilDate,
-                        typeTempTarget: .tempTarget
-                    )
-                }
-
-            // add a specific temp target  in progress if this temp target is not a preset
-            if let current = self.tempTargetsStorage.current(), !presetTempTargetSelected {
-                tempTargetPresetArray.append(
-                    TempTargetWatchPreset(
-                        name: "Custom",
-                        id: current.id,
-                        description: self.descriptionForTarget(current),
-                        until: current.createdAt.addingTimeInterval(TimeInterval(Double(current.duration) * 60)),
-                        typeTempTarget: .tempTarget
-                    )
-                )
-            }
-
-            // add override in the temp target list
-            let current = self.overrideStorage.current()
-            if current != nil {
-                let percentString = "\((current?.percentage ?? 100).formatted(.number)) %"
-                self.state.override = percentString
-
-            } else {
-                self.state.override = "100 %"
-            }
-
-            var presetOverrideSelected: Bool = false
-            var overridePresetArray: [TempTargetWatchPreset] = self.overrideStorage.presets().compactMap { target in
-                var untilDate: Date?
-
-                if let date = current?.createdAt, current?.name == target.name
-                {
-                    // duration = 0 -> unlimited duration = 1 year
-                    let duration = target.duration ?? (24 * 60 * 365)
-                    untilDate = date.addingTimeInterval(TimeInterval(duration * 60))
-                    presetOverrideSelected = true
-                } else {
-                    untilDate = nil
-                }
-
-                return TempTargetWatchPreset(
-                    name: target.name ?? "",
-                    id: target.id,
-                    description: "Profil : \(target.percentage ?? 100) %",
-                    until: untilDate,
-                    typeTempTarget: .override
-                )
-            }
-
-            // add a specific override profil in progress if this override is not a preset
-            if let current = current, !presetOverrideSelected {
-                let duration = current.duration ?? (24 * 60 * 365)
-                let date = current.createdAt
-                let untilDate = date?.addingTimeInterval(TimeInterval(duration * 60))
-                overridePresetArray.append(
-                    TempTargetWatchPreset(
-                        name: "Custom",
-                        id: current.id,
-                        description: "Profil : \(current.percentage ?? 100) %",
-                        until: untilDate,
-                        typeTempTarget: .override
-                    )
-                )
-            }
-
-            self.state.tempTargets = tempTargetPresetArray + overridePresetArray
 
             self.sendState()
         }
+    }
+
+    private func updateBGandISF() {
+        let glucoseValues = glucoseText()
+        state.glucose = glucoseValues.glucose
+        state.trend = glucoseValues.trend
+        state.delta = glucoseValues.delta
+        state.trendRaw = glucoseStorage.recent().last?.direction?.rawValue
+        state.glucoseDate = glucoseStorage.recent().last?.dateString
+        state.glucoseDateInterval = state.glucoseDate.map { UInt64($0.timeIntervalSince1970) }
+        state.lastLoopDate = enactedSuggestion?.recieved == true ? enactedSuggestion?.deliverAt : apsManager.lastLoopDate
+        state.lastLoopDateInterval = state.lastLoopDate.map {
+            guard $0.timeIntervalSince1970 > 0 else { return 0 }
+            return UInt64($0.timeIntervalSince1970)
+        }
+        state.bolusIncrement = settingsManager.preferences.bolusIncrement
+        state.maxCOB = settingsManager.preferences.maxCOB
+        state.maxBolus = settingsManager.pumpSettings.maxBolus
+        state.carbsRequired = suggestion?.carbsReq
+
+        var insulinRequired = suggestion?.insulinReq ?? 0
+        var double: Decimal = 2
+        if (suggestion?.cob ?? 0) > 0 {
+            if suggestion?.manualBolusErrorString == 0 {
+                insulinRequired = suggestion?.insulinForManualBolus ?? 0
+                double = 1
+            }
+        }
+
+        state.bolusRecommended = apsManager
+            .roundBolus(amount: max(insulinRequired * (settingsManager.settings.insulinReqPercentage / 100) * double, 0))
+
+        state.iob = suggestion?.iob
+        state.cob = suggestion?.cob
+        state.bolusAfterCarbs = !settingsManager.settings.skipBolusScreenAfterCarbs
+        state.displayOnWatch = settingsManager.settings.displayOnWatch
+        state.displayFatAndProteinOnWatch = settingsManager.settings.displayFatAndProteinOnWatch
+        let eBG = evetualBGStraing()
+        state.eventualBG = eBG.map { "⇢ " + $0 }
+        state.eventualBGRaw = eBG
+
+        state.isf = suggestion?.isf
+    }
+
+    private func updateTempTarget() -> [TempTargetWatchPreset] {
+        // add temp preset
+        var presetTempTargetSelected: Bool = false
+        var tempTargetPresetArray: [TempTargetWatchPreset] = []
+        tempTargetPresetArray = tempTargetsStorage.presets()
+            .map { target -> TempTargetWatchPreset in
+                let untilDate = self.tempTargetsStorage.current().flatMap { currentTarget -> Date? in
+                    guard currentTarget.id == target.id else { return nil }
+                    let date = currentTarget.createdAt.addingTimeInterval(TimeInterval(currentTarget.duration * 60))
+                    return date > Date() ? date : nil
+                }
+                if untilDate != nil { presetTempTargetSelected = true }
+                return TempTargetWatchPreset(
+                    name: target.displayName,
+                    id: target.id,
+                    description: self.descriptionForTarget(target),
+                    until: untilDate,
+                    typeTempTarget: .tempTarget
+                )
+            }
+
+        // add a specific temp target  in progress if this temp target is not a preset
+        if let current = tempTargetsStorage.current(), !presetTempTargetSelected {
+            tempTargetPresetArray.append(
+                TempTargetWatchPreset(
+                    name: "Custom",
+                    id: current.id,
+                    description: descriptionForTarget(current),
+                    until: current.createdAt.addingTimeInterval(TimeInterval(Double(current.duration) * 60)),
+                    typeTempTarget: .tempTarget
+                )
+            )
+        }
+
+        return tempTargetPresetArray
+    }
+
+    private func updateOverride(_ currentOverride: OverrideProfil?) -> [TempTargetWatchPreset] {
+        // add override in the temp target list
+        let current = currentOverride ?? overrideStorage.current()
+        if current != nil {
+            let percentString = "\((current?.percentage ?? 100).formatted(.number)) %"
+            state.override = percentString
+
+        } else {
+            state.override = "100 %"
+        }
+
+        var presetOverrideSelected: Bool = false
+        var overridePresetArray: [TempTargetWatchPreset] = []
+        overridePresetArray = overrideStorage.presets().compactMap { target in
+            var untilDate: Date?
+
+            if let date = current?.createdAt, current?.name == target.name
+            {
+                // duration = 0 -> unlimited duration = 1 year
+                let duration = target.duration ?? (24 * 60 * 365)
+                untilDate = date.addingTimeInterval(TimeInterval(duration * 60))
+                presetOverrideSelected = true
+            } else {
+                untilDate = nil
+            }
+
+            return TempTargetWatchPreset(
+                name: target.name ?? "",
+                id: target.id,
+                description: "Profil : \(target.percentage ?? 100) %",
+                until: untilDate,
+                typeTempTarget: .override
+            )
+        }
+
+        // add a specific override profil in progress if this override is not a preset
+        if let current = current, !presetOverrideSelected {
+            let duration = current.duration ?? (24 * 60 * 365)
+            let date = current.createdAt
+            let untilDate = date?.addingTimeInterval(TimeInterval(duration * 60))
+            overridePresetArray.append(
+                TempTargetWatchPreset(
+                    name: "Custom",
+                    id: current.id,
+                    description: "Profil : \(current.percentage ?? 100) %",
+                    until: untilDate,
+                    typeTempTarget: .override
+                )
+            )
+        }
+        return overridePresetArray
     }
 
     private func sendState() {
@@ -416,20 +443,20 @@ extension BaseWatchManager:
     PumpReservoirObserver,
     OverrideObserver
 {
-    func overrideDidUpdate(_: [OverrideProfil?]) {
-        configureState()
+    func overrideDidUpdate(_: [OverrideProfil?], current: OverrideProfil?) {
+        updateState(.override, current)
     }
 
     func glucoseDidUpdate(_: [BloodGlucose]) {
-        configureState()
+        updateState(.BGandISF)
     }
 
     func suggestionDidUpdate(_: Suggestion) {
-        configureState()
+        updateState(.BGandISF)
     }
 
     func settingsDidChange(_: FreeAPSSettings) {
-        configureState()
+        updateState(.BGandISF)
     }
 
     func pumpHistoryDidUpdate(_: [PumpHistoryEvent]) {
@@ -437,7 +464,7 @@ extension BaseWatchManager:
     }
 
     func pumpSettingsDidChange(_: PumpSettings) {
-        configureState()
+        updateState(.BGandISF)
     }
 
     func basalProfileDidChange(_: [BasalProfileEntry]) {
@@ -445,15 +472,16 @@ extension BaseWatchManager:
     }
 
     func tempTargetsDidUpdate(_: [TempTarget]) {
-        configureState()
+        updateState(.tempTarget)
     }
 
     func carbsDidUpdate(_: [CarbsEntry]) {
         // TODO:
+        updateState(.BGandISF)
     }
 
     func enactedSuggestionDidUpdate(_: Suggestion) {
-        configureState()
+        updateState(.BGandISF)
     }
 
     func pumpBatteryDidChange(_: Battery) {

--- a/FreeAPSTests/CalibrationsTests.swift
+++ b/FreeAPSTests/CalibrationsTests.swift
@@ -30,16 +30,24 @@ class CalibrationsTests: XCTestCase, Injectable {
 
         let calibration2 = Calibration(x: 120.0, y: 130.0)
         calibrationService.addCalibration(calibration2)
+        // The original 4 XCTAsserts() below fail on the initial run,
+        //    but will work on subsequent runs.
+        // Should fix this stuff to not be stateful so that the
+        //    same results are obtained on each run.
+        // Temporary fix comment out original and use XCTAssertEqual
+        //    which allows an accuracy parameter
+        // XCTAssertTrue(calibrationService.slope == 0.8)
+        // XCTAssertTrue(calibrationService.intercept == 37)
+        // XCTAssertTrue(calibrationService.calibrate(value: 80) == 101)
 
-        XCTAssertTrue(calibrationService.slope == 0.8)
-
-        XCTAssertTrue(calibrationService.intercept == 37)
-
-        XCTAssertTrue(calibrationService.calibrate(value: 80) == 101)
+        XCTAssertEqual(calibrationService.slope, 0.95, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.intercept, 16, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.calibrate(value: 80), 92, accuracy: 0.0001)
 
         calibrationService.removeLast()
 
-        XCTAssertTrue(calibrationService.calibrations.count == 1)
+        // XCTAssertTrue(calibrationService.calibrations.count == 1)
+        XCTAssertEqual(calibrationService.calibrations.count, 2)
 
         calibrationService.removeAllCalibrations()
         XCTAssertTrue(calibrationService.calibrations.isEmpty)

--- a/FreeAPSTests/CalibrationsTests.swift
+++ b/FreeAPSTests/CalibrationsTests.swift
@@ -12,6 +12,9 @@ class CalibrationsTests: XCTestCase, Injectable {
     }
 
     func testCreateSimpleCalibration() {
+        // restore state so each test is independent
+        calibrationService.removeAllCalibrations()
+
         let calibration = Calibration(x: 100.0, y: 102.0)
         calibrationService.addCalibration(calibration)
 
@@ -25,29 +28,22 @@ class CalibrationsTests: XCTestCase, Injectable {
     }
 
     func testCreateMultipleCalibration() {
+        // restore state so each test is independent
+        calibrationService.removeAllCalibrations()
+
         let calibration = Calibration(x: 100.0, y: 120)
         calibrationService.addCalibration(calibration)
 
         let calibration2 = Calibration(x: 120.0, y: 130.0)
         calibrationService.addCalibration(calibration2)
-        // The original 4 XCTAsserts() below fail on the initial run,
-        //    but will work on subsequent runs.
-        // Should fix this stuff to not be stateful so that the
-        //    same results are obtained on each run.
-        // Temporary fix comment out original and use XCTAssertEqual
-        //    which allows an accuracy parameter
-        // XCTAssertTrue(calibrationService.slope == 0.8)
-        // XCTAssertTrue(calibrationService.intercept == 37)
-        // XCTAssertTrue(calibrationService.calibrate(value: 80) == 101)
 
-        XCTAssertEqual(calibrationService.slope, 0.95, accuracy: 0.0001)
-        XCTAssertEqual(calibrationService.intercept, 16, accuracy: 0.0001)
-        XCTAssertEqual(calibrationService.calibrate(value: 80), 92, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.slope, 0.8, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.intercept, 37, accuracy: 0.0001)
+        XCTAssertEqual(calibrationService.calibrate(value: 80), 101, accuracy: 0.0001)
 
         calibrationService.removeLast()
 
-        // XCTAssertTrue(calibrationService.calibrations.count == 1)
-        XCTAssertEqual(calibrationService.calibrations.count, 2)
+        XCTAssertTrue(calibrationService.calibrations.count == 1)
 
         calibrationService.removeAllCalibrations()
         XCTAssertTrue(calibrationService.calibrations.isEmpty)

--- a/FreeAPSTests/OverrideTests.swift
+++ b/FreeAPSTests/OverrideTests.swift
@@ -1,0 +1,160 @@
+//
+//  OverrideTests.swift
+//  FreeAPSTests
+//
+//  Created by Pierre LAGARDE on 05/05/2024.
+//
+import CoreData
+@testable import FreeAPS
+import Swinject
+import XCTest
+
+final class OverrideTests: XCTestCase, Injectable {
+    var overrideTestStorage: OverrideStorage!
+    let resolver = FreeAPSApp().resolver
+    var coreDataStack: CoreDataStack?
+
+    override func setUp() {
+        coreDataStack = TestCoreData()
+        (resolver as! Container)
+            .register(OverrideStorage.self, name: "testOverrideStorage") { r in
+                BaseOverrideStorage(resolver: r, managedObjectContext: self.coreDataStack!.persistentContainer.viewContext) }
+
+        overrideTestStorage = resolver.resolve(OverrideStorage.self, name: "testOverrideStorage")
+        injectServices(resolver)
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+        overrideTestStorage = nil
+        coreDataStack = nil
+    }
+
+    func testAddOverridePreset() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+
+        // new override preset :
+        let op = OverrideProfil(name: "test 1", percentage: 120, reason: "test 1")
+
+        overrideTestStorage.storeOverridePresets([op])
+        XCTAssertTrue(overrideTestStorage.presets().count == 1)
+        XCTAssertTrue(overrideTestStorage.presets().first?.percentage == 120)
+        XCTAssertNil(overrideTestStorage.presets().first?.date)
+
+        let op2 = OverrideProfil(name: "test 2", percentage: 80, reason: "test 2")
+        let op3 = OverrideProfil(name: "test 3", percentage: 200, reason: "test 3")
+        overrideTestStorage.storeOverridePresets([op2, op3])
+        XCTAssertTrue(overrideTestStorage.presets().count == 3)
+    }
+
+    func testUpdateOverridePreset() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+
+        // new override preset :
+        let op = OverrideProfil(name: "test 1", percentage: 120, reason: "test 1")
+
+        overrideTestStorage.storeOverridePresets([op])
+        var opUpdate = overrideTestStorage.presets().first
+        opUpdate?.percentage = 150
+        overrideTestStorage.storeOverridePresets([opUpdate!])
+        XCTAssertTrue(overrideTestStorage.presets().count == 1)
+        XCTAssertTrue(overrideTestStorage.presets().first?.percentage == 150)
+    }
+
+    func testRemoveOverridePreset() {
+        // new override preset :
+        let op = OverrideProfil(name: "test 1", percentage: 120, reason: "test 1")
+
+        overrideTestStorage.storeOverridePresets([op])
+        XCTAssertTrue(overrideTestStorage.presets().count == 1)
+        let id = overrideTestStorage.presets().first(where: { $0.name == "test 1" })?.id
+        overrideTestStorage.deleteOverridePreset(id!)
+        XCTAssertTrue(overrideTestStorage.presets().isEmpty)
+    }
+
+    func testAddOverride() {
+        let op = OverrideProfil(createdAt: Date(), duration: 20, percentage: 110, reason: "test 1")
+        let op2 = OverrideProfil(
+            createdAt: Date().addingTimeInterval(-10.minutes),
+            duration: 10,
+            percentage: 120,
+            reason: "test 2"
+        )
+        let op3 = OverrideProfil(
+            createdAt: Date().addingTimeInterval(-2.days.timeInterval),
+            percentage: 20,
+            reason: "test 3"
+        )
+
+        overrideTestStorage.storeOverride([op, op2, op3])
+
+        XCTAssertTrue(overrideTestStorage.recent().count == 2)
+        XCTAssertTrue(overrideTestStorage.recent().last!?.duration == 10)
+        XCTAssertTrue(overrideTestStorage.current()?.percentage == 110)
+    }
+
+    func testUpdateOverride() {
+        let op = OverrideProfil(createdAt: Date(), duration: 20, percentage: 110, reason: "test 1")
+
+        overrideTestStorage.storeOverride([op])
+        var opUpdate = overrideTestStorage.current()!
+        opUpdate.duration = nil // force to be indefinate
+        overrideTestStorage.storeOverride([opUpdate])
+        XCTAssertNil(overrideTestStorage.current()?.duration)
+        XCTAssertTrue(overrideTestStorage.current()?.indefinite == true)
+    }
+
+    func testCancelOverride() {
+        let op = OverrideProfil(
+            createdAt: Date().addingTimeInterval(-10.minutes),
+            duration: 20,
+            percentage: 110,
+            reason: "test 1"
+        )
+
+        overrideTestStorage.storeOverride([op])
+        let durationFinal = overrideTestStorage.cancelCurrentOverride()!
+        XCTAssertNil(overrideTestStorage.current())
+        XCTAssertLessThan(durationFinal, 1)
+    }
+
+    func testApplyOverrideProfil() {
+        let op = OverrideProfil(name: "test 1", indefinite: true, percentage: 120, reason: "test 1")
+        overrideTestStorage.storeOverridePresets([op])
+
+//        let ov = OverrideProfil(createdAt: Date(), indefinite: true, percentage: 10, reason: "test 2")
+//        overrideTestStorage.storeOverride([ov])
+
+        let presetId = overrideTestStorage.presets().first?.id
+
+        let date: Date = overrideTestStorage.applyOverridePreset(presetId!)!
+
+        XCTAssertTrue(overrideTestStorage.current()?.percentage == 120)
+        XCTAssertTrue(overrideTestStorage.current()?.createdAt == date)
+
+        let op2 = OverrideProfil(name: "test 2", duration: 20, percentage: 10, reason: "test 2")
+        overrideTestStorage.storeOverridePresets([op2])
+
+        let presetId2 = overrideTestStorage.presets().first(where: { $0.name == "test 2" })!.id
+
+        _ = overrideTestStorage.applyOverridePreset(presetId2)
+
+        XCTAssertTrue(overrideTestStorage.recent().count == 2)
+        XCTAssertTrue(overrideTestStorage.recent().last??.indefinite == false)
+        if let duration = overrideTestStorage.recent().last??.duration {
+            XCTAssertLessThan(duration, 1)
+        } else {
+            XCTAssert(false)
+        }
+        XCTAssertTrue(overrideTestStorage.current()?.percentage == 10)
+    }
+}

--- a/FreeAPSTests/TestCoreData.swift
+++ b/FreeAPSTests/TestCoreData.swift
@@ -1,0 +1,28 @@
+//
+//  TestCoreData.swift
+//  FreeAPSTests
+//
+//  Created by Pierre LAGARDE on 05/05/2024.
+//
+import CoreData
+@testable import FreeAPS
+import Swinject
+import XCTest
+
+final class TestCoreData: CoreDataStack {
+    override init() {
+        super.init()
+        let persistentStoreDescription = NSPersistentStoreDescription()
+        persistentStoreDescription.type = NSInMemoryStoreType
+        let container = NSPersistentContainer(name: CoreDataStack.modelName, managedObjectModel: CoreDataStack.model)
+
+        container.persistentStoreDescriptions = [persistentStoreDescription]
+
+        container.loadPersistentStores { _, error in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        }
+        persistentContainer = container
+    }
+}

--- a/FreeAPSWatch WatchKit Extension/DataFlow.swift
+++ b/FreeAPSWatch WatchKit Extension/DataFlow.swift
@@ -31,4 +31,10 @@ struct TempTargetWatchPreset: Codable, Identifiable {
     let id: String
     let description: String
     let until: Date?
+    let typeTempTarget: typeTempTarget
+}
+
+enum typeTempTarget: Codable {
+    case tempTarget
+    case override
 }

--- a/FreeAPSWatch WatchKit Extension/Views/MainView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/MainView.swift
@@ -266,15 +266,31 @@ struct MainView: View {
                     .environmentObject(state)
             } label: {
                 VStack {
-                    Image("target", bundle: nil)
-                        .renderingMode(.template)
-                        .resizable()
-                        .frame(width: 24, height: 24)
-                        .foregroundColor(.loopGreen)
                     if let until = state.tempTargets.compactMap(\.until).first, until > Date() {
-                        Text(until, style: .timer)
-                            .scaledToFill()
+                        let typeTempTarget = state.tempTargets.filter { $0.until == until }.first?.typeTempTarget
+                        if typeTempTarget == .tempTarget {
+                            Image("target", bundle: nil)
+                                .renderingMode(.template)
+                                .resizable()
+                                .frame(width: 24, height: 24)
+                                .foregroundColor(.loopGreen)
+                        } else {
+                            Image(systemName: "person.3.sequence.fill")
+                                .scaledToFit()
+                                .foregroundColor(.loopGreen)
+                        }
+                        until.timeIntervalSinceNow >= 900_000 ?
+                            Text("Always").scaledToFill()
+                            .font(.system(size: 8)) :
+                            Text(until, style: .timer).scaledToFill()
                             .font(.system(size: 8))
+
+                    } else {
+                        Image("target", bundle: nil)
+                            .renderingMode(.template)
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.loopGreen)
                     }
                 }
             }
@@ -422,7 +438,13 @@ struct ContentView_Previews: PreviewProvider {
         state.lastLoopDate = Date().addingTimeInterval(-200)
         state
             .tempTargets =
-            [TempTargetWatchPreset(name: "Test", id: "test", description: "", until: Date().addingTimeInterval(3600 * 3))]
+            [TempTargetWatchPreset(
+                name: "Test",
+                id: "test",
+                description: "",
+                until: Date().addingTimeInterval(3600 * 3),
+                typeTempTarget: .tempTarget
+            )]
 
         return Group {
             MainView()

--- a/FreeAPSWatch WatchKit Extension/Views/TempTargetsView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/TempTargetsView.swift
@@ -6,35 +6,54 @@ struct TempTargetsView: View {
     var body: some View {
         List {
             if state.tempTargets.isEmpty {
-                Text("Set temp targets presets on iPhone first").padding()
+                Text("Set temp targets presets or override on iPhone first").padding()
             } else {
                 ForEach(state.tempTargets) { target in
                     Button {
                         WKInterfaceDevice.current().play(.click)
-                        state.enactTempTarget(id: target.id)
+                        state.enactTempTarget(id: target.id, typeTempTarget: target.typeTempTarget)
                     } label: {
                         VStack(alignment: .leading) {
                             HStack {
+                                if target.typeTempTarget == .tempTarget {
+                                    Image("target", bundle: nil)
+                                        .renderingMode(.template)
+                                        .resizable()
+                                        .frame(width: 12, height: 12)
+                                        .foregroundColor(.white)
+                                } else
+                                {
+                                    Image(systemName: "person.3.sequence.fill")
+                                        .renderingMode(.template)
+                                        .resizable()
+                                        .frame(width: 24, height: 12)
+                                        .foregroundColor(.white)
+                                }
                                 Text(target.name)
                                 if let until = target.until, until > Date() {
                                     Spacer()
-                                    Text(until, style: .timer).foregroundColor(.loopGreen)
+                                    until.timeIntervalSinceNow >= (24 * 60 * 60 * 300) ? Text("Always") :
+                                        Text(until, style: .timer).foregroundColor(.white)
                                 }
                             }
-                            Text(target.description).font(.caption2).foregroundColor(.secondary)
+                            Text(target.description).font(.caption2).foregroundColor(.white)
                         }
-                    }
+                    }.listRowBackground(
+                        RoundedRectangle(cornerRadius: 15)
+                            .background(Color.clear)
+                            .foregroundColor(target.typeTempTarget == .tempTarget ? Color.tempBasal : Color.profil)
+                    )
                 }
             }
 
             Button {
                 WKInterfaceDevice.current().play(.click)
-                state.enactTempTarget(id: "cancel")
+                state.cancelTempTarget()
             } label: {
-                Text("Cancel Temp Target")
+                Text("Cancel Temp Target/Profil")
             }
         }
-        .navigationTitle("Temp Targets")
+        .navigationTitle("Temp Targets/Profil")
     }
 }
 
@@ -46,10 +65,22 @@ struct TempTargetsView_Previews: PreviewProvider {
                 name: "Target 0",
                 id: UUID().uuidString,
                 description: "blablabla",
-                until: Date().addingTimeInterval(60 * 60)
+                until: Date().addingTimeInterval(60 * 60), typeTempTarget: .tempTarget
             ),
-            TempTargetWatchPreset(name: "target1", id: UUID().uuidString, description: "blablabla", until: nil),
-            TempTargetWatchPreset(name: "🤖 Target 2", id: UUID().uuidString, description: "blablabla", until: nil)
+            TempTargetWatchPreset(
+                name: "target1",
+                id: UUID().uuidString,
+                description: "blablabla",
+                until: nil,
+                typeTempTarget: .tempTarget
+            ),
+            TempTargetWatchPreset(
+                name: "🤖 Target 2",
+                id: UUID().uuidString,
+                description: "blablabla",
+                until: nil,
+                typeTempTarget: .tempTarget
+            )
         ]
         return TempTargetsView().environmentObject(model)
     }

--- a/FreeAPSWatch WatchKit Extension/WatchStateModel.swift
+++ b/FreeAPSWatch WatchKit Extension/WatchStateModel.swift
@@ -88,11 +88,33 @@ class WatchStateModel: NSObject, ObservableObject {
         }
     }
 
-    func enactTempTarget(id: String) {
+    func enactTempTarget(id: String, typeTempTarget: typeTempTarget) {
         confirmationSuccess = nil
         isConfirmationViewActive = true
         isTempTargetViewActive = false
-        session.sendMessage(["tempTarget": id], replyHandler: completionHandler) { error in
+        switch typeTempTarget {
+        case .tempTarget:
+            session.sendMessage(["tempTarget": id], replyHandler: completionHandler) { error in
+                print(error.localizedDescription)
+                DispatchQueue.main.async {
+                    self.confirmation(false)
+                }
+            }
+        case .override:
+            session.sendMessage(["overrideTarget": id], replyHandler: completionHandler) { error in
+                print(error.localizedDescription)
+                DispatchQueue.main.async {
+                    self.confirmation(false)
+                }
+            }
+        }
+    }
+
+    func cancelTempTarget() {
+        confirmationSuccess = nil
+        isConfirmationViewActive = true
+        isTempTargetViewActive = false
+        session.sendMessage(["cancelTempTarget": "true"], replyHandler: completionHandler) { error in
             print(error.localizedDescription)
             DispatchQueue.main.async {
                 self.confirmation(false)

--- a/Open-iAPS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Open-iAPS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift",
+      "state" : {
+        "revision" : "19b3c3ceed117c5cc883517c4e658548315ba70b",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "slidebutton",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/no-comment/SlideButton",
+      "state" : {
+        "branch" : "main",
+        "revision" : "5eacebba4d7deeb693592bc9a62ab2d2181e133b"
+      }
+    },
+    {
+      "identity" : "swiftcharts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ivanschuetz/SwiftCharts.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "c354c1945bb35a1f01b665b22474f6db28cba4a2"
+      }
+    },
+    {
+      "identity" : "tidepoolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tidepool-org/TidepoolKit",
+      "state" : {
+        "branch" : "dev",
+        "revision" : "b8185353c0f46a055f6d5681bb3f18ec86a5b974"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Trio.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Trio.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "mkringprogressview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/maxkonovalov/MKRingProgressView.git",
-      "state" : {
-        "branch" : "master",
-        "revision" : "660888aab1d2ab0ed7eb9eb53caec12af4955fa7"
-      }
-    },
-    {
       "identity" : "slidebutton",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/no-comment/SlideButton",
@@ -28,57 +19,12 @@
       }
     },
     {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms",
-      "state" : {
-        "revision" : "2327673b0e9c7e90e6b1826376526ec3627210e4",
-        "version" : "0.2.1"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "6583ac70c326c3ee080c1d42d9ca3361dca816cd",
-        "version" : "0.1.0"
-      }
-    },
-    {
       "identity" : "swiftcharts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ivanschuetz/SwiftCharts.git",
       "state" : {
         "branch" : "master",
         "revision" : "c354c1945bb35a1f01b665b22474f6db28cba4a2"
-      }
-    },
-    {
-      "identity" : "swiftdate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/malcommac/SwiftDate",
-      "state" : {
-        "revision" : "6190d0cefff3013e77ed567e6b074f324e5c5bf5",
-        "version" : "6.3.1"
-      }
-    },
-    {
-      "identity" : "swiftmessages",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftKickMobile/SwiftMessages",
-      "state" : {
-        "revision" : "62e12e138fc3eedf88c7553dd5d98712aa119f40",
-        "version" : "9.0.9"
-      }
-    },
-    {
-      "identity" : "swinject",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Swinject/Swinject",
-      "state" : {
-        "revision" : "0b0fa300d0fe24be810750272e0e7ea1971dff90",
-        "version" : "2.8.5"
       }
     },
     {

--- a/Trio.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Trio.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -48,7 +48,7 @@
     {
       "identity" : "swiftcharts",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ivanschuetz/SwiftCharts",
+      "location" : "https://github.com/ivanschuetz/SwiftCharts.git",
       "state" : {
         "branch" : "master",
         "revision" : "c354c1945bb35a1f01b665b22474f6db28cba4a2"


### PR DESCRIPTION
The PR includes a large refactoring of the swift part of override/profile functions :
- Override is stored in override core data, including history
- Override preset is stored in overridepreset core data
- Add the display of the override in main graph
- allows to select a override preset (or a temp target) in AW
- allows to cancel a current override preset or specific override (idem for temp target) in AW
- add a color profil for override profil in AW 
- Fix some minor code in AW
- add the upload of override as a exercice in Nightscout - Fix #145 
- improve the management of indefinate override / stop of indefinate override
- modify the code to respect the Ivan’s patterns of the app : 

> - Use of swiftInject (dependency injection) with the use of protocol class in the code 
> - Use of MVP principes, in particular not use of direct coredata in view class 
> - Use of a proxy model class between coredata and the app to manage changes of core data 
> - Use of the pattern of observe to refresh data/view/uploads
> 

- add a core data unit tests allowing to add tests for coredata with a in-memory datastore for tests.
- test for overrideStorage available

This PR do NOT change the logic with oref and the interface of override informations in oref. This PR do NOT require a update of trio-oref code.

TODO : Changes the shortcuts after merging with PR #144   and add watch for overrides.

The PR replaces the PR #178  with the functionality for Apple Watch. 

| override display | override in NS |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-05-07 at 21 43 34](https://github.com/nightscout/Trio/assets/4339604/b7635c39-79db-4f48-b352-de955c3d4989)| ![CleanShot 2024-05-07 at 21 44 16](https://github.com/nightscout/Trio/assets/4339604/2e6400aa-b93c-463d-a19b-3feed04d055f) | 
![CleanShot 2024-05-19 at 20 47 23](https://github.com/nightscout/Trio/assets/4339604/c12938e8-fd76-4569-ac17-e85401253447)|![CleanShot 2024-05-19 at 20 50 17](https://github.com/nightscout/Trio/assets/4339604/8fdbb8e3-fca3-4ca0-a444-c3fc4f83cb45)|


