### PR TITLE
Add Tidepool navigation view (fix missing chevron)

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		5D16287A969E64D18CE40E44 /* PumpConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F60E97100041040446F44E7 /* PumpConfigStateModel.swift */; };
 		63E890B4D951EAA91C071D5C /* BasalProfileEditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF91130F2FCCC7EBBA11AD /* BasalProfileEditorStateModel.swift */; };
 		642F76A05A4FF530463A9FD0 /* NightscoutConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8782B44544F38F2B2D82C38E /* NightscoutConfigRootView.swift */; };
+		65070A332BFDCB83006F213F /* TidePoolStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65070A322BFDCB83006F213F /* TidePoolStartView.swift */; };
 		6632A0DC746872439A858B44 /* ISFEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BDA519C9B890FD9A5DFCF3 /* ISFEditorDataFlow.swift */; };
 		69A31254F2451C20361D172F /* BolusStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223EC0494F55A91E3EA69EF4 /* BolusStateModel.swift */; };
 		69B9A368029F7EB39F525422 /* CREditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64AA5E04A2761F6EEA6568E1 /* CREditorStateModel.swift */; };
@@ -767,6 +768,7 @@
 		60744C3E9BB3652895C908CC /* DataTableProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableProvider.swift; sourceTree = "<group>"; };
 		618E62C9757B2F95431B5DC0 /* AddCarbsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddCarbsProvider.swift; sourceTree = "<group>"; };
 		64AA5E04A2761F6EEA6568E1 /* CREditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CREditorStateModel.swift; sourceTree = "<group>"; };
+		65070A322BFDCB83006F213F /* TidePoolStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidePoolStartView.swift; sourceTree = "<group>"; };
 		67F94DD2853CF42BA4E30616 /* BasalProfileEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorDataFlow.swift; sourceTree = "<group>"; };
 		680C4420C9A345D46D90D06C /* ManualTempBasalProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalProvider.swift; sourceTree = "<group>"; };
 		6B1A8D012B14D88B00E76752 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
@@ -1277,6 +1279,7 @@
 				3811DE3C25C9D4A100A708ED /* SettingsRootView.swift */,
 				CE1F6DE82BAF37C90064EB8D /* TidePoolConfigView.swift */,
 				DD1DB7CD2BED00CF0048B367 /* SettingsRootViewModel.swift */,
+				65070A322BFDCB83006F213F /* TidePoolStartView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2648,6 +2651,7 @@
 				3811DE1825C9D40400A708ED /* Router.swift in Sources */,
 				CE7950262998056D00FA576E /* CGMSetupView.swift in Sources */,
 				38A0363B25ECF07E00FCBB52 /* GlucoseStorage.swift in Sources */,
+				65070A332BFDCB83006F213F /* TidePoolStartView.swift in Sources */,
 				190EBCC629FF138000BA767D /* StatConfigProvider.swift in Sources */,
 				38E98A2725F52C9300C0CED0 /* CollectionIssueReporter.swift in Sources */,
 				E00EEC0427368630002FF094 /* SecurityAssembly.swift in Sources */,

--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -244,7 +244,7 @@
 		5D16287A969E64D18CE40E44 /* PumpConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F60E97100041040446F44E7 /* PumpConfigStateModel.swift */; };
 		63E890B4D951EAA91C071D5C /* BasalProfileEditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF91130F2FCCC7EBBA11AD /* BasalProfileEditorStateModel.swift */; };
 		642F76A05A4FF530463A9FD0 /* NightscoutConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8782B44544F38F2B2D82C38E /* NightscoutConfigRootView.swift */; };
-		65070A332BFDCB83006F213F /* TidePoolStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65070A322BFDCB83006F213F /* TidePoolStartView.swift */; };
+		65070A332BFDCB83006F213F /* TidepoolStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65070A322BFDCB83006F213F /* TidepoolStartView.swift */; };
 		6632A0DC746872439A858B44 /* ISFEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BDA519C9B890FD9A5DFCF3 /* ISFEditorDataFlow.swift */; };
 		69A31254F2451C20361D172F /* BolusStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223EC0494F55A91E3EA69EF4 /* BolusStateModel.swift */; };
 		69B9A368029F7EB39F525422 /* CREditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64AA5E04A2761F6EEA6568E1 /* CREditorStateModel.swift */; };
@@ -291,7 +291,7 @@
 		CE1F6DD92BADF4620064EB8D /* PluginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */; };
 		CE1F6DDB2BAE08B60064EB8D /* TidepoolManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DDA2BAE08B60064EB8D /* TidepoolManager.swift */; };
 		CE1F6DE72BAF1A180064EB8D /* BuildDetails.plist in Resources */ = {isa = PBXBuildFile; fileRef = CE1F6DE62BAF1A180064EB8D /* BuildDetails.plist */; };
