### PR TITLE
Added ability to add min and max values to decimals in preferences page

### DIFF
--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorDataFlow.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorDataFlow.swift
@@ -11,7 +11,7 @@ enum PreferencesEditor {
 
     enum FieldType {
         case boolean(keypath: WritableKeyPath<Preferences, Bool>)
-        case decimal(keypath: WritableKeyPath<Preferences, Decimal>)
+        case decimal(keypath: WritableKeyPath<Preferences, Decimal>, minVal: Decimal? = nil, maxVal: Decimal? = nil)
         case insulinCurve(keypath: WritableKeyPath<Preferences, InsulinCurve>)
     }
 
@@ -34,7 +34,7 @@ enum PreferencesEditor {
         var decimalValue: Decimal {
             get {
                 switch type {
-                case let .decimal(keypath):
+                case let .decimal(keypath, _, _):
                     return settable?.get(keypath) ?? 0
                 default: return 0
                 }
@@ -57,8 +57,18 @@ enum PreferencesEditor {
             switch (type, value) {
             case let (.boolean(keypath), value as Bool):
                 settable?.set(keypath, value: value)
-            case let (.decimal(keypath), value as Decimal):
-                settable?.set(keypath, value: value)
+            case let (.decimal(keypath, minVal, maxVal), value as Decimal):
+                let constrainedValue: Decimal
+                if let minValue = minVal, let maxValue = maxVal {
+                    constrainedValue = min(max(value, minValue), maxValue)
+                } else if let minValue = minVal {
+                    constrainedValue = max(value, minValue)
+                } else if let maxValue = maxVal {
+                    constrainedValue = min(value, maxValue)
+                } else {
+                    constrainedValue = value
+                }
+                settable?.set(keypath, value: constrainedValue)
             case let (.insulinCurve(keypath), value as InsulinCurve):
                 settable?.set(keypath, value: value)
             default: break

--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorDataFlow.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorDataFlow.swift
@@ -11,7 +11,11 @@ enum PreferencesEditor {
 
     enum FieldType {
         case boolean(keypath: WritableKeyPath<Preferences, Bool>)
-        case decimal(keypath: WritableKeyPath<Preferences, Decimal>, minVal: Decimal? = nil, maxVal: Decimal? = nil)
+        case decimal(
+            keypath: WritableKeyPath<Preferences, Decimal>,
+            minVal: WritableKeyPath<Preferences, Decimal>? = nil,
+            maxVal: WritableKeyPath<Preferences, Decimal>? = nil
+        )
         case insulinCurve(keypath: WritableKeyPath<Preferences, InsulinCurve>)
     }
 
@@ -59,12 +63,12 @@ enum PreferencesEditor {
                 settable?.set(keypath, value: value)
             case let (.decimal(keypath, minVal, maxVal), value as Decimal):
                 let constrainedValue: Decimal
-                if let minValue = minVal, let maxValue = maxVal {
-                    constrainedValue = min(max(value, minValue), maxValue)
-                } else if let minValue = minVal {
-                    constrainedValue = max(value, minValue)
-                } else if let maxValue = maxVal {
-                    constrainedValue = min(value, maxValue)
+                if let minValue = minVal, let minValueDecimal: Decimal = settable?.get(minValue), let maxValue = maxVal, let maxValueDecimal: Decimal = settable?.get(maxValue) {
+                    constrainedValue = min(max(value, minValueDecimal), maxValueDecimal)
+                } else if let minValue = minVal, let minValueDecimal: Decimal = settable?.get(minValue) {
+                    constrainedValue = max(value, minValueDecimal)
+                } else if let maxValue = maxVal, let maxValueDecimal: Decimal = settable?.get(maxValue) {
+                    constrainedValue = min(value, maxValueDecimal)
                 } else {
                     constrainedValue = value
                 }

--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
@@ -443,7 +443,7 @@ extension PreferencesEditor {
                 ),
                 Field(
                     displayName: NSLocalizedString("Remaining Carbs Cap", comment: "Remaining Carbs Cap"),
-                    type: .decimal(keypath: \.remainingCarbsCap),
+                    type: .decimal(keypath: \.remainingCarbsCap, minVal: 90),
                     infoText: NSLocalizedString(
                         "This is the amount of the maximum number of carbs we’ll assume will absorb over 4h if we don’t yet see carb absorption.",
                         comment: "Remaining Carbs Cap"

--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
@@ -443,7 +443,7 @@ extension PreferencesEditor {
                 ),
                 Field(
                     displayName: NSLocalizedString("Remaining Carbs Cap", comment: "Remaining Carbs Cap"),
-                    type: .decimal(keypath: \.remainingCarbsCap, minVal: 90),
+                    type: .decimal(keypath: \.remainingCarbsCap),
                     infoText: NSLocalizedString(
                         "This is the amount of the maximum number of carbs we’ll assume will absorb over 4h if we don’t yet see carb absorption.",
                         comment: "Remaining Carbs Cap"


### PR DESCRIPTION
Closes #189 

I've made it so that remaining carbs cap will not go less than 90 based on the docs. I've also added the functionality to set constraints to values (any safety setting we decide on in the future). 