### PR TITLE
Prevent entries for Carbs, Fat, Protein, and Bolus that exceed Max settings

### DIFF
--- a/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
+++ b/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
@@ -40,6 +40,8 @@
   "oneDimensionalGraph" : false,
   "rulerMarks" : true,
   "maxCarbs": 250,
+  "maxFat": 250,
+  "maxProtein": 250,
   "displayFatAndProteinOnWatch": false,
   "lockScreenView": "simple"
 }

--- a/FreeAPS/Sources/Localizations/Main/ar.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ar.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pump Settings";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/ca.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ca.lproj/Localizable.strings
@@ -344,6 +344,33 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Bolus" = "Max Bolus";
 
+/* Max setting */
+"Max Carbs" = "Max Carbs";
+
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pump Settings";
 

--- a/FreeAPS/Sources/Localizations/Main/da.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/da.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Maks Kulhydrater";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pumpe Indstillinger";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Kohlenhydrate";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pumpeneinstellungen";
 
@@ -1054,9 +1078,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus fehlgeschlagen";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Maximaler Bolus überschritten!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus ist fehlgeschlagen oder ungenau. Prüfe den Pumpenverlauf vor einer erneuten Abgabe.";

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pump Settings";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/es.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/es.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Configuración de la bomba";
 
@@ -1050,9 +1074,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "¡Bolo máximo superado!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/fi.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/fi.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pump Settings";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/fr.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/fr.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Glucides max";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Paramètres de la pompe";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Échec du Bolus";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Bolus max dépassé!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus échoué ou imprécis. Vérifier l’historique de la pompe avant recommencer.";

--- a/FreeAPS/Sources/Localizations/Main/he.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/he.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pump Settings";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/hu.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/hu.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Maximum szénhidrát";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pumpa beállítások";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/it.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/it.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Ultimi carboidrati";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Microinfusore";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolo fallito";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Bolo massimo superato!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolo fallito o impreciso. Controlla la cronologia del microinfusore prima di ripetere.";

--- a/FreeAPS/Sources/Localizations/Main/nb.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/nb.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Maksimalt antall karbohydrater";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pumpeinnstillinger";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus mislyktes";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus overskredet!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus mislyktes eller var upresis. Kontroller bolus-historikken før du gjentar.";

--- a/FreeAPS/Sources/Localizations/Main/nl.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/nl.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max koolhydraten";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pomp instellingen";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus is mislukt";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Maximale bolus overschreden!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus mislukt of onjuist. Controleer de pompgeschiedenis voordat je herhaalt.";

--- a/FreeAPS/Sources/Localizations/Main/pl.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pl.lproj/Localizable.strings
@@ -433,6 +433,30 @@ Połączono z Nightscout!";
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pump Settings";
 
@@ -1053,9 +1077,6 @@ Połączono z Nightscout!";
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/pt-BR.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pt-BR.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Ajustes Bomba";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/pt-PT.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pt-PT.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Ajustes Bomba";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus failed";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus failed or inaccurate. Check pump history before repeating.";

--- a/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Максимум углеводов";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Настройки помпы";
 
@@ -1054,9 +1078,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Болюс не выполнен";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Максимальный болюс превышен!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Болюс не выполнен или неточный. Перед повторением проверьте историю помпы.";

--- a/FreeAPS/Sources/Localizations/Main/sk.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sk.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Maximum sacharidov";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Nastavenia pumpy";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Chyba pri aplikácii bolusu";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Maximálny bolus prekročený!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus zlyhal alebo bol nepresný. Pred opakovaním skontrolujte históriu čerpadla.";

--- a/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max antal kolhydrater";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pumpinställningar";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus misslyckades";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Du kan inte dosera mer än din maxinställning!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Misslyckad eller felaktig bolus. Kontrollera pumpens historik innan du försöker igen.";

--- a/FreeAPS/Sources/Localizations/Main/tr.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/tr.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Pompa Ayarları";
 
@@ -1055,9 +1079,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Bolus başarısız";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Bolus başarısız veya hatalı. Tekrarlamadan önce pompa geçmişini kontrol edin.";

--- a/FreeAPS/Sources/Localizations/Main/uk.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/uk.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Максимум вуглеводів";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Налаштування Помпи";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Болюс не вдався";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Максимальний болюс перевищено!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Болюс не пройшов або неточний. Перевір історію помпи, перш ніж повторити.";

--- a/FreeAPS/Sources/Localizations/Main/vi.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/vi.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Khối lượng carbs tối đa";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "Cấu hình bơm";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "Liều bolus thất bại";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Liều Max Bolus đã vượt quá mong đợi!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "Liều bolus thất bại hoặc không chính xác. Kiểm tra lại bơm trước khi lặp lại.";