-		CE1F6DE92BAF37C90064EB8D /* TidePoolConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DE82BAF37C90064EB8D /* TidePoolConfigView.swift */; };
+		CE1F6DE92BAF37C90064EB8D /* TidepoolConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1F6DE82BAF37C90064EB8D /* TidepoolConfigView.swift */; };
 		CE2FAD3A297D93F0001A872C /* BloodGlucoseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2FAD39297D93F0001A872C /* BloodGlucoseExtensions.swift */; };
 		CE48C86428CA69D5007C0598 /* OmniBLEPumpManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE48C86328CA69D5007C0598 /* OmniBLEPumpManagerExtensions.swift */; };
 		CE48C86628CA6B48007C0598 /* OmniPodManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE48C86528CA6B48007C0598 /* OmniPodManagerExtensions.swift */; };
@@ -768,7 +768,7 @@
 		60744C3E9BB3652895C908CC /* DataTableProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableProvider.swift; sourceTree = "<group>"; };
 		618E62C9757B2F95431B5DC0 /* AddCarbsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddCarbsProvider.swift; sourceTree = "<group>"; };
 		64AA5E04A2761F6EEA6568E1 /* CREditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CREditorStateModel.swift; sourceTree = "<group>"; };
-		65070A322BFDCB83006F213F /* TidePoolStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidePoolStartView.swift; sourceTree = "<group>"; };
+		65070A322BFDCB83006F213F /* TidepoolStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolStartView.swift; sourceTree = "<group>"; };
 		67F94DD2853CF42BA4E30616 /* BasalProfileEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorDataFlow.swift; sourceTree = "<group>"; };
 		680C4420C9A345D46D90D06C /* ManualTempBasalProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalProvider.swift; sourceTree = "<group>"; };
 		6B1A8D012B14D88B00E76752 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
@@ -817,7 +817,7 @@
 		CE1F6DD82BADF4620064EB8D /* PluginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginManagerTests.swift; sourceTree = "<group>"; };
 		CE1F6DDA2BAE08B60064EB8D /* TidepoolManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolManager.swift; sourceTree = "<group>"; };
 		CE1F6DE62BAF1A180064EB8D /* BuildDetails.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = BuildDetails.plist; sourceTree = "<group>"; };
-		CE1F6DE82BAF37C90064EB8D /* TidePoolConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidePoolConfigView.swift; sourceTree = "<group>"; };
+		CE1F6DE82BAF37C90064EB8D /* TidepoolConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolConfigView.swift; sourceTree = "<group>"; };
 		CE2FAD39297D93F0001A872C /* BloodGlucoseExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloodGlucoseExtensions.swift; sourceTree = "<group>"; };
 		CE398D012977349800DF218F /* CryptoKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoKit.framework; path = System/Library/Frameworks/CryptoKit.framework; sourceTree = SDKROOT; };
 		CE398D17297C9EE800DF218F /* G7SensorKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = G7SensorKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1277,9 +1277,9 @@
 			isa = PBXGroup;
 			children = (
 				3811DE3C25C9D4A100A708ED /* SettingsRootView.swift */,
-				CE1F6DE82BAF37C90064EB8D /* TidePoolConfigView.swift */,
+				CE1F6DE82BAF37C90064EB8D /* TidepoolConfigView.swift */,
 				DD1DB7CD2BED00CF0048B367 /* SettingsRootViewModel.swift */,
-				65070A322BFDCB83006F213F /* TidePoolStartView.swift */,
+				65070A322BFDCB83006F213F /* TidepoolStartView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2651,7 +2651,7 @@
 				3811DE1825C9D40400A708ED /* Router.swift in Sources */,
 				CE7950262998056D00FA576E /* CGMSetupView.swift in Sources */,
 				38A0363B25ECF07E00FCBB52 /* GlucoseStorage.swift in Sources */,
-				65070A332BFDCB83006F213F /* TidePoolStartView.swift in Sources */,
+				65070A332BFDCB83006F213F /* TidepoolStartView.swift in Sources */,
 				190EBCC629FF138000BA767D /* StatConfigProvider.swift in Sources */,
 				38E98A2725F52C9300C0CED0 /* CollectionIssueReporter.swift in Sources */,
 				E00EEC0427368630002FF094 /* SecurityAssembly.swift in Sources */,
@@ -2665,7 +2665,7 @@
 				38569347270B5DFB0002C50D /* CGMType.swift in Sources */,
 				3821ED4C25DD18BA00BC42AD /* Constants.swift in Sources */,
 				384E803425C385E60086DB71 /* JavaScriptWorker.swift in Sources */,
-				CE1F6DE92BAF37C90064EB8D /* TidePoolConfigView.swift in Sources */,
+				CE1F6DE92BAF37C90064EB8D /* TidepoolConfigView.swift in Sources */,
 				3811DE5D25C9D4D500A708ED /* Publisher.swift in Sources */,
 				E00EEC0727368630002FF094 /* APSAssembly.swift in Sources */,
 				38B4F3AF25E2979F00E76A18 /* IndexedCollection.swift in Sources */,

