### PR TITLE
Reset profile override name textbox after saving

### DIFF
--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
@@ -87,6 +87,7 @@ extension OverrideProfilesConfig {
                 saveOverride.percentage = self.percentage
                 saveOverride.smbIsOff = self.smbIsOff
                 saveOverride.name = self.profileName
+                self.profileName = ""
                 id = UUID().uuidString
                 self.isPreset.toggle()
                 saveOverride.id = id


### PR DESCRIPTION
Proposed solution for #229 

Tested in a simulator and on a spare iPhone.