--- a/FreeAPS/Sources/Localizations/Main/zh-Hans.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/zh-Hans.lproj/Localizable.strings
@@ -431,6 +431,30 @@ Enact a temp Basal or a temp target */
 /* Max setting */
 "Max Carbs" = "Max Carbs";
 
+/* Max setting */
+"Max Fat" = "Max Fat";
+
+/* Max setting */
+"Max Protein" = "Max Protein";
+
+/* Max setting */
+"Limit Per Entry" = "Limit Per Entry";
+
+/* Max Carbs limit exceeded */
+"Max Carbs of" = "Max Carbs of";
+
+/* Max Fat limit exceeded */
+"Max Fat of" = "Max Fat of";
+
+/* Max Protein limit exceeded */
+"Max Protein of" = "Max Protein of";
+
+/* Max Bolus limit exceeded */
+"Max Bolus of" = "Max Bolus of";
+
+/* Limit Exceeded label */
+"exceeded" = "exceeded";
+
 /* */
 "Pump Settings" = "泵设置";
 
@@ -1051,9 +1075,6 @@ Enact a temp Basal or a temp target */
 
 /* */
 "Bolus failed" = "大剂量输注失败";
-
-/* "Max Bolus Exceeded label" */
-"Max Bolus exceeded!" = "Max Bolus exceeded!";
 
 /* */
 "Bolus failed or inaccurate. Check pump history before repeating." = "大剂量失败或者不准确，请在重复操作前检查胰岛素泵历史";

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -41,6 +41,8 @@ struct FreeAPSSettings: JSON, Equatable {
     var oneDimensionalGraph: Bool = false
     var rulerMarks: Bool = true
     var maxCarbs: Decimal = 250
+    var maxFat: Decimal = 250
+    var maxProtein: Decimal = 250
     var displayFatAndProteinOnWatch: Bool = false
     var onlyAutotuneBasals: Bool = false
     var useLiveActivity: Bool = false
@@ -216,6 +218,14 @@ extension FreeAPSSettings: Decodable {
 
         if let maxCarbs = try? container.decode(Decimal.self, forKey: .maxCarbs) {
             settings.maxCarbs = maxCarbs
+        }
+
+        if let maxFat = try? container.decode(Decimal.self, forKey: .maxFat) {
+            settings.maxFat = maxFat
+        }
+
+        if let maxProtein = try? container.decode(Decimal.self, forKey: .maxProtein) {
+            settings.maxProtein = maxProtein
         }
 
         if let displayFatAndProteinOnWatch = try? container.decode(Bool.self, forKey: .displayFatAndProteinOnWatch) {

--- a/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
@@ -16,7 +16,9 @@ extension AddCarbs {
         @Published var dish: String = ""
         @Published var selection: Presets?
         @Published var summation: [String] = []
-        @Published var maxCarbs: Decimal = 0
+        @Published var maxCarbs: Decimal = 250
+        @Published var maxFat: Decimal = 250
+        @Published var maxProtein: Decimal = 250
         @Published var note: String = ""
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
@@ -25,6 +27,8 @@ extension AddCarbs {
             subscribeSetting(\.useFPUconversion, on: $useFPUconversion) { useFPUconversion = $0 }
             carbsRequired = provider.suggestion?.carbsReq
             maxCarbs = settings.settings.maxCarbs
+            maxFat = settings.settings.maxFat
+            maxProtein = settings.settings.maxProtein
         }
 
         func add() {
@@ -159,6 +163,18 @@ extension AddCarbs {
                 }
             }
             return waitersNotepadString
+        }
+
+        func saveButtonText() -> String {
+            if carbs > maxCarbs {
+                return "\(NSLocalizedString("Max Carbs of", comment: "")) \(maxCarbs) \(NSLocalizedString("g", comment: "")) \(NSLocalizedString("exceeded", comment: ""))"
+            } else if fat > maxFat {
+                return "\(NSLocalizedString("Max Fat of", comment: "")) \(maxFat) \(NSLocalizedString("g", comment: "")) \(NSLocalizedString("exceeded", comment: ""))"
+            } else if protein > maxProtein {
+                return "\(NSLocalizedString("Max Protein of", comment: "")) \(maxProtein) \(NSLocalizedString("g", comment: "")) \(NSLocalizedString("exceeded", comment: ""))"
+            } else {
+                return NSLocalizedString("Save and continue", comment: "")
+            }
         }
     }
 }

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -131,7 +131,7 @@ extension AddCarbs {
                                 || (state.carbs <= 0 && state.fat <= 0 && state.protein <= 0)
                         )
                         .foregroundStyle(
-                            (state.carbs <= 0 && state.fat <= 0 && state.protein <= 0) ? .gray :
+                            mealSaved || (state.carbs <= 0 && state.fat <= 0 && state.protein <= 0) ? .gray :
                                 state.carbs > state.maxCarbs || state.fat > state.maxFat || state.protein > state
                                 .maxProtein ? .red : .blue
                         )

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -118,8 +118,24 @@ extension AddCarbs {
 
                 Section {
                     Button { state.add() }
-                    label: { Text("Save and continue").font(.title3) }
-                        .disabled(state.carbs <= 0 && state.fat <= 0 && state.protein <= 0)
+                    label: {
+                        Text(
+                            state.carbs <= state.maxCarbs ? NSLocalizedString("Save and continue", comment: "") :
+                                NSLocalizedString("Max Carbs of", comment: "")
+                                + " "
+                                + formatter.string(from: state.maxCarbs as NSNumber)!
+                                + NSLocalizedString("g", comment: "The short unit display string for grams")
+                                + " "
+                                + NSLocalizedString("exceeded", comment: "")
+                        ).font(.title3) }
+                        .disabled(
+                            state.carbs > state.maxCarbs
+                                || (state.carbs <= 0 && state.fat <= 0 && state.protein <= 0)
+                        )
+                        .foregroundStyle(
+                            (state.carbs <= 0 && state.fat <= 0 && state.protein <= 0) ? .gray :
+                                state.carbs > state.maxCarbs ? .red : .blue
+                        )
                         .frame(maxWidth: .infinity, alignment: .center)
                 } footer: { Text(state.waitersNotepad().description) }
 

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -48,7 +48,7 @@ extension AddCarbs {
                             autofocus: true,
                             cleanInput: true
                         )
-                        Text("grams").foregroundColor(.secondary)
+                        Text(state.carbs > state.maxCarbs ? "⚠️" : "g").foregroundColor(.secondary)
                     }.padding(.vertical)
 
                     if state.useFPUconversion {
@@ -118,23 +118,17 @@ extension AddCarbs {
 
                 Section {
                     Button { state.add() }
-                    label: {
-                        Text(
-                            state.carbs <= state.maxCarbs ? NSLocalizedString("Save and continue", comment: "") :
-                                NSLocalizedString("Max Carbs of", comment: "")
-                                + " "
-                                + formatter.string(from: state.maxCarbs as NSNumber)!
-                                + NSLocalizedString("g", comment: "The short unit display string for grams")
-                                + " "
-                                + NSLocalizedString("exceeded", comment: "")
-                        ).font(.title3) }
+                    label: { Text(state.saveButtonText()).font(.title3) }
                         .disabled(
                             state.carbs > state.maxCarbs
+                                || state.fat > state.maxFat
+                                || state.protein > state.maxProtein
                                 || (state.carbs <= 0 && state.fat <= 0 && state.protein <= 0)
                         )
                         .foregroundStyle(
                             (state.carbs <= 0 && state.fat <= 0 && state.protein <= 0) ? .gray :
-                                state.carbs > state.maxCarbs ? .red : .blue
+                                state.carbs > state.maxCarbs || state.fat > state.maxFat || state.protein > state
+                                .maxProtein ? .red : .blue
                         )
                         .frame(maxWidth: .infinity, alignment: .center)
                 } footer: { Text(state.waitersNotepad().description) }
@@ -276,7 +270,7 @@ extension AddCarbs {
                     autofocus: false,
                     cleanInput: true
                 )
-                Text("grams").foregroundColor(.secondary)
+                Text(state.fat > state.maxFat ? "⚠️" : "g").foregroundColor(.secondary)
             }
             HStack {
                 Text("Protein").foregroundColor(.red) // .fontWeight(.thin)
@@ -287,9 +281,8 @@ extension AddCarbs {
                     formatter: formatter,
                     autofocus: false,
                     cleanInput: true
-                ).foregroundColor(.loopRed)
-
-                Text("grams").foregroundColor(.secondary)
+                )
+                Text(state.protein > state.maxProtein ? "⚠️" : "g").foregroundColor(.secondary)
             }
         }
     }

