### PR TITLE
Remove duplicate "Remote control" toggle from preferences

### DIFF
--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
@@ -4,14 +4,12 @@ import SwiftUI
 extension PreferencesEditor {
     final class StateModel: BaseStateModel<Provider>, PreferencesSettable { private(set) var preferences = Preferences()
         @Published var unitsIndex = 1
-        @Published var allowAnnouncements = false
         @Published var insulinReqPercentage: Decimal = 70
         @Published var skipBolusScreenAfterCarbs = false
         @Published var sections: [FieldSection] = []
 
         override func subscribe() {
             preferences = provider.preferences
-            subscribeSetting(\.allowAnnouncements, on: $allowAnnouncements) { allowAnnouncements = $0 }
             subscribeSetting(\.insulinReqPercentage, on: $insulinReqPercentage) { insulinReqPercentage = $0 }
             subscribeSetting(\.skipBolusScreenAfterCarbs, on: $skipBolusScreenAfterCarbs) { skipBolusScreenAfterCarbs = $0 }
 

--- a/FreeAPS/Sources/Modules/PreferencesEditor/View/PreferencesEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/View/PreferencesEditorRootView.swift
@@ -27,9 +27,6 @@ extension PreferencesEditor {
                         Text("mg/dL").tag(0)
                         Text("mmol/L").tag(1)
                     }
-
-                    Toggle("Remote control", isOn: $state.allowAnnouncements)
-
                     HStack {
                         Text("Recommended Bolus Percentage")
                         DecimalTextField("", value: $state.insulinReqPercentage, formatter: formatter)


### PR DESCRIPTION
Keep the toggle in Nightscout Config

This is a suggested change after discussions in the remote-control channel in discord earlier today.

| Preferences before change | Preferences after change | Nightscout Config unchanged |
|--------|--------|--------|
| ![IMG_3763](https://github.com/nightscout/Trio/assets/72826201/fabaddf5-f587-4c13-ab9a-844a1f10d87b) | ![Simulator Screenshot - iPhone 13 mini+ - 2024-05-20 at 20 58 18](https://github.com/nightscout/Trio/assets/72826201/0a436782-8e87-4279-a43c-eb795fa8abda) | ![Simulator Screenshot - iPhone 13 mini+ - 2024-05-20 at 20 58 25](https://github.com/nightscout/Trio/assets/72826201/e926fd2f-6938-47c2-9326-981eecb296d9) | 