--- a/FreeAPS/Sources/APS/FetchGlucoseManager.swift
+++ b/FreeAPS/Sources/APS/FetchGlucoseManager.swift
@@ -30,7 +30,7 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
     private let processQueue = DispatchQueue(label: "BaseGlucoseManager.processQueue")
     @Injected() var glucoseStorage: GlucoseStorage!
     @Injected() var nightscoutManager: NightscoutManager!
-    @Injected() var tidePoolService: TidePoolManager!
+    @Injected() var tidepoolService: TidepoolManager!
     @Injected() var apsManager: APSManager!
     @Injected() var settingsManager: SettingsManager!
     @Injected() var healthKitManager: HealthKitManager!
@@ -235,7 +235,7 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
         deviceDataManager.heartbeat(date: Date())
 
         nightscoutManager.uploadGlucose()
-        tidePoolService.uploadGlucose(device: cgmManager?.cgmManagerStatus.device)
+        tidepoolService.uploadGlucose(device: cgmManager?.cgmManagerStatus.device)
 
         let glucoseForHealth = filteredByDate.filter { !glucoseFromHealth.contains($0) }
 

--- a/FreeAPS/Sources/Assemblies/NetworkAssembly.swift
+++ b/FreeAPS/Sources/Assemblies/NetworkAssembly.swift
@@ -8,6 +8,6 @@ final class NetworkAssembly: Assembly {
         }
 
         container.register(NightscoutManager.self) { r in BaseNightscoutManager(resolver: r) }
-        container.register(TidePoolManager.self) { r in BaseTidePoolManager(resolver: r) }
+        container.register(TidepoolManager.self) { r in BaseTidepoolManager(resolver: r) }
     }
 }

