### PR TITLE
Enable editing of preset profile overrides

### DIFF
--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
@@ -248,5 +248,25 @@ extension OverrideProfilesConfig {
             smbMinutes = defaultSmbMinutes
             uamMinutes = defaultUamMinutes
         }
+
+        func updatePreset(_ preset: OverridePresets) {
+            let context = CoreDataStack.shared.persistentContainer.viewContext
+            context.performAndWait {
+                preset.name = profileName
+                preset.percentage = percentage
+                preset.duration = NSDecimalNumber(decimal: duration)
+                preset.target = override_target ? NSDecimalNumber(decimal: target) : nil
+                preset.indefinite = _indefinite
+                preset.advancedSettings = advancedSettings
+                preset.smbIsOff = smbIsOff
+                preset.smbIsScheduledOff = smbIsScheduledOff
+                preset.isf = isf
+                preset.cr = cr
+                preset.smbMinutes = NSDecimalNumber(decimal: smbMinutes)
+                preset.uamMinutes = NSDecimalNumber(decimal: uamMinutes)
+                preset.isfAndCr = isfAndCr
+                try? context.save()
+            }
+        }
     }
 }

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
@@ -29,6 +29,24 @@ extension OverrideProfilesConfig {
 
         var units: GlucoseUnits = .mmolL
 
+        private var formatter: NumberFormatter {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 0
+            return formatter
+        }
+
+        private var glucoseFormatter: NumberFormatter {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 0
+            if units == .mmolL {
+                formatter.maximumFractionDigits = 1
+            }
+            formatter.roundingMode = .halfUp
+            return formatter
+        }
+
         override func subscribe() {
             units = settingsManager.settings.units
             defaultSmbMinutes = settingsManager.preferences.maxSMBBasalMinutes
@@ -37,6 +55,59 @@ extension OverrideProfilesConfig {
         }
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
+
+        struct ProfileViewData {
+            let target: Decimal
+            let duration: Decimal
+            let name: String
+            let percent: Double
+            let perpetual: Bool
+            let durationString: String
+            let scheduledSMBString: String
+            let smbString: String
+            let targetString: String
+            let maxMinutesSMB: Decimal
+            let maxMinutesUAM: Decimal
+            let isfString: String
+            let crString: String
+            let isfAndCRString: String
+        }
+
+        func profileViewData(for preset: OverridePresets) -> ProfileViewData {
+            let target = units == .mmolL ? (((preset.target ?? 0) as NSDecimalNumber) as Decimal)
+                .asMmolL : (preset.target ?? 0) as Decimal
+            let duration = (preset.duration ?? 0) as Decimal
+            let name = ((preset.name ?? "") == "") || (preset.name?.isEmpty ?? true) ? "" : preset.name!
+            let percent = preset.percentage / 100
+            let perpetual = preset.indefinite
+            let durationString = perpetual ? "" : "\(formatter.string(from: duration as NSNumber)!)"
+            let scheduledSMBString = (preset.smbIsOff && preset.smbIsScheduledOff) ? "Scheduled SMBs" : ""
+            let smbString = (preset.smbIsOff && scheduledSMBString == "") ? "SMBs are off" : ""
+            let targetString = target != 0 ? "\(glucoseFormatter.string(from: target as NSNumber)!)" : ""
+            let maxMinutesSMB = (preset.smbMinutes as Decimal?) != nil ? (preset.smbMinutes ?? 0) as Decimal : 0
+            let maxMinutesUAM = (preset.uamMinutes as Decimal?) != nil ? (preset.uamMinutes ?? 0) as Decimal : 0
+            let isfString = preset.isf ? "ISF" : ""
+            let crString = preset.cr ? "CR" : ""
+            let dash = crString != "" ? "/" : ""
+            let isfAndCRString = isfString + dash + crString
+
+            return ProfileViewData(
+                target: target,
+                duration: duration,
+                name: name,
+                percent: percent,
+                perpetual: perpetual,
+                durationString: durationString,
+                scheduledSMBString: scheduledSMBString,
+                smbString: smbString,
+                targetString: targetString,
+                maxMinutesSMB: maxMinutesSMB,
+                maxMinutesUAM: maxMinutesUAM,
+                isfString: isfString,
+                crString: crString,
+                isfAndCRString: isfAndCRString
+            )
+        }
 
         func saveSettings() {
             coredataContext.perform { [self] in
@@ -167,7 +238,6 @@ extension OverrideProfilesConfig {
                 let requestEnabled = Override.fetchRequest() as NSFetchRequest<Override>
                 let sortIsEnabled = NSSortDescriptor(key: "date", ascending: false)
                 requestEnabled.sortDescriptors = [sortIsEnabled]
-                // requestEnabled.fetchLimit = 1
                 try? overrideArray = coredataContext.fetch(requestEnabled)
                 isEnabled = overrideArray.first?.enabled ?? false
                 percentage = overrideArray.first?.percentage ?? 100
@@ -228,6 +298,29 @@ extension OverrideProfilesConfig {
                     uamMinutes = defaultUamMinutes
                 }
             }
+        }
+
+        func populateSettings(from preset: OverridePresets) {
+            profileName = preset.name ?? ""
+            percentage = preset.percentage
+            duration = (preset.duration ?? 0) as Decimal
+            _indefinite = preset.indefinite
+            override_target = preset.target != nil
+            if let targetValue = preset.target as NSDecimalNumber? {
+                target = units == .mmolL ? (targetValue as Decimal).asMmolL : targetValue as Decimal
+            } else {
+                target = 0
+            }
+            advancedSettings = preset.advancedSettings
+            smbIsOff = preset.smbIsOff
+            smbIsScheduledOff = preset.smbIsScheduledOff
+            isf = preset.isf
+            cr = preset.cr
+            smbMinutes = (preset.smbMinutes ?? 0) as Decimal
+            uamMinutes = (preset.uamMinutes ?? 0) as Decimal
+            isfAndCr = preset.isfAndCr
+            start = (preset.start ?? 0) as Decimal
+            end = (preset.end ?? 0) as Decimal
         }
 
         func cancelProfile() {

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
@@ -255,7 +255,8 @@ extension OverrideProfilesConfig {
                 preset.name = profileName
                 preset.percentage = percentage
                 preset.duration = NSDecimalNumber(decimal: duration)
-                preset.target = override_target ? NSDecimalNumber(decimal: target) : nil
+                let targetValue = override_target ? (units == .mmolL ? target.asMgdL : target) : nil
+                preset.target = targetValue != nil ? NSDecimalNumber(decimal: targetValue!) : nil
                 preset.indefinite = _indefinite
                 preset.advancedSettings = advancedSettings
                 preset.smbIsOff = smbIsOff

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -111,6 +111,14 @@ extension OverrideProfilesConfig {
         @ViewBuilder private func settingsConfig(header: String) -> some View {
             Section {
                 VStack {
+                    Spacer()
+                    Text("\(state.percentage.formatted(.number)) %")
+                        .foregroundColor(
+                            state
+                                .percentage >= 130 ? .red :
+                                (isEditing ? .orange : .blue)
+                        )
+                        .font(.largeTitle)
                     Slider(
                         value: $state.percentage,
                         in: 10 ... 200,
@@ -119,13 +127,6 @@ extension OverrideProfilesConfig {
                             isEditing = editing
                         }
                     ).accentColor(state.percentage >= 130 ? .red : .blue)
-                    Text("\(state.percentage.formatted(.number)) %")
-                        .foregroundColor(
-                            state
-                                .percentage >= 130 ? .red :
-                                (isEditing ? .orange : .blue)
-                        )
-                        .font(.largeTitle)
                     Spacer()
                     Toggle(isOn: $state._indefinite) {
                         Text("Enable indefinitely")

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -6,12 +6,10 @@ import Swinject
 extension OverrideProfilesConfig {
     struct RootView: BaseView {
         let resolver: Resolver
-        
+
         @StateObject var state = StateModel()
         @State private var isEditing = false
         @State private var showAlert = false
-        @State private var isRemoveAlertPresented = false
-        @State private var removeAlert: Alert?
         @State private var showingDetail = false
         @State private var selectedPreset: OverridePresets?
         @State private var isEditSheetPresented: Bool = false
@@ -21,24 +19,24 @@ extension OverrideProfilesConfig {
         @State private var showDeleteAlert = false
         @State private var indexToDelete: Int?
         @State private var profileNameToDelete: String = ""
-        
+
         @Environment(\.dismiss) var dismiss
         @Environment(\.managedObjectContext) var moc
-        
+
         @FetchRequest(
             entity: OverridePresets.entity(),
             sortDescriptors: [NSSortDescriptor(key: "name", ascending: true)], predicate: NSPredicate(
                 format: "name != %@", "" as String
             )
         ) var fetchedProfiles: FetchedResults<OverridePresets>
-        
+
         private var formatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
             formatter.maximumFractionDigits = 0
             return formatter
         }
-        
+
         private var glucoseFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
@@ -49,7 +47,7 @@ extension OverrideProfilesConfig {
             formatter.roundingMode = .halfUp
             return formatter
         }
-        
+
         var presetPopover: some View {
             Form {
                 nameSection(header: "Enter a name")
@@ -63,7 +61,7 @@ extension OverrideProfilesConfig {
                         state.profileName.isEmpty || fetchedProfiles
                             .contains(where: { $0.name == state.profileName })
                     )
-                    
+
                     Button("Cancel") {
                         isSheetPresented = false
                     }
@@ -71,7 +69,7 @@ extension OverrideProfilesConfig {
                 }
             }
         }
-        
+
         var editPresetPopover: some View {
             Form {
                 nameSection(header: "Change name?")
@@ -83,7 +81,7 @@ extension OverrideProfilesConfig {
                         isEditSheetPresented = false
                     }
                     .disabled(!hasChanges())
-                    
+
                     Button("Cancel") {
                         isEditSheetPresented = false
                     }
@@ -97,7 +95,7 @@ extension OverrideProfilesConfig {
                 }
             }
         }
-        
+
         @ViewBuilder private func nameSection(header: String) -> some View {
             Section {
                 TextField("Profile override name", text: $state.profileName)
@@ -105,7 +103,7 @@ extension OverrideProfilesConfig {
                 Text(header)
             }
         }
-        
+
         @ViewBuilder private func settingsConfig(header: String) -> some View {
             Section {
                 VStack {
@@ -136,7 +134,7 @@ extension OverrideProfilesConfig {
                         Text("minutes").foregroundColor(.secondary)
                     }
                 }
-                
+
                 HStack {
                     Toggle(isOn: $state.override_target) {
                         Text("Override Profile Target")
@@ -221,7 +219,7 @@ extension OverrideProfilesConfig {
                 Text(header)
             }
         }
-        
+
         @ViewBuilder private func settingsSection(header: String) -> some View {
             Section(header: Text(header)) {
                 let percentString = Text("Override: \(Int(state.percentage))%")
@@ -237,7 +235,7 @@ extension OverrideProfilesConfig {
                     .smbMinutes != 0 ? Text("\(state.smbMinutes.formatted()) SMB Basal minutes") : Text("")
                 let maxMinutesUAMString = state
                     .uamMinutes != 0 ? Text("\(state.uamMinutes.formatted()) UAM Basal minutes") : Text("")
-                
+
                 VStack(alignment: .leading, spacing: 2) {
                     percentString
                     if targetString != Text("") { targetString }
@@ -253,7 +251,7 @@ extension OverrideProfilesConfig {
                 .font(.caption)
             }
         }
-        
+
         var body: some View {
             Form {
                 if state.presets.isNotEmpty {
@@ -269,7 +267,7 @@ extension OverrideProfilesConfig {
                                     } label: {
                                         Label("Ta bort", systemImage: "trash")
                                     }.tint(.red)
-                                    
+
                                     Button {
                                         selectedPreset = preset
                                         state.profileName = preset.name ?? ""
@@ -280,11 +278,11 @@ extension OverrideProfilesConfig {
                                 }
                         }
                     }
-                header: { Text("Activate profile override") }
-                footer: { VStack(alignment: .leading) {
-                    Text("Swipe left on a profile to edit or delete it.")
-                }
-                }
+                    header: { Text("Activate profile override") }
+                    footer: { VStack(alignment: .leading) {
+                        Text("Swipe left on a profile to edit or delete it.")
+                    }
+                    }
                 }
                 settingsConfig(header: "Insulin")
                 Section {
@@ -292,37 +290,37 @@ extension OverrideProfilesConfig {
                         Button("Start new Profile") {
                             showAlert.toggle()
                             alertSring = "\(state.percentage.formatted(.number)) %, " +
-                            (
-                                state.duration > 0 || !state
-                                    ._indefinite ?
+                                (
+                                    state.duration > 0 || !state
+                                        ._indefinite ?
+                                        (
+                                            state
+                                                .duration
+                                                .formatted(.number.grouping(.never).rounded().precision(.fractionLength(0))) +
+                                                " min."
+                                        ) :
+                                        NSLocalizedString(" infinite duration.", comment: "")
+                                ) +
+                                (
+                                    (state.target == 0 || !state.override_target) ? "" :
+                                        (" Target: " + state.target.formatted() + " " + state.units.rawValue + ".")
+                                )
+                                +
                                 (
                                     state
-                                        .duration
-                                        .formatted(.number.grouping(.never).rounded().precision(.fractionLength(0))) +
-                                    " min."
-                                ) :
-                                    NSLocalizedString(" infinite duration.", comment: "")
-                            ) +
-                            (
-                                (state.target == 0 || !state.override_target) ? "" :
-                                    (" Target: " + state.target.formatted() + " " + state.units.rawValue + ".")
-                            )
-                            +
-                            (
-                                state
-                                    .smbIsOff ?
+                                        .smbIsOff ?
+                                        NSLocalizedString(
+                                            " SMBs are disabled either by schedule or during the entire duration.",
+                                            comment: ""
+                                        ) : ""
+                                )
+                                +
+                                "\n\n"
+                                +
                                 NSLocalizedString(
-                                    " SMBs are disabled either by schedule or during the entire duration.",
+                                    "Starting this override will change your Profiles and/or your Target Glucose used for looping during the entire selected duration. Tapping ”Start Profile” will start your new profile or edit your current active profile.",
                                     comment: ""
-                                ) : ""
-                            )
-                            +
-                            "\n\n"
-                            +
-                            NSLocalizedString(
-                                "Starting this override will change your Profiles and/or your Target Glucose used for looping during the entire selected duration. Tapping ”Start Profile” will start your new profile or edit your current active profile.",
-                                comment: ""
-                            )
+                                )
                         }
                         .disabled(unChanged())
                         .buttonStyle(BorderlessButtonStyle())
@@ -347,7 +345,7 @@ extension OverrideProfilesConfig {
                         Button {
                             isSheetPresented = true
                         }
-                    label: { Text("Save as Profile") }
+                        label: { Text("Save as Profile") }
                             .tint(.orange)
                             .frame(maxWidth: .infinity, alignment: .trailing)
                             .buttonStyle(BorderlessButtonStyle())
@@ -359,12 +357,12 @@ extension OverrideProfilesConfig {
                         presetPopover
                     }
                 }
-            footer: {
-                Text(
-                    "Your profile basal insulin will be adjusted with the override percentage and your profile ISF and CR will be inversly adjusted with the percentage."
-                )
-            }
-                
+                footer: {
+                    Text(
+                        "Your profile basal insulin will be adjusted with the override percentage and your profile ISF and CR will be inversly adjusted with the percentage."
+                    )
+                }
+
                 Button("Return to Normal") {
                     state.cancelProfile()
                     dismiss()
@@ -396,7 +394,7 @@ extension OverrideProfilesConfig {
                 )
             }
         }
-        
+
         @ViewBuilder private func profilesView(for preset: OverridePresets) -> some View {
             let target = state.units == .mmolL ? (((preset.target ?? 0) as NSDecimalNumber) as Decimal)
                 .asMmolL : (preset.target ?? 0) as Decimal
@@ -414,7 +412,7 @@ extension OverrideProfilesConfig {
             let crString = preset.cr ? "CR" : ""
             let dash = crString != "" ? "/" : ""
             let isfAndCRstring = isfString + dash + crString
-            
+
             if name != "" {
                 HStack {
                     VStack {
@@ -450,23 +448,23 @@ extension OverrideProfilesConfig {
                 }
             }
         }
-        
+
         private func unChanged() -> Bool {
             let defaultProfile = state.percentage == 100 && !state.override_target && !state.advancedSettings
             let noDurationSpecified = !state._indefinite && state.duration == 0
             let targetZeroWithOverride = state.override_target && state.target == 0
             let allSettingsDefault = state.percentage == 100 && !state.override_target && !state.smbIsOff && !state
                 .smbIsScheduledOff && state.smbMinutes == state.defaultSmbMinutes && state.uamMinutes == state.defaultUamMinutes
-            
+
             return defaultProfile || noDurationSpecified || targetZeroWithOverride || allSettingsDefault
         }
-        
+
         private func hasChanges() -> Bool {
             guard let originalPreset = originalPreset else { return false }
-            
+
             let targetInStateUnits: Decimal
             let targetInPresetUnits: Decimal
-            
+
             if state.units == .mmolL {
                 targetInStateUnits = state.target
                 targetInPresetUnits = Decimal(Double(truncating: originalPreset.target ?? 0) * 0.0555)
@@ -474,27 +472,27 @@ extension OverrideProfilesConfig {
                 targetInStateUnits = state.target
                 targetInPresetUnits = (originalPreset.target ?? 0) as Decimal
             }
-            
+
             let hasChanges = state.profileName != originalPreset.name ||
-            state.percentage != originalPreset.percentage ||
-            state.duration != (originalPreset.duration ?? 0) as Decimal ||
-            state._indefinite != originalPreset.indefinite ||
-            state.override_target != (originalPreset.target != nil) ||
-            (state.override_target && targetInStateUnits != targetInPresetUnits) ||
-            // state.advancedSettings != originalPreset.advancedSettings ||
-            state.smbIsOff != originalPreset.smbIsOff ||
-            state.smbIsScheduledOff != originalPreset.smbIsScheduledOff ||
-            state.isf != originalPreset.isf ||
-            state.cr != originalPreset.cr ||
-            state.smbMinutes != (originalPreset.smbMinutes ?? 0) as Decimal ||
-            state.uamMinutes != (originalPreset.uamMinutes ?? 0) as Decimal ||
-            state.isfAndCr != originalPreset.isfAndCr ||
-            state.start != (originalPreset.start ?? 0) as Decimal ||
-            state.end != (originalPreset.end ?? 0) as Decimal
-            
+                state.percentage != originalPreset.percentage ||
+                state.duration != (originalPreset.duration ?? 0) as Decimal ||
+                state._indefinite != originalPreset.indefinite ||
+                state.override_target != (originalPreset.target != nil) ||
+                (state.override_target && targetInStateUnits != targetInPresetUnits) ||
+                // state.advancedSettings != originalPreset.advancedSettings ||
+                state.smbIsOff != originalPreset.smbIsOff ||
+                state.smbIsScheduledOff != originalPreset.smbIsScheduledOff ||
+                state.isf != originalPreset.isf ||
+                state.cr != originalPreset.cr ||
+                state.smbMinutes != (originalPreset.smbMinutes ?? 0) as Decimal ||
+                state.uamMinutes != (originalPreset.uamMinutes ?? 0) as Decimal ||
+                state.isfAndCr != originalPreset.isfAndCr ||
+                state.start != (originalPreset.start ?? 0) as Decimal ||
+                state.end != (originalPreset.end ?? 0) as Decimal
+
             return hasChanges
         }
-        
+
         private func removeProfile(at offsets: IndexSet) {
             for index in offsets {
                 let language = fetchedProfiles[index]

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -46,106 +46,88 @@ extension OverrideProfilesConfig {
 
         var presetPopover: some View {
             Form {
-                Section {
-                    TextField("Override preset name", text: $state.profileName)
-                } header: { Text("Enter a name") }
-
-                Section(header: Text("Settings to save")) {
-                    let percentString = Text("Override: \(Int(state.percentage))%")
-                    let targetString = state
-                        .target != 0 ? Text("Target: \(state.target.formatted()) \(state.units.rawValue)") :
-                        Text("")
-                    let durationString = state
-                        ._indefinite ? Text("Duration: Indefinite") :
-                        Text("Duration: \(state.duration.formatted()) minutes")
-                    let isfString = state.isf ? Text("Change ISF") : Text("")
-                    let crString = state.cr ? Text("Change CR") : Text("")
-                    let smbString = state.smbIsOff ? Text("Disable SMB") : Text("")
-                    let scheduledSMBString = state.smbIsScheduledOff ? Text("SMB Schedule On") : Text("")
-                    let maxMinutesSMBString = state
-                        .smbMinutes != 0 ? Text("\(state.smbMinutes.formatted()) SMB Basal minutes") :
-                        Text("")
-                    let maxMinutesUAMString = state
-                        .uamMinutes != 0 ? Text("\(state.uamMinutes.formatted()) UAM Basal minutes") :
-                        Text("")
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        percentString
-                        if targetString != Text("") { targetString }
-                        if durationString != Text("") { durationString }
-                        if isfString != Text("") { isfString }
-                        if crString != Text("") { crString }
-                        if smbString != Text("") { smbString }
-                        if scheduledSMBString != Text("") { scheduledSMBString }
-                        if maxMinutesSMBString != Text("") { maxMinutesSMBString }
-                        if maxMinutesUAMString != Text("") { maxMinutesUAMString }
-                    }
-                    .foregroundColor(.secondary)
-                    .font(.caption)
-                }
-
-                Section {
-                    Button("Save") {
+                nameSection(header: "Enter a name")
+                settingsSection(header: "Settings to save")
+                actionButtons(
+                    saveAction: {
                         state.savePreset()
                         isSheetPresented = false
-                    }
-                    .disabled(state.profileName.isEmpty || fetchedProfiles.filter({ $0.name == state.profileName }).isNotEmpty)
-
-                    Button("Cancel") {
+                    },
+                    cancelAction: {
                         isSheetPresented = false
                     }
-                }
+                )
             }
         }
 
         var editPresetPopover: some View {
             Form {
-                Section {
-                    TextField("Override preset name", text: $state.profileName)
-                } header: { Text("Keep or change name?") }
-
-                Section(header: Text("New settings to save")) {
-                    let percentString = Text("Override: \(Int(state.percentage))%")
-                    let targetString = state
-                        .target != 0 ? Text("Target: \(state.target.formatted()) \(state.units.rawValue)") : Text("")
-                    let durationString = state
-                        ._indefinite ? Text("Duration: Indefinite") : Text("Duration: \(state.duration.formatted()) minutes")
-                    let isfString = state.isf ? Text("Change ISF") : Text("")
-                    let crString = state.cr ? Text("Change CR") : Text("")
-                    let smbString = state.smbIsOff ? Text("Disable SMB") : Text("")
-                    let scheduledSMBString = state.smbIsScheduledOff ? Text("SMB Schedule On") : Text("")
-                    let maxMinutesSMBString = state
-                        .smbMinutes != 0 ? Text("\(state.smbMinutes.formatted()) SMB Basal minutes") : Text("")
-                    let maxMinutesUAMString = state
-                        .uamMinutes != 0 ? Text("\(state.uamMinutes.formatted()) UAM Basal minutes") : Text("")
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        percentString
-                        if targetString != Text("") { targetString }
-                        if durationString != Text("") { durationString }
-                        if isfString != Text("") { isfString }
-                        if crString != Text("") { crString }
-                        if smbString != Text("") { smbString }
-                        if scheduledSMBString != Text("") { scheduledSMBString }
-                        if maxMinutesSMBString != Text("") { maxMinutesSMBString }
-                        if maxMinutesUAMString != Text("") { maxMinutesUAMString }
-                    }
-                    .foregroundColor(.secondary)
-                    .font(.caption)
-                }
-
-                Section {
-                    Button("Save") {
+                nameSection(header: "Keep or change name?")
+                settingsSection(header: "New settings to save")
+                actionButtons(
+                    saveAction: {
                         guard let selectedPreset = selectedPreset else { return }
                         state.updatePreset(selectedPreset)
                         isEditSheetPresented = false
-                    }
-                    .disabled(state.profileName.isEmpty)
-
-                    Button("Cancel") {
+                    },
+                    cancelAction: {
                         isEditSheetPresented = false
                     }
+                )
+            }
+        }
+
+        @ViewBuilder  private func nameSection(header: String) -> some View {
+            Section {
+                TextField("Override preset name", text: $state.profileName)
+            } header: {
+                Text(header)
+            }
+        }
+
+        @ViewBuilder  private func settingsSection(header: String) -> some View {
+            Section(header: Text(header)) {
+                let percentString = Text("Override: \(Int(state.percentage))%")
+                let targetString = state
+                    .target != 0 ? Text("Target: \(state.target.formatted()) \(state.units.rawValue)") : Text("")
+                let durationString = state
+                    ._indefinite ? Text("Duration: Indefinite") : Text("Duration: \(state.duration.formatted()) minutes")
+                let isfString = state.isf ? Text("Change ISF") : Text("")
+                let crString = state.cr ? Text("Change CR") : Text("")
+                let smbString = state.smbIsOff ? Text("Disable SMB") : Text("")
+                let scheduledSMBString = state.smbIsScheduledOff ? Text("SMB Schedule On") : Text("")
+                let maxMinutesSMBString = state
+                    .smbMinutes != 0 ? Text("\(state.smbMinutes.formatted()) SMB Basal minutes") : Text("")
+                let maxMinutesUAMString = state
+                    .uamMinutes != 0 ? Text("\(state.uamMinutes.formatted()) UAM Basal minutes") : Text("")
+
+                VStack(alignment: .leading, spacing: 2) {
+                    percentString
+                    if targetString != Text("") { targetString }
+                    if durationString != Text("") { durationString }
+                    if isfString != Text("") { isfString }
+                    if crString != Text("") { crString }
+                    if smbString != Text("") { smbString }
+                    if scheduledSMBString != Text("") { scheduledSMBString }
+                    if maxMinutesSMBString != Text("") { maxMinutesSMBString }
+                    if maxMinutesUAMString != Text("") { maxMinutesUAMString }
                 }
+                .foregroundColor(.secondary)
+                .font(.caption)
+            }
+        }
+
+        @ViewBuilder  private func actionButtons(
+            saveAction: @escaping () -> Void,
+            cancelAction: @escaping () -> Void
+        ) -> some View {
+            Section {
+                Button("Save", action: saveAction)
+                    .disabled(
+                        state.profileName.isEmpty || fetchedProfiles.filter { $0.name == state.profileName }
+                            .isNotEmpty
+                    )
+                Button("Cancel", action: cancelAction)
             }
         }
 

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -265,7 +265,7 @@ extension OverrideProfilesConfig {
                                         profileNameToDelete = preset.name ?? "this profile"
                                         showDeleteAlert = true
                                     } label: {
-                                        Label("Ta bort", systemImage: "trash")
+                                        Label("Delete", systemImage: "trash")
                                     }.tint(.red)
 
                                     Button {
@@ -273,7 +273,7 @@ extension OverrideProfilesConfig {
                                         state.profileName = preset.name ?? ""
                                         isEditSheetPresented = true
                                     } label: {
-                                        Label("Redigera", systemImage: "square.and.pencil")
+                                        Label("Edit", systemImage: "square.and.pencil")
                                     }.tint(.blue)
                                 }
                         }

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -86,7 +86,7 @@ extension OverrideProfilesConfig {
 
         @ViewBuilder private func nameSection(header: String) -> some View {
             Section {
-                TextField("Override preset name", text: $state.profileName)
+                TextField("Profile override name", text: $state.profileName)
             } header: {
                 Text(header)
             }
@@ -135,7 +135,7 @@ extension OverrideProfilesConfig {
                                     Button(role: .destructive) {
                                         removeProfile(at: IndexSet(integer: index))
                                     } label: {
-                                        Label("Ta bort", systemImage: "trash")
+                                        Label("Delete", systemImage: "trash")
                                     }
 
                                     Button {
@@ -143,31 +143,31 @@ extension OverrideProfilesConfig {
                                         state.profileName = preset.name ?? ""
                                         isEditSheetPresented = true
                                     } label: {
-                                        Label("Redigera", systemImage: "square.and.pencil")
+                                        Label("Edit", systemImage: "square.and.pencil")
                                     }.tint(.blue)
                                 }
                         }
                     }
-                    header: { Text("Activate preset override") }
+                    header: { Text("Activate profile override") }
                     footer: { VStack(alignment: .leading) {
-                        Text("Swipe left on a preset to edit or delete it.")
-                        Text("When you want to edit a preset:")
+                        Text("Swipe left on a profile to edit or delete it.")
+                        Text("When you want to edit a profile:")
                         HStack(alignment: .top) {
                             Text(" •")
                             Text(
-                                "First use the override configurator below and select the settings you want to include."
+                                "First use the profile configurator below and select the settings you want to include."
                             )
                         }
                         HStack(alignment: .top) {
                             Text(" •")
                             Text(
-                                "Then swipe left on the preset you want to change and click the edit symbol."
+                                "Then swipe left on the profile you want to change and click the edit symbol."
                             )
                         }
                         HStack(alignment: .top) {
                             Text(" •")
                             Text(
-                                "In the pop-up: Use the existing preset name or enter a new name and click save - Done!"
+                                "In the pop-up: Use the existing profile name or enter a new name and click save - Done!"
                             )
                         }
                     }

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -10,7 +10,6 @@ extension OverrideProfilesConfig {
         @State private var isEditing = false
         @State private var showAlert = false
         @State private var showingDetail = false
-        @State private var alertString = ""
         @State private var selectedPreset: OverridePresets?
         @State private var isEditSheetPresented: Bool = false
         @State private var alertSring = ""

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -372,6 +372,7 @@ extension OverrideProfilesConfig {
                             .tint(.orange)
                             .frame(maxWidth: .infinity, alignment: .trailing)
                             .buttonStyle(BorderlessButtonStyle())
+                            .font(.callout)
                             .controlSize(.mini)
                             .disabled(unChanged())
                     }

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -67,7 +67,8 @@ extension OverrideProfilesConfig {
         var editPresetPopover: some View {
             Form {
                 nameSection(header: "Keep or change name?")
-                settingsSection(header: "New settings to save")
+                // settingsSection(header: "New settings to save")
+                settingsConfig(header: "Change settings")
                 Section {
                     Button("Save") {
                         guard let selectedPreset = selectedPreset else { return }
@@ -86,6 +87,122 @@ extension OverrideProfilesConfig {
         @ViewBuilder private func nameSection(header: String) -> some View {
             Section {
                 TextField("Profile override name", text: $state.profileName)
+            } header: {
+                Text(header)
+            }
+        }
+
+        @ViewBuilder private func settingsConfig(header: String) -> some View {
+            Section {
+                VStack {
+                    Slider(
+                        value: $state.percentage,
+                        in: 10 ... 200,
+                        step: 1,
+                        onEditingChanged: { editing in
+                            isEditing = editing
+                        }
+                    ).accentColor(state.percentage >= 130 ? .red : .blue)
+                    Text("\(state.percentage.formatted(.number)) %")
+                        .foregroundColor(
+                            state
+                                .percentage >= 130 ? .red :
+                                (isEditing ? .orange : .blue)
+                        )
+                        .font(.largeTitle)
+                    Spacer()
+                    Toggle(isOn: $state._indefinite) {
+                        Text("Enable indefinitely")
+                    }
+                }
+                if !state._indefinite {
+                    HStack {
+                        Text("Duration")
+                        DecimalTextField("0", value: $state.duration, formatter: formatter, cleanInput: false)
+                        Text("minutes").foregroundColor(.secondary)
+                    }
+                }
+
+                HStack {
+                    Toggle(isOn: $state.override_target) {
+                        Text("Override Profile Target")
+                    }
+                }
+                if state.override_target {
+                    HStack {
+                        Text("Target Glucose")
+                        DecimalTextField("0", value: $state.target, formatter: glucoseFormatter, cleanInput: false)
+                        Text(state.units.rawValue).foregroundColor(.secondary)
+                    }
+                }
+                HStack {
+                    Toggle(isOn: $state.advancedSettings) {
+                        Text("More options")
+                    }
+                }
+                if state.advancedSettings {
+                    HStack {
+                        Toggle(isOn: $state.smbIsOff) {
+                            Text("Always Disable SMBs")
+                        }
+                    }
+                    if !state.smbIsOff {
+                        HStack {
+                            Toggle(isOn: $state.smbIsScheduledOff) {
+                                Text("Schedule when SMBs are Off")
+                            }
+                        }
+                        if state.smbIsScheduledOff {
+                            HStack {
+                                Text("First Hour SMBs are Off (24 hours)")
+                                DecimalTextField("0", value: $state.start, formatter: formatter, cleanInput: false)
+                                Text("hour").foregroundColor(.secondary)
+                            }
+                            HStack {
+                                Text("First Hour SMBs are Resumed (24 hours)")
+                                DecimalTextField("0", value: $state.end, formatter: formatter, cleanInput: false)
+                                Text("hour").foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                    HStack {
+                        Toggle(isOn: $state.isfAndCr) {
+                            Text("Change ISF and CR")
+                        }
+                    }
+                    if !state.isfAndCr {
+                        HStack {
+                            Toggle(isOn: $state.isf) {
+                                Text("Change ISF")
+                            }
+                        }
+                        HStack {
+                            Toggle(isOn: $state.cr) {
+                                Text("Change CR")
+                            }
+                        }
+                    }
+                    HStack {
+                        Text("SMB Minutes")
+                        DecimalTextField(
+                            "0",
+                            value: $state.smbMinutes,
+                            formatter: formatter,
+                            cleanInput: false
+                        )
+                        Text("minutes").foregroundColor(.secondary)
+                    }
+                    HStack {
+                        Text("UAM SMB Minutes")
+                        DecimalTextField(
+                            "0",
+                            value: $state.uamMinutes,
+                            formatter: formatter,
+                            cleanInput: false
+                        )
+                        Text("minutes").foregroundColor(.secondary)
+                    }
+                }
             } header: {
                 Text(header)
             }
@@ -150,139 +267,11 @@ extension OverrideProfilesConfig {
                     header: { Text("Activate profile override") }
                     footer: { VStack(alignment: .leading) {
                         Text("Swipe left on a profile to edit or delete it.")
-                        Text("When you want to edit a profile:")
-                        HStack(alignment: .top) {
-                            Text(" •")
-                            Text(
-                                "First use the profile configurator below and select the settings you want to include."
-                            )
-                        }
-                        HStack(alignment: .top) {
-                            Text(" •")
-                            Text(
-                                "Then swipe left on the profile you want to change and click the edit symbol."
-                            )
-                        }
-                        HStack(alignment: .top) {
-                            Text(" •")
-                            Text(
-                                "In the pop-up: Use the existing profile name or enter a new name and click save - Done!"
-                            )
-                        }
                     }
                     }
                 }
+                settingsConfig(header: "Insulin")
                 Section {
-                    VStack {
-                        Slider(
-                            value: $state.percentage,
-                            in: 10 ... 200,
-                            step: 1,
-                            onEditingChanged: { editing in
-                                isEditing = editing
-                            }
-                        ).accentColor(state.percentage >= 130 ? .red : .blue)
-                        Text("\(state.percentage.formatted(.number)) %")
-                            .foregroundColor(
-                                state
-                                    .percentage >= 130 ? .red :
-                                    (isEditing ? .orange : .blue)
-                            )
-                            .font(.largeTitle)
-                        Spacer()
-                        Toggle(isOn: $state._indefinite) {
-                            Text("Enable indefinitely")
-                        }
-                    }
-                    if !state._indefinite {
-                        HStack {
-                            Text("Duration")
-                            DecimalTextField("0", value: $state.duration, formatter: formatter, cleanInput: false)
-                            Text("minutes").foregroundColor(.secondary)
-                        }
-                    }
-
-                    HStack {
-                        Toggle(isOn: $state.override_target) {
-                            Text("Override Profile Target")
-                        }
-                    }
-                    if state.override_target {
-                        HStack {
-                            Text("Target Glucose")
-                            DecimalTextField("0", value: $state.target, formatter: glucoseFormatter, cleanInput: false)
-                            Text(state.units.rawValue).foregroundColor(.secondary)
-                        }
-                    }
-                    HStack {
-                        Toggle(isOn: $state.advancedSettings) {
-                            Text("More options")
-                        }
-                    }
-                    if state.advancedSettings {
-                        HStack {
-                            Toggle(isOn: $state.smbIsOff) {
-                                Text("Always Disable SMBs")
-                            }
-                        }
-                        if !state.smbIsOff {
-                            HStack {
-                                Toggle(isOn: $state.smbIsScheduledOff) {
-                                    Text("Schedule when SMBs are Off")
-                                }
-                            }
-                            if state.smbIsScheduledOff {
-                                HStack {
-                                    Text("First Hour SMBs are Off (24 hours)")
-                                    DecimalTextField("0", value: $state.start, formatter: formatter, cleanInput: false)
-                                    Text("hour").foregroundColor(.secondary)
-                                }
-                                HStack {
-                                    Text("First Hour SMBs are Resumed (24 hours)")
-                                    DecimalTextField("0", value: $state.end, formatter: formatter, cleanInput: false)
-                                    Text("hour").foregroundColor(.secondary)
-                                }
-                            }
-                        }
-                        HStack {
-                            Toggle(isOn: $state.isfAndCr) {
-                                Text("Change ISF and CR")
-                            }
-                        }
-                        if !state.isfAndCr {
-                            HStack {
-                                Toggle(isOn: $state.isf) {
-                                    Text("Change ISF")
-                                }
-                            }
-                            HStack {
-                                Toggle(isOn: $state.cr) {
-                                    Text("Change CR")
-                                }
-                            }
-                        }
-                        HStack {
-                            Text("SMB Minutes")
-                            DecimalTextField(
-                                "0",
-                                value: $state.smbMinutes,
-                                formatter: formatter,
-                                cleanInput: false
-                            )
-                            Text("minutes").foregroundColor(.secondary)
-                        }
-                        HStack {
-                            Text("UAM SMB Minutes")
-                            DecimalTextField(
-                                "0",
-                                value: $state.uamMinutes,
-                                formatter: formatter,
-                                cleanInput: false
-                            )
-                            Text("minutes").foregroundColor(.secondary)
-                        }
-                    }
-
                     HStack {
                         Button("Start new Profile") {
                             showAlert.toggle()
@@ -354,8 +343,6 @@ extension OverrideProfilesConfig {
                         presetPopover
                     }
                 }
-
-                header: { Text("Insulin") }
                 footer: {
                     Text(
                         "Your profile basal insulin will be adjusted with the override percentage and your profile ISF and CR will be inversly adjusted with the percentage."

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -48,15 +48,20 @@ extension OverrideProfilesConfig {
             Form {
                 nameSection(header: "Enter a name")
                 settingsSection(header: "Settings to save")
-                actionButtons(
-                    saveAction: {
+                Section {
+                    Button("Save") {
                         state.savePreset()
                         isSheetPresented = false
-                    },
-                    cancelAction: {
+                    }
+                    .disabled(
+                        state.profileName.isEmpty || fetchedProfiles
+                            .contains(where: { $0.name == state.profileName })
+                    )
+
+                    Button("Cancel") {
                         isSheetPresented = false
                     }
-                )
+                }
             }
         }
 
@@ -64,20 +69,22 @@ extension OverrideProfilesConfig {
             Form {
                 nameSection(header: "Keep or change name?")
                 settingsSection(header: "New settings to save")
-                actionButtons(
-                    saveAction: {
+                Section {
+                    Button("Save") {
                         guard let selectedPreset = selectedPreset else { return }
                         state.updatePreset(selectedPreset)
                         isEditSheetPresented = false
-                    },
-                    cancelAction: {
+                    }
+                    .disabled(state.profileName.isEmpty)
+
+                    Button("Cancel") {
                         isEditSheetPresented = false
                     }
-                )
+                }
             }
         }
 
-        @ViewBuilder  private func nameSection(header: String) -> some View {
+        @ViewBuilder private func nameSection(header: String) -> some View {
             Section {
                 TextField("Override preset name", text: $state.profileName)
             } header: {
@@ -85,7 +92,7 @@ extension OverrideProfilesConfig {
             }
         }
 
-        @ViewBuilder  private func settingsSection(header: String) -> some View {
+        @ViewBuilder private func settingsSection(header: String) -> some View {
             Section(header: Text(header)) {
                 let percentString = Text("Override: \(Int(state.percentage))%")
                 let targetString = state
@@ -114,20 +121,6 @@ extension OverrideProfilesConfig {
                 }
                 .foregroundColor(.secondary)
                 .font(.caption)
-            }
-        }
-
-        @ViewBuilder  private func actionButtons(
-            saveAction: @escaping () -> Void,
-            cancelAction: @escaping () -> Void
-        ) -> some View {
-            Section {
-                Button("Save", action: saveAction)
-                    .disabled(
-                        state.profileName.isEmpty || fetchedProfiles.filter { $0.name == state.profileName }
-                            .isNotEmpty
-                    )
-                Button("Cancel", action: cancelAction)
             }
         }
 


### PR DESCRIPTION
- Enable edit of all settings and/or name for already stored profile overrides
- Swipe left to edit or delete
- Get list of all settings included in the override when saving a new one or editing an existing one

Suggested solution for issue #234 

- Extra useful when overrides are used with shortcuts (no need to re add changed overrides in shortcuts since id remains unchanged after edit - even if you change name on the override)

**NOTE!** This is not an attempt to redesign the entire UI. This is just to add edit functionality with minimal changes.

**Screenshots**
| Edit or Delete swipe | Settings summary before saving |
|--------|--------|
| ![Simulator Screenshot - iPhone 13 mini+ - 2024-05-25 at 01 55 40](https://github.com/nightscout/Trio/assets/72826201/6c1b542b-8d5a-47ca-80f2-4e614c995e45) | ![Simulator Screenshot - iPhone 13 mini+ - 2024-05-25 at 01 56 39](https://github.com/nightscout/Trio/assets/72826201/aa8f2ce9-95e0-467e-9268-9ea33ba69aff) | 