--- a/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
@@ -87,14 +87,13 @@ extension Bolus {
                                     + NSLocalizedString("U", comment: "Insulin unit")
                                     + " "
                                     + NSLocalizedString("exceeded", comment: "")
-                            ) }
-                            .disabled(
-                                state.amount <= 0 || state.amount > state.maxBolus
-                            )
+                            ).font(.title3) }
+                            .disabled(state.amount <= 0 || state.amount > state.maxBolus)
                             .foregroundStyle(
                                 state.amount <= 0 ? .gray :
                                     state.amount > state.maxBolus ? .red : .blue
                             )
+                            .frame(maxWidth: .infinity, alignment: .center)
                     }
                     if waitForSuggestion {
                         Section {

--- a/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
@@ -81,14 +81,19 @@ extension Bolus {
                         label: {
                             Text(
                                 state.amount <= state.maxBolus ? NSLocalizedString("Enact bolus", comment: "") :
-                                    NSLocalizedString("Max Bolus exceeded!", comment: "")
-                                    + " (>"
+                                    NSLocalizedString("Max Bolus of", comment: "")
+                                    + " "
                                     + formatter.string(from: state.maxBolus as NSNumber)!
                                     + NSLocalizedString("U", comment: "Insulin unit")
-                                    + ")"
+                                    + " "
+                                    + NSLocalizedString("exceeded", comment: "")
                             ) }
                             .disabled(
                                 state.amount <= 0 || state.amount > state.maxBolus
+                            )
+                            .foregroundStyle(
+                                state.amount <= 0 ? .gray :
+                                    state.amount > state.maxBolus ? .red : .blue
                             )
                     }
                     if waitForSuggestion {

--- a/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
@@ -72,7 +72,7 @@ extension Bolus {
                                 autofocus: true,
                                 cleanInput: true
                             )
-                            Text("U").foregroundColor(.secondary)
+                            Text(state.amount > state.maxBolus ? "⚠️" : "U").foregroundColor(.secondary)
                         }
                     }
                     header: { Text("Bolus") }

--- a/FreeAPS/Sources/Modules/FPUConfig/FPUConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/FPUConfig/FPUConfigStateModel.swift
@@ -3,6 +3,8 @@ import SwiftUI
 extension FPUConfig {
     final class StateModel: BaseStateModel<Provider> {
         @Published var maxCarbs: Decimal = 250
+        @Published var maxFat: Decimal = 250
+        @Published var maxProtein: Decimal = 250
         @Published var individualAdjustmentFactor: Decimal = 0
         @Published var timeCap: Decimal = 0
         @Published var minuteInterval: Decimal = 0
@@ -10,6 +12,8 @@ extension FPUConfig {
 
         override func subscribe() {
             subscribeSetting(\.maxCarbs, on: $maxCarbs) { maxCarbs = $0 }
+            subscribeSetting(\.maxFat, on: $maxFat) { maxFat = $0 }
+            subscribeSetting(\.maxProtein, on: $maxProtein) { maxProtein = $0 }
             subscribeSetting(\.timeCap, on: $timeCap.map(Int.init), initial: {
                 let value = max(min($0, 12), 5)
                 timeCap = Decimal(value)

--- a/FreeAPS/Sources/Modules/FPUConfig/View/FPUConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/FPUConfig/View/FPUConfigRootView.swift
@@ -28,10 +28,18 @@ extension FPUConfig {
 
         var body: some View {
             Form {
-                Section(header: Text("Carbohydrate limit")) {
+                Section(header: Text("Limit Per Entry")) {
                     HStack {
                         Text("Max Carbs")
                         DecimalTextField("g", value: $state.maxCarbs, formatter: formatter)
+                    }
+                    HStack {
+                        Text("Max Fat")
+                        DecimalTextField("g", value: $state.maxFat, formatter: formatter)
+                    }
+                    HStack {
+                        Text("Max Protein")
+                        DecimalTextField("g", value: $state.maxProtein, formatter: formatter)
                     }
                 }
 


### PR DESCRIPTION
- Adds two new settings: `maxFat` & `maxProtein`
  - default to 250g, same as `maxCarbs`
- Change label of `Carbohydrate limit` to `Limit Per Entry` for Meal Settings
- For meal entry module, shorten `grams` to `g`
- If bolus, carbs, fat, or protein exceed their limit:
  - Change `U` or `g` to `⚠️`
  - Disable submit button, change text to red, and replace with warning

~~I also thought it might be nice to make the "enact bolus" and "save and continue" text orange if IOB+bolus>MaxIOB or if COB+carbs>MaxCOB, but have not added that yet.~~

https://github.com/nightscout/Trio/assets/82073483/649f2677-8146-4328-9dd7-5371aec8e4ec

https://github.com/nightscout/Trio/assets/82073483/bb3aa81f-78f8-453a-a9c6-5b547011af84