--- a/FreeAPS/Sources/Modules/DataTable/DataTableProvider.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableProvider.swift
@@ -8,7 +8,7 @@ extension DataTable {
         @Injected() var carbsStorage: CarbsStorage!
         @Injected() var nightscoutManager: NightscoutManager!
         @Injected() var healthkitManager: HealthKitManager!
-        @Injected() var tidePoolManager: TidePoolManager!
+        @Injected() var tidepoolManager: TidepoolManager!
 
         func pumpHistory() -> [PumpHistoryEvent] {
             pumpHistoryStorage.recent()
@@ -33,10 +33,10 @@ extension DataTable {
         }
 
         func deleteCarbs(_ treatement: Treatment) {
-            // need to start with tidePool because Nightscout delete data
+            // need to start with tidepool because Nightscout delete data
             // probably to revise the logic
             // TODO:
-            tidePoolManager.deleteCarbs(
+            tidepoolManager.deleteCarbs(
                 at: treatement.date,
                 isFPU: treatement.isFPU,
                 fpuID: treatement.fpuID,
@@ -52,8 +52,8 @@ extension DataTable {
         }
 
         func deleteInsulin(_ treatement: Treatment) {
-            // delete tidePoolManager before NS - TODO
-            tidePoolManager.deleteInsulin(at: treatement.date)
+            // delete tidepoolManager before NS - TODO
+            tidepoolManager.deleteInsulin(at: treatement.date)
             nightscoutManager.deleteInsulin(at: treatement.date)
             if let id = treatement.idPumpEvent {
                 healthkitManager.deleteInsulin(syncID: id)

--- a/FreeAPS/Sources/Modules/Settings/SettingsProvider.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsProvider.swift
@@ -1,5 +1,5 @@
 extension Settings {
     final class Provider: BaseProvider, SettingsProvider {
-        @Injected() var tidePoolManager: TidePoolManager!
+        @Injected() var tidepoolManager: TidepoolManager!
     }
 }

--- a/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
@@ -14,7 +14,7 @@ extension Settings {
         @Published var debugOptions = false
         @Published var animatedBackground = false
         @Published var serviceUIType: ServiceUI.Type?
-        @Published var setupTidePool = false
+        @Published var setupTidepool = false
 
         private(set) var buildNumber = ""
         private(set) var versionNumber = ""
@@ -75,7 +75,7 @@ extension Settings.StateModel: SettingsObserver {
 extension Settings.StateModel: ServiceOnboardingDelegate {
     func serviceOnboarding(didCreateService service: Service) {
         debug(.nightscout, "Service with identifier \(service.pluginIdentifier) created")
-        provider.tidePoolManager.addTidePoolService(service: service)
+        provider.tidepoolManager.addTidepoolService(service: service)
     }
 
     func serviceOnboarding(didOnboardService service: Service) {
@@ -86,7 +86,7 @@ extension Settings.StateModel: ServiceOnboardingDelegate {
 
 extension Settings.StateModel: CompletionDelegate {
     func completionNotifyingDidComplete(_: CompletionNotifying) {
-        setupTidePool = false
-        provider.tidePoolManager.forceUploadData(device: fetchCgmManager.cgmManager?.cgmManagerStatus.device)
+        setupTidepool = false
+        provider.tidepoolManager.forceUploadData(device: fetchCgmManager.cgmManager?.cgmManagerStatus.device)
     }
 }

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -29,7 +29,7 @@ extension Settings {
                 Section {
                     Text("Nightscout").navigationLink(to: .nighscoutConfig, from: self)
 
-                    NavigationLink(destination: TidePoolStartView(state: state)) {
+                    NavigationLink(destination: TidepoolStartView(state: state)) {
                         Text("Tidepool")
                     }
                     if HKHealthStore.isHealthDataAvailable() {

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -29,10 +29,9 @@ extension Settings {
                 Section {
                     Text("Nightscout").navigationLink(to: .nighscoutConfig, from: self)
 
-                    Text("TidePool")
-                        .onTapGesture {
-                            state.setupTidePool = true
-                        }
+                    NavigationLink(destination: TidePoolStartView(state: state)) {
+                        Text("Tidepool")
+                    }
                     if HKHealthStore.isHealthDataAvailable() {
                         Text("Apple Health").navigationLink(to: .healthkit, from: self)
                     }
@@ -129,26 +128,6 @@ extension Settings {
             }
             .sheet(isPresented: $showShareSheet) {
                 ShareSheet(activityItems: state.logItems())
-            }
-            .sheet(isPresented: $state.setupTidePool) {
-                if let serviceUIType = state.serviceUIType,
-                   let pluginHost = state.provider.tidePoolManager.getTidePoolPluginHost()
-                {
-                    if let serviceUI = state.provider.tidePoolManager.getTidePoolServiceUI() {
-                        TidePoolSettingsView(
-                            serviceUI: serviceUI,
-                            serviceOnBoardDelegate: self.state,
-                            serviceDelegate: self.state
-                        )
-                    } else {
-                        TidePoolSetupView(
-                            serviceUIType: serviceUIType,
-                            pluginHost: pluginHost,
-                            serviceOnBoardDelegate: self.state,
-                            serviceDelegate: self.state
-                        )
-                    }
-                }
             }
             .onAppear(perform: configureView)
             .navigationTitle("Settings")

--- a/FreeAPS/Sources/Modules/Settings/View/TidePoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidePoolStartView.swift
@@ -7,13 +7,11 @@ struct TidePoolStartView: View {
     var body: some View {
         Form {
             Section {
-                Text("Tidepool")
+                Text("Connect to Tidepool")
                     .onTapGesture {
                         state.setupTidePool = true
                     }
 
-            } header: {
-                Text("Connect to Tidepool")
             } footer: {
                 Text(
                     "When connected, uploading of carbs, bolus, basal and glucose from Trio to your Tidepool account is enabled. \n\nUse your Tidepool credentials to login. If you dont already have a Tidepool account, you can sign up for one on the login page."

--- a/FreeAPS/Sources/Modules/Settings/View/TidePoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidePoolStartView.swift
@@ -1,0 +1,45 @@
+
+import SwiftUI
+
+struct TidePoolStartView: View {
+    @ObservedObject var state: Settings.StateModel
+
+    var body: some View {
+        Form {
+            Section {
+                Text("Tidepool")
+                    .onTapGesture {
+                        state.setupTidePool = true
+                    }
+
+            } header: {
+                Text("Connect to Tidepool")
+            } footer: {
+                Text(
+                    "When connected, uploading of carbs, bolus, basal and glucose from Trio to your Tidepool account is enabled. \n\nUse your Tidepool credentials to login. If you dont already have a Tidepool account, you can sign up for one on the login page."
+                )
+            }
+        }
+        .sheet(isPresented: $state.setupTidePool) {
+            if let serviceUIType = state.serviceUIType,
+               let pluginHost = state.provider.tidePoolManager.getTidePoolPluginHost()
+            {
+                if let serviceUI = state.provider.tidePoolManager.getTidePoolServiceUI() {
+                    TidePoolSettingsView(
+                        serviceUI: serviceUI,
+                        serviceOnBoardDelegate: self.state,
+                        serviceDelegate: self.state
+                    )
+                } else {
+                    TidePoolSetupView(
+                        serviceUIType: serviceUIType,
+                        pluginHost: pluginHost,
+                        serviceOnBoardDelegate: self.state,
+                        serviceDelegate: self.state
+                    )
+                }
+            }
+        }
+        .navigationTitle("Tidepool")
+    }
+}

--- a/FreeAPS/Sources/Modules/Settings/View/TidepoolConfigView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidepoolConfigView.swift
@@ -3,13 +3,13 @@ import LoopKit
 import LoopKitUI
 import SwiftUI
 
-struct TidePoolSetupView: UIViewControllerRepresentable {
+struct TidepoolSetupView: UIViewControllerRepresentable {
     let serviceUIType: ServiceUI.Type
     let pluginHost: PluginHost
     let serviceOnBoardDelegate: ServiceOnboardingDelegate
     let serviceDelegate: CompletionDelegate
 
-    func makeUIViewController(context _: UIViewControllerRepresentableContext<TidePoolSetupView>) -> UIViewController {
+    func makeUIViewController(context _: UIViewControllerRepresentableContext<TidepoolSetupView>) -> UIViewController {
         let result = serviceUIType.setupViewController(
             colorPalette: .default,
             pluginHost: pluginHost
@@ -26,20 +26,20 @@ struct TidePoolSetupView: UIViewControllerRepresentable {
         }
     }
 
-    func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<TidePoolSetupView>) {}
+    func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<TidepoolSetupView>) {}
 }
 
-struct TidePoolSettingsView: UIViewControllerRepresentable {
+struct TidepoolSettingsView: UIViewControllerRepresentable {
     let serviceUI: ServiceUI
     let serviceOnBoardDelegate: ServiceOnboardingDelegate
     let serviceDelegate: CompletionDelegate?
 
-    func makeUIViewController(context _: UIViewControllerRepresentableContext<TidePoolSettingsView>) -> UIViewController {
+    func makeUIViewController(context _: UIViewControllerRepresentableContext<TidepoolSettingsView>) -> UIViewController {
         var vc = serviceUI.settingsViewController(colorPalette: .default)
         vc.completionDelegate = serviceDelegate
         vc.serviceOnboardingDelegate = serviceOnBoardDelegate
         return vc
     }
 
-    func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<TidePoolSettingsView>) {}
+    func updateUIViewController(_: UIViewController, context _: UIViewControllerRepresentableContext<TidepoolSettingsView>) {}
 }

--- a/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
@@ -6,38 +6,41 @@ struct TidepoolStartView: View {
 
     var body: some View {
         Form {
-            Section {
-                Text("Connect to Tidepool")
-                    .onTapGesture {
-                        state.setupTidepool = true
-                    }
-
-            } footer: {
-                Text(
-                    "When connected, uploading of carbs, bolus, basal and glucose from Trio to your Tidepool account is enabled. \n\nUse your Tidepool credentials to login. If you dont already have a Tidepool account, you can sign up for one on the login page."
-                )
-            }
-        }
-        .sheet(isPresented: $state.setupTidepool) {
-            if let serviceUIType = state.serviceUIType,
-               let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
-            {
-                if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
-                    TidepoolSettingsView(
-                        serviceUI: serviceUI,
-                        serviceOnBoardDelegate: self.state,
-                        serviceDelegate: self.state
+            Section(
+                header: Text("Connect to Tidepool"),
+                footer: VStack(alignment: .leading, spacing: 2) {
+                    Text(
+                        "When connected, uploading of carbs, bolus, basal and glucose from Trio to your Tidepool account is enabled."
                     )
-                } else {
-                    TidepoolSetupView(
-                        serviceUIType: serviceUIType,
-                        pluginHost: pluginHost,
-                        serviceOnBoardDelegate: self.state,
-                        serviceDelegate: self.state
+                    Text(
+                        "\nUse your Tidepool credentials to login. If you dont already have a Tidepool account, you can sign up for one on the login page."
                     )
                 }
-            }
+            )
+                {
+                    Button("Connect to Tidepool") { state.setupTidepool = true }
+                }
+                .sheet(isPresented: $state.setupTidepool) {
+                    if let serviceUIType = state.serviceUIType,
+                       let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
+                    {
+                        if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
+                            TidepoolSettingsView(
+                                serviceUI: serviceUI,
+                                serviceOnBoardDelegate: self.state,
+                                serviceDelegate: self.state
+                            )
+                        } else {
+                            TidepoolSetupView(
+                                serviceUIType: serviceUIType,
+                                pluginHost: pluginHost,
+                                serviceOnBoardDelegate: self.state,
+                                serviceDelegate: self.state
+                            )
+                        }
+                    }
+                }
+                .navigationTitle("Tidepool")
         }
-        .navigationTitle("Tidepool")
     }
 }

--- a/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
@@ -1,7 +1,7 @@
 
 import SwiftUI
 
-struct TidePoolStartView: View {
+struct TidepoolStartView: View {
     @ObservedObject var state: Settings.StateModel
 
     var body: some View {
@@ -9,7 +9,7 @@ struct TidePoolStartView: View {
             Section {
                 Text("Connect to Tidepool")
                     .onTapGesture {
-                        state.setupTidePool = true
+                        state.setupTidepool = true
                     }
 
             } footer: {
@@ -18,18 +18,18 @@ struct TidePoolStartView: View {
                 )
             }
         }
-        .sheet(isPresented: $state.setupTidePool) {
+        .sheet(isPresented: $state.setupTidepool) {
             if let serviceUIType = state.serviceUIType,
-               let pluginHost = state.provider.tidePoolManager.getTidePoolPluginHost()
+               let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
             {
-                if let serviceUI = state.provider.tidePoolManager.getTidePoolServiceUI() {
-                    TidePoolSettingsView(
+                if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
+                    TidepoolSettingsView(
                         serviceUI: serviceUI,
                         serviceOnBoardDelegate: self.state,
                         serviceDelegate: self.state
                     )
                 } else {
-                    TidePoolSetupView(
+                    TidepoolSetupView(
                         serviceUIType: serviceUIType,
                         pluginHost: pluginHost,
                         serviceOnBoardDelegate: self.state,

--- a/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/TidepoolStartView.swift
@@ -20,27 +20,27 @@ struct TidepoolStartView: View {
                 {
                     Button("Connect to Tidepool") { state.setupTidepool = true }
                 }
-                .sheet(isPresented: $state.setupTidepool) {
-                    if let serviceUIType = state.serviceUIType,
-                       let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
-                    {
-                        if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
-                            TidepoolSettingsView(
-                                serviceUI: serviceUI,
-                                serviceOnBoardDelegate: self.state,
-                                serviceDelegate: self.state
-                            )
-                        } else {
-                            TidepoolSetupView(
-                                serviceUIType: serviceUIType,
-                                pluginHost: pluginHost,
-                                serviceOnBoardDelegate: self.state,
-                                serviceDelegate: self.state
-                            )
-                        }
-                    }
-                }
                 .navigationTitle("Tidepool")
+        }
+        .sheet(isPresented: $state.setupTidepool) {
+            if let serviceUIType = state.serviceUIType,
+               let pluginHost = state.provider.tidepoolManager.getTidepoolPluginHost()
+            {
+                if let serviceUI = state.provider.tidepoolManager.getTidepoolServiceUI() {
+                    TidepoolSettingsView(
+                        serviceUI: serviceUI,
+                        serviceOnBoardDelegate: self.state,
+                        serviceDelegate: self.state
+                    )
+                } else {
+                    TidepoolSetupView(
+                        serviceUIType: serviceUIType,
+                        pluginHost: pluginHost,
+                        serviceOnBoardDelegate: self.state,
+                        serviceDelegate: self.state
+                    )
+                }
+            }
         }
     }
 }

--- a/FreeAPS/Sources/Services/Network/TidepoolManager.swift
+++ b/FreeAPS/Sources/Services/Network/TidepoolManager.swift
@@ -54,7 +54,7 @@ final class BaseTidepoolManager: TidepoolManager, Injectable {
         }
     }
 
-    /// allows to acces to tidepoolService as a simple ServiceUI
+    /// allows access to tidepoolService as a simple ServiceUI
     func getTidepoolServiceUI() -> ServiceUI? {
         if let tidepoolService = self.tidepoolService {
             return tidepoolService as! any ServiceUI as ServiceUI

--- a/FreeAPS/Sources/Services/Network/TidepoolManager.swift
+++ b/FreeAPS/Sources/Services/Network/TidepoolManager.swift
@@ -5,10 +5,10 @@ import LoopKit
 import LoopKitUI
 import Swinject
 
-protocol TidePoolManager {
-    func addTidePoolService(service: Service)
-    func getTidePoolServiceUI() -> ServiceUI?
-    func getTidePoolPluginHost() -> PluginHost?
+protocol TidepoolManager {
+    func addTidepoolService(service: Service)
+    func getTidepoolServiceUI() -> ServiceUI?
+    func getTidepoolPluginHost() -> PluginHost?
     func deleteCarbs(at date: Date, isFPU: Bool?, fpuID: String?, syncID: String)
     func deleteInsulin(at date: Date)
 //    func uploadStatus()
@@ -18,7 +18,7 @@ protocol TidePoolManager {
 //    func uploadProfileAndSettings(_: Bool)
 }
 
-final class BaseTidePoolManager: TidePoolManager, Injectable {
+final class BaseTidepoolManager: TidepoolManager, Injectable {
     @Injected() private var broadcaster: Broadcaster!
     @Injected() private var pluginManager: PluginManager!
     @Injected() private var glucoseStorage: GlucoseStorage!
@@ -27,53 +27,53 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     @Injected() private var pumpHistoryStorage: PumpHistoryStorage!
 
     private let processQueue = DispatchQueue(label: "BaseNetworkManager.processQueue")
-    private var tidePoolService: RemoteDataService? {
+    private var tidepoolService: RemoteDataService? {
         didSet {
-            if let tidePoolService = tidePoolService {
-                rawTidePoolManager = tidePoolService.rawValue
+            if let tidepoolService = tidepoolService {
+                rawTidepoolManager = tidepoolService.rawValue
             } else {
-                rawTidePoolManager = nil
+                rawTidepoolManager = nil
             }
         }
     }
 
-    @PersistedProperty(key: "TidePoolState") var rawTidePoolManager: Service.RawValue?
+    @PersistedProperty(key: "TidepoolState") var rawTidepoolManager: Service.RawValue?
 
     init(resolver: Resolver) {
         injectServices(resolver)
-        loadTidePoolManager()
+        loadTidepoolManager()
         subscribe()
     }
 
-    /// load the TidePool Remote Data Service if available
-    fileprivate func loadTidePoolManager() {
-        if let rawTidePoolManager = rawTidePoolManager {
-            tidePoolService = tidePoolServiceFromRaw(rawTidePoolManager)
-            tidePoolService?.serviceDelegate = self
-            tidePoolService?.stateDelegate = self
+    /// load the Tidepool Remote Data Service if available
+    fileprivate func loadTidepoolManager() {
+        if let rawTidepoolManager = rawTidepoolManager {
+            tidepoolService = tidepoolServiceFromRaw(rawTidepoolManager)
+            tidepoolService?.serviceDelegate = self
+            tidepoolService?.stateDelegate = self
         }
     }
 
-    /// allows to acces to tidePoolService as a simple ServiceUI
-    func getTidePoolServiceUI() -> ServiceUI? {
-        if let tidePoolService = self.tidePoolService {
-            return tidePoolService as! any ServiceUI as ServiceUI
+    /// allows to acces to tidepoolService as a simple ServiceUI
+    func getTidepoolServiceUI() -> ServiceUI? {
+        if let tidepoolService = self.tidepoolService {
+            return tidepoolService as! any ServiceUI as ServiceUI
         } else {
             return nil
         }
     }
 
-    /// get the pluginHost of TidePool
-    func getTidePoolPluginHost() -> PluginHost? {
+    /// get the pluginHost of Tidepool
+    func getTidepoolPluginHost() -> PluginHost? {
         self as PluginHost
     }
 
-    func addTidePoolService(service: Service) {
-        tidePoolService = service as! any RemoteDataService as RemoteDataService
+    func addTidepoolService(service: Service) {
+        tidepoolService = service as! any RemoteDataService as RemoteDataService
     }
 
-    /// load the TidePool Remote Data Service from raw storage
-    private func tidePoolServiceFromRaw(_ rawValue: [String: Any]) -> RemoteDataService? {
+    /// load the Tidepool Remote Data Service from raw storage
+    private func tidepoolServiceFromRaw(_ rawValue: [String: Any]) -> RemoteDataService? {
         guard let rawState = rawValue["state"] as? Service.RawStateValue,
               let serviceType = pluginManager.getServiceTypeByIdentifier("TidepoolService")
         else {
@@ -97,15 +97,15 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     func uploadCarbs() {
         let carbs: [CarbsEntry] = carbsStorage.recent()
 
-        guard !carbs.isEmpty, let tidePoolService = self.tidePoolService else { return }
+        guard !carbs.isEmpty, let tidepoolService = self.tidepoolService else { return }
 
         processQueue.async {
-            carbs.chunks(ofCount: tidePoolService.carbDataLimit ?? 100).forEach { chunk in
+            carbs.chunks(ofCount: tidepoolService.carbDataLimit ?? 100).forEach { chunk in
 
                 let syncCarb: [SyncCarbObject] = Array(chunk).map {
                     $0.convertSyncCarb()
                 }
-                tidePoolService.uploadCarbData(created: syncCarb, updated: [], deleted: []) { result in
+                tidepoolService.uploadCarbData(created: syncCarb, updated: [], deleted: []) { result in
                     switch result {
                     case let .failure(error):
                         debug(.nightscout, "Error synchronizing carbs data: \(String(describing: error))")
@@ -118,7 +118,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     }
 
     func deleteCarbs(at date: Date, isFPU: Bool?, fpuID: String?, syncID _: String) {
-        guard let tidePoolService = self.tidePoolService else { return }
+        guard let tidepoolService = self.tidepoolService else { return }
 
         processQueue.async {
             var carbsToDelete: [CarbsEntry] = []
@@ -135,7 +135,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
                 d.convertSyncCarb(operation: .delete)
             }
 
-            tidePoolService.uploadCarbData(created: [], updated: [], deleted: syncCarb) { result in
+            tidepoolService.uploadCarbData(created: [], updated: [], deleted: syncCarb) { result in
                 switch result {
                 case let .failure(error):
                     debug(.nightscout, "Error synchronizing carbs data: \(String(describing: error))")
@@ -149,7 +149,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     func deleteInsulin(at d: Date) {
         let allValues = storage.retrieve(OpenAPS.Monitor.pumpHistory, as: [PumpHistoryEvent].self) ?? []
 
-        guard !allValues.isEmpty, let tidePoolService = self.tidePoolService else { return }
+        guard !allValues.isEmpty, let tidepoolService = self.tidepoolService else { return }
 
         var doseDataToDelete: [DoseEntry] = []
 
@@ -166,7 +166,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
             ))
 
         processQueue.async {
-            tidePoolService.uploadDoseData(created: [], deleted: doseDataToDelete) { result in
+            tidepoolService.uploadDoseData(created: [], deleted: doseDataToDelete) { result in
                 switch result {
                 case let .failure(error):
                     debug(.nightscout, "Error synchronizing Dose delete data: \(String(describing: error))")
@@ -179,7 +179,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
 
     func uploadDose() {
         let events = pumpHistoryStorage.recent()
-        guard !events.isEmpty, let tidePoolService = self.tidePoolService else { return }
+        guard !events.isEmpty, let tidepoolService = self.tidepoolService else { return }
 
         let eventsBasal = events.filter { $0.type == .tempBasal || $0.type == .tempBasalDuration }
             .sorted { $0.timestamp < $1.timestamp }
@@ -297,7 +297,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
         }
 
         processQueue.async {
-            tidePoolService.uploadDoseData(created: doseDataBasal + boluses, deleted: []) { result in
+            tidepoolService.uploadDoseData(created: doseDataBasal + boluses, deleted: []) { result in
                 switch result {
                 case let .failure(error):
                     debug(.nightscout, "Error synchronizing Dose data: \(String(describing: error))")
@@ -306,7 +306,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
                 }
             }
 
-            tidePoolService.uploadPumpEventData(pumpEvents) { result in
+            tidepoolService.uploadPumpEventData(pumpEvents) { result in
                 switch result {
                 case let .failure(error):
                     debug(.nightscout, "Error synchronizing Pump Event data: \(String(describing: error))")
@@ -320,19 +320,19 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     func uploadGlucose(device: HKDevice?) {
         let glucose: [BloodGlucose] = glucoseStorage.recent()
 
-        guard !glucose.isEmpty, let tidePoolService = self.tidePoolService else { return }
+        guard !glucose.isEmpty, let tidepoolService = self.tidepoolService else { return }
 
         let glucoseWithoutCorrectID = glucose.filter { UUID(uuidString: $0._id) != nil }
 
         processQueue.async {
-            glucoseWithoutCorrectID.chunks(ofCount: tidePoolService.glucoseDataLimit ?? 100)
+            glucoseWithoutCorrectID.chunks(ofCount: tidepoolService.glucoseDataLimit ?? 100)
                 .forEach { chunk in
                     // all glucose attached with the current device ;-(
 
                     let chunkStoreGlucose = Array(chunk).map {
                         $0.convertStoredGlucoseSample(device: device)
                     }
-                    tidePoolService.uploadGlucoseData(chunkStoreGlucose) { result in
+                    tidepoolService.uploadGlucoseData(chunkStoreGlucose) { result in
                         switch result {
                         case let .failure(error):
                             debug(.nightscout, "Error synchronizing glucose data: \(String(describing: error))")
@@ -345,7 +345,7 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
         }
     }
 
-    /// force to uploads all data in TidePool Service
+    /// force to uploads all data in Tidepool Service
     func forceUploadData(device: HKDevice?) {
         uploadDose()
         uploadCarbs()
@@ -353,23 +353,23 @@ final class BaseTidePoolManager: TidePoolManager, Injectable {
     }
 }
 
-extension BaseTidePoolManager: PumpHistoryObserver {
+extension BaseTidepoolManager: PumpHistoryObserver {
     func pumpHistoryDidUpdate(_: [PumpHistoryEvent]) {
         uploadDose()
     }
 }
 
-extension BaseTidePoolManager: CarbsObserver {
+extension BaseTidepoolManager: CarbsObserver {
     func carbsDidUpdate(_: [CarbsEntry]) {
         uploadCarbs()
     }
 }
 
-extension BaseTidePoolManager: TempTargetsObserver {
+extension BaseTidepoolManager: TempTargetsObserver {
     func tempTargetsDidUpdate(_: [TempTarget]) {}
 }
 
-extension BaseTidePoolManager: ServiceDelegate {
+extension BaseTidepoolManager: ServiceDelegate {
     var hostIdentifier: String {
         "com.loopkit.Loop" // To check
     }
@@ -404,11 +404,11 @@ extension BaseTidePoolManager: ServiceDelegate {
     func deliverRemoteBolus(amountInUnits _: Double) async throws {}
 }
 
-extension BaseTidePoolManager: StatefulPluggableDelegate {
+extension BaseTidepoolManager: StatefulPluggableDelegate {
     func pluginDidUpdateState(_: LoopKit.StatefulPluggable) {}
 
     func pluginWantsDeletion(_: LoopKit.StatefulPluggable) {
-        tidePoolService = nil
+        tidepoolService = nil
     }
 }
 


### PR DESCRIPTION
- One more click to reach the service, but
- Added chevron in settings list (for consistency)
- Added room for information/explainations of the setting in header/footer in the new view
- First draft to build on (maybe: rephrase header/footer, add connection status in navigation view, other relevant info etc)
- Change TidePool to Tidepool

**Demo of PR implementation:**

https://github.com/nightscout/Trio/assets/72826201/28b50e36-f08b-4486-9623-b58257a0e6f0


**Settings navigation before change (missing chevron)**
![image0](https://github.com/nightscout/Trio/assets/72826201/ea292463-b18a-4132-b53b-79fa5c1b6ef2)
