### PR TITLE
Enable editing of preset temp targets

### DIFF
--- a/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
@@ -9,7 +9,6 @@ extension AddTempTarget {
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
 
         @Published var low: Decimal = 0
-        // @Published var target: Decimal = 0
         @Published var high: Decimal = 0
         @Published var duration: Decimal = 0
         @Published var date = Date()
@@ -129,15 +128,18 @@ extension AddTempTarget {
                 lowTarget = Decimal(round(Double(computeTarget())))
                 saveSettings = true
             }
+            var highTarget = lowTarget
 
-            let roundedLow = convertAndRound(lowTarget)
+            if units == .mmolL, !viewPercantage {
+                lowTarget = Decimal(round(Double(lowTarget.asMgdL)))
+                highTarget = lowTarget
+            }
 
             let entry = TempTarget(
                 name: newPresetName.isEmpty ? TempTarget.custom : newPresetName,
                 createdAt: Date(),
-                targetTop: roundedLow,
-                targetBottom: roundedLow,
-
+                targetTop: highTarget,
+                targetBottom: lowTarget,
                 duration: duration,
                 enteredBy: TempTarget.manual,
                 reason: newPresetName.isEmpty ? TempTarget.custom : newPresetName
@@ -181,7 +183,6 @@ extension AddTempTarget {
                         saveToCoreData.active = true
                         saveToCoreData.date = Date()
                         saveToCoreData.hbt = whichID?.hbt ?? 160
-                        // saveToCoreData.id = id
                         saveToCoreData.startDate = Date()
                         saveToCoreData.duration = whichID?.duration ?? 0
 

--- a/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
@@ -196,6 +196,19 @@ extension AddTempTarget {
             return Decimal(Double(target))
         }
 
+        func computePercentage(target: Decimal) -> Decimal {
+            let c = Decimal(hbt - 100)
+            var ratio = c / (c + target - 100)
+
+            if ratio > maxValue {
+                ratio = maxValue
+            }
+
+            let adjustedPercentage = ratio * 100
+            let roundedPercentage = (adjustedPercentage as NSDecimalNumber).rounding(accordingToBehavior: nil)
+            return roundedPercentage as Decimal
+        }
+
         func updatePreset(_ preset: TempTarget) {
             var lowTarget = low
 

--- a/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
@@ -100,24 +100,6 @@ extension AddTempTarget {
             }
         }
 
-        func updatePreset(_ preset: TempTarget, low: Decimal) {
-            let roundedLow = convertAndRound(low)
-
-            if let index = presets.firstIndex(where: { $0.id == preset.id }) {
-                presets[index] = TempTarget(
-                    id: preset.id,
-                    name: newPresetName.isEmpty ? preset.name : newPresetName,
-                    createdAt: preset.createdAt,
-                    targetTop: roundedLow,
-                    targetBottom: roundedLow,
-                    duration: duration,
-                    enteredBy: preset.enteredBy,
-                    reason: newPresetName.isEmpty ? preset.reason : newPresetName
-                )
-                storage.storePresets(presets)
-            }
-        }
-
         func save() {
             guard duration > 0 else {
                 return
@@ -215,12 +197,22 @@ extension AddTempTarget {
         }
 
         func updatePreset(_ preset: TempTarget) {
+            var lowTarget = low
+
+            if viewPercantage {
+                lowTarget = Decimal(round(Double(computeTarget())))
+            }
+
+            if units == .mmolL, !viewPercantage {
+                lowTarget = Decimal(round(Double(lowTarget.asMgdL)))
+            }
+
             let updatedPreset = TempTarget(
                 id: preset.id,
                 name: newPresetName.isEmpty ? preset.name : newPresetName,
                 createdAt: preset.createdAt,
-                targetTop: preset.targetTop,
-                targetBottom: low,
+                targetTop: lowTarget,
+                targetBottom: lowTarget,
                 duration: duration,
                 enteredBy: preset.enteredBy,
                 reason: newPresetName.isEmpty ? preset.reason : newPresetName

--- a/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 extension AddTempTarget {
     final class StateModel: BaseStateModel<Provider> {
-        @Injected() private var storage: TempTargetsStorage!
+        @Injected() var storage: TempTargetsStorage!
         @Injected() var apsManager: APSManager!
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
@@ -188,6 +188,24 @@ extension AddTempTarget {
                 target = (c / ratio) - c + 100
             }
             return Decimal(Double(target))
+        }
+
+        func updatePreset(_ preset: TempTarget) {
+            let updatedPreset = TempTarget(
+                id: preset.id,
+                name: newPresetName.isEmpty ? preset.name : newPresetName,
+                createdAt: preset.createdAt,
+                targetTop: preset.targetTop,
+                targetBottom: low,
+                duration: duration,
+                enteredBy: preset.enteredBy,
+                reason: newPresetName.isEmpty ? preset.reason : newPresetName
+            )
+
+            if let index = presets.firstIndex(where: { $0.id == preset.id }) {
+                presets[index] = updatedPreset
+                storage.storePresets(presets)
+            }
         }
     }
 }

--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -199,13 +199,13 @@ extension AddTempTarget {
                         Text("New Target")
                         Spacer()
                         DecimalTextField("0", value: $state.low, formatter: formatter, cleanInput: true)
-                        Text(state.units.rawValue)
+                        Text(state.units.rawValue).foregroundColor(.secondary)
                     }
                     HStack {
                         Text("New Duration")
                         Spacer()
                         DecimalTextField("0", value: $state.duration, formatter: formatter, cleanInput: true)
-                        Text("min")
+                        Text("min").foregroundColor(.secondary)
                     }
                 }
                 Section {

--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -81,89 +81,17 @@ extension AddTempTarget {
                     }
                 }
 
-                HStack {
-                    Text("Experimental")
-                    Toggle(isOn: $state.viewPercantage) {}.controlSize(.mini)
-                    Image(systemName: "figure.highintensity.intervaltraining")
-                    Image(systemName: "fork.knife")
-                }
+                settingsSection(header: "Custom")
 
-                if state.viewPercantage {
-                    Section {
-                        VStack {
-                            Text("\(state.percentage.formatted(.number)) % Insulin")
-                                .foregroundColor(isEditing ? .orange : .blue)
-                                .font(.largeTitle)
-                                .padding(.vertical)
-                            Slider(
-                                value: $state.percentage,
-                                in: 15 ...
-                                    min(Double(state.maxValue * 100), 200),
-                                step: 1,
-                                onEditingChanged: { editing in
-                                    isEditing = editing
-                                }
-                            )
-                            HStack {}
-                            // Only display target slider when not 100 %
-                            if state.percentage != 100 {
-                                Spacer()
-                                Divider()
-                                Text(
-                                    (
-                                        state
-                                            .units == .mmolL ?
-                                            "\(state.computeTarget().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L" :
-                                            "\(state.computeTarget().formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) mg/dl"
-                                    )
-                                        + NSLocalizedString(" Target Glucose", comment: "")
-                                )
-                                .foregroundColor(.green)
-                                .padding(.vertical)
-                                Slider(
-                                    value: $state.hbt,
-                                    in: 101 ... 295,
-                                    step: 1
-                                ).accentColor(.green)
-                            }
-                        }
-                    }
-                } else {
-                    Section(header: Text("Custom")) {
-                        HStack {
-                            Text("Target")
-                            Spacer()
-                            DecimalTextField("0", value: $state.low, formatter: formatter, cleanInput: true)
-                            Text(state.units.rawValue).foregroundColor(.secondary)
-                        }
-                        HStack {
-                            Text("Duration")
-                            Spacer()
-                            DecimalTextField("0", value: $state.duration, formatter: formatter, cleanInput: true)
-                            Text("minutes").foregroundColor(.secondary)
-                        }
-                        DatePicker("Date", selection: $state.date)
-                        Button { isPromtPresented = true }
-                        label: { Text("Save as preset") }
-                    }
-                }
-                if state.viewPercantage {
-                    Section {
-                        HStack {
-                            Text("Duration")
-                            Spacer()
-                            DecimalTextField("0", value: $state.duration, formatter: formatter, cleanInput: true)
-                            Text("minutes").foregroundColor(.secondary)
-                        }
-                        DatePicker("Date", selection: $state.date)
-                        Button { isPromtPresented = true }
-                        label: { Text("Save as preset") }
-                            .disabled(state.duration == 0)
-                    }
-                }
+                DatePicker("Date", selection: $state.date)
+                Button { isPromtPresented = true }
+                label: { Text("Save as preset") }
+                    .disabled(state.duration == 0)
+
                 Section {
                     Button { state.enact() }
                     label: { Text("Enact") }
+                        .disabled(state.duration == 0)
                     Button { state.cancel() }
                     label: { Text("Cancel Temp Target") }
                 }
@@ -197,30 +125,97 @@ extension AddTempTarget {
             .navigationBarItems(leading: Button("Close", action: state.hideModal))
         }
 
-        @ViewBuilder private func editPresetPopover() -> some View {
-            Form {
-                Section(header: Text("Edit Preset")) {
-                    TextField("Name", text: $state.newPresetName)
-                    Text("Before change: \(displayString)")
-                        .foregroundColor(.secondary)
-                        .font(.caption)
+        @ViewBuilder func settingsSection(header: String) -> some View {
+            HStack {
+                Text("Experimental")
+                Toggle(isOn: $state.viewPercantage) {}
+                    .controlSize(.mini)
+                Image(systemName: "figure.highintensity.intervaltraining")
+                Image(systemName: "fork.knife")
+            }
+
+            if state.viewPercantage {
+                Section {
+                    VStack {
+                        Text("\(state.percentage.formatted(.number)) % Insulin")
+                            .foregroundColor(isEditing ? .orange : .blue)
+                            .font(.largeTitle)
+                            .padding(.vertical)
+                        Slider(
+                            value: $state.percentage,
+                            in: 15 ...
+                                min(Double(state.maxValue * 100), 200),
+                            step: 1,
+                            onEditingChanged: { editing in
+                                isEditing = editing
+                            }
+                        )
+                        HStack {}
+                        // Only display target slider when not 100 %
+                        if state.percentage != 100 {
+                            Spacer()
+                            Divider()
+                            Text(
+                                (
+                                    state
+                                        .units == .mmolL ?
+                                        "\(state.computeTarget().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L" :
+                                        "\(state.computeTarget().formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) mg/dl"
+                                )
+                                    + NSLocalizedString(" Target Glucose", comment: "")
+                            )
+                            .foregroundColor(.green)
+                            .padding(.vertical)
+                            Slider(
+                                value: $state.hbt,
+                                in: 101 ... 295,
+                                step: 1
+                            ).accentColor(.green)
+                        }
+                    }
+                }
+            } else {
+                Section(header: Text(header)) {
                     HStack {
-                        Text("New Target")
+                        Text("Target")
                         Spacer()
                         DecimalTextField("0", value: $state.low, formatter: formatter, cleanInput: true)
                         Text(state.units.rawValue).foregroundColor(.secondary)
                     }
                     HStack {
-                        Text("New Duration")
+                        Text("Duration")
                         Spacer()
                         DecimalTextField("0", value: $state.duration, formatter: formatter, cleanInput: true)
-                        Text("min").foregroundColor(.secondary)
+                        Text("minutes").foregroundColor(.secondary)
                     }
                 }
+            }
+            if state.viewPercantage {
+                Section {
+                    HStack {
+                        Text("Duration")
+                        Spacer()
+                        DecimalTextField("0", value: $state.duration, formatter: formatter, cleanInput: true)
+                        Text("minutes").foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+
+        @ViewBuilder private func editPresetPopover() -> some View {
+            Form {
+                Section(header: Text("Edit Name?")) {
+                    TextField("Name", text: $state.newPresetName)
+                    Text("Settings before change: \(displayString)")
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+                }
+                settingsSection(header: "New target and duration")
+
                 Section {
                     Button("Save") {
                         guard let selectedPreset = selectedPreset else { return }
-                        state.updatePreset(selectedPreset, low: state.low)
+                        state.updatePreset(selectedPreset)
                         isEditSheetPresented = false
                     }
                     .disabled(state.newPresetName.isEmpty)
@@ -257,16 +252,6 @@ extension AddTempTarget {
                     HStack {
                         Text(preset.displayName)
                         Spacer()
-                        /* Button {
-                             selectedPreset = preset
-                             state.newPresetName = preset.displayName
-                             state.low = state.units == .mmolL ? preset.targetBottom?.asMmolL ?? 0 : preset.targetBottom ?? 0
-                             state.duration = preset.duration
-                             state.date = preset.date as? Date ?? Date()
-                             isEditSheetPresented = true
-                         } label: {
-                             Image(systemName: "square.and.pencil")
-                         } */
                     }
                     HStack(spacing: 2) {
                         if let lowValue = low,

--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -7,39 +7,73 @@ extension AddTempTarget {
         let resolver: Resolver
         @StateObject var state = StateModel()
         @State private var isPromtPresented = false
-        @State private var isRemoveAlertPresented = false
-        @State private var removeAlert: Alert?
         @State private var isEditing = false
-
+        @State private var selectedPreset: TempTarget?
+        @State private var isEditSheetPresented = false
+        
         @FetchRequest(
             entity: TempTargetsSlider.entity(),
             sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)]
         ) var isEnabledArray: FetchedResults<TempTargetsSlider>
-
+        
         private var formatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
             formatter.maximumFractionDigits = 1
             return formatter
         }
-
+        
+        private var displayString: String {
+            guard let preset = selectedPreset else { return "" }
+            var low = preset.targetBottom
+            var high = preset.targetBottom // change to only use targetBottom instead of targetTop
+            if state.units == .mmolL {
+                low = low?.asMmolL
+                high = high?.asMmolL
+            }
+            
+            let formattedLow = low.flatMap { formatter.string(from: $0 as NSNumber) } ?? ""
+            let formattedDuration = formatter.string(from: preset.duration as NSNumber) ?? ""
+            
+            return "\(formattedLow) \(state.units.rawValue) for \(formattedDuration) min"
+        }
+        
         var body: some View {
             Form {
                 if !state.presets.isEmpty {
                     Section(header: Text("Presets")) {
                         ForEach(state.presets) { preset in
                             presetView(for: preset)
+                                .swipeActions {
+                                    Button(role: .destructive) {
+                                        state.removePreset(id: preset.id)
+                                    } label: {
+                                        Label("Delete", systemImage: "trash")
+                                    }
+                                    Button {
+                                        selectedPreset = preset
+                                        state.newPresetName = preset.displayName
+                                        state.low = state.units == .mmolL ? preset.targetBottom?.asMmolL ?? 0 : preset
+                                            .targetBottom ?? 0
+                                        state.duration = preset.duration
+                                        state.date = preset.date as? Date ?? Date()
+                                        isEditSheetPresented = true
+                                    } label: {
+                                        Label("Edit", systemImage: "square.and.pencil")
+                                    }
+                                    .tint(.blue)
+                                }
                         }
                     }
                 }
-
+                
                 HStack {
                     Text("Experimental")
                     Toggle(isOn: $state.viewPercantage) {}.controlSize(.mini)
                     Image(systemName: "figure.highintensity.intervaltraining")
                     Image(systemName: "fork.knife")
                 }
-
+                
                 if state.viewPercantage {
                     Section(
                         header: Text("")
@@ -48,7 +82,7 @@ extension AddTempTarget {
                             Slider(
                                 value: $state.percentage,
                                 in: 15 ...
-                                    min(Double(state.maxValue * 100), 200),
+                                min(Double(state.maxValue * 100), 200),
                                 step: 1,
                                 onEditingChanged: { editing in
                                     isEditing = editing
@@ -62,22 +96,22 @@ extension AddTempTarget {
                             // Only display target slider when not 100 %
                             if state.percentage != 100 {
                                 Divider()
-
+                                
                                 Slider(
                                     value: $state.hbt,
                                     in: 101 ... 295,
                                     step: 1
                                 ).accentColor(.green)
-
+                                
                                 HStack {
                                     Text(
                                         (
                                             state
                                                 .units == .mmolL ?
-                                                "\(state.computeTarget().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L" :
+                                            "\(state.computeTarget().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L" :
                                                 "\(state.computeTarget().formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) mg/dl"
                                         )
-                                            + NSLocalizedString("  Target Glucose", comment: "")
+                                        + NSLocalizedString("  Target Glucose", comment: "")
                                     )
                                     .foregroundColor(.green)
                                 }
@@ -100,7 +134,7 @@ extension AddTempTarget {
                         }
                         DatePicker("Date", selection: $state.date)
                         Button { isPromtPresented = true }
-                        label: { Text("Save as preset") }
+                    label: { Text("Save as preset") }
                     }
                 }
                 if state.viewPercantage {
@@ -113,31 +147,37 @@ extension AddTempTarget {
                         }
                         DatePicker("Date", selection: $state.date)
                         Button { isPromtPresented = true }
-                        label: { Text("Save as preset") }
+                    label: { Text("Save as preset") }
                             .disabled(state.duration == 0)
                     }
                 }
-
+                
                 Section {
                     Button { state.enact() }
-                    label: { Text("Enact") }
+                label: { Text("Enact") }
                     Button { state.cancel() }
-                    label: { Text("Cancel Temp Target") }
+                label: { Text("Cancel Temp Target") }
                 }
             }
             .popover(isPresented: $isPromtPresented) {
                 Form {
                     Section(header: Text("Enter preset name")) {
                         TextField("Name", text: $state.newPresetName)
+                    }
+                    Section {
                         Button {
                             state.save()
                             isPromtPresented = false
                         }
-                        label: { Text("Save") }
+                    label: { Text("Save") }
                         Button { isPromtPresented = false }
-                        label: { Text("Cancel") }
+                    label: { Text("Cancel") }
                     }
                 }
+            }
+            .sheet(isPresented: $isEditSheetPresented) {
+                editPresetPopover()
+                    .padding()
             }
             .onAppear {
                 configureView()
@@ -147,10 +187,48 @@ extension AddTempTarget {
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarItems(leading: Button("Close", action: state.hideModal))
         }
-
+        
+        @ViewBuilder private func editPresetPopover() -> some View {
+            Form {
+                Section(header: Text("Edit Preset")) {
+                    TextField("Name", text: $state.newPresetName)
+                    Text(displayString)
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+                    HStack {
+                        Text("New Target")
+                        Spacer()
+                        DecimalTextField("0", value: $state.low, formatter: formatter, cleanInput: true)
+                        Text(state.units.rawValue)
+                    }
+                    HStack {
+                        Text("New Duration")
+                        Spacer()
+                        DecimalTextField("0", value: $state.duration, formatter: formatter, cleanInput: true)
+                        Text("minutes")
+                    }
+                }
+                Section {
+                    Button("Save") {
+                        guard let selectedPreset = selectedPreset else { return }
+                        state.updatePreset(
+                            selectedPreset,
+                            low: state.units == .mmolL ? state.low.asMgdL : state.low
+                        )
+                        isEditSheetPresented = false
+                    }
+                    .disabled(state.newPresetName.isEmpty)
+                    
+                    Button("Cancel") {
+                        isEditSheetPresented = false
+                    }
+                }
+            }
+        }
+        
         private func presetView(for preset: TempTarget) -> some View {
             var low = preset.targetBottom
-            var high = preset.targetTop
+            var high = preset.targetBottom // change to only use targetBottom instead of targetTop
             if state.units == .mmolL {
                 low = low?.asMmolL
                 high = high?.asMmolL
@@ -160,14 +238,25 @@ extension AddTempTarget {
                     HStack {
                         Text(preset.displayName)
                         Spacer()
+                        Button {
+                            selectedPreset = preset
+                            state.newPresetName = preset.displayName
+                            state.low = state.units == .mmolL ? preset.targetBottom?
+                                .asMmolL ?? 0 : preset.targetBottom ?? 0
+                            state.duration = preset.duration
+                            state.date = preset.date as? Date ?? Date()
+                            isEditSheetPresented = true
+                        } label: {}
                     }
                     HStack(spacing: 2) {
-                        Text(
-                            "\(formatter.string(from: (low ?? 0) as NSNumber)!) - \(formatter.string(from: (high ?? 0) as NSNumber)!)"
-                        )
-                        .foregroundColor(.secondary)
-                        .font(.caption)
-
+                        if let lowValue = low,
+                           let formattedLow = formatter.string(from: lowValue as NSNumber)
+                        {
+                            Text(formattedLow)
+                                .foregroundColor(.secondary)
+                                .font(.caption)
+                        }
+                        
                         Text(state.units.rawValue)
                             .foregroundColor(.secondary)
                             .font(.caption)
@@ -180,31 +269,33 @@ extension AddTempTarget {
                         Text("min")
                             .foregroundColor(.secondary)
                             .font(.caption)
-
+                        
                         Spacer()
-                    }.padding(.top, 2)
+                    }.padding(.bottom, 2)
                 }
                 .contentShape(Rectangle())
                 .onTapGesture {
                     state.enactPreset(id: preset.id)
                 }
-
-                Image(systemName: "xmark.circle").foregroundColor(.secondary)
-                    .contentShape(Rectangle())
-                    .padding(.vertical)
-                    .onTapGesture {
-                        removeAlert = Alert(
-                            title: Text("Are you sure?"),
-                            message: Text("Delete preset \"\(preset.displayName)\""),
-                            primaryButton: .destructive(Text("Delete"), action: { state.removePreset(id: preset.id) }),
-                            secondaryButton: .cancel()
-                        )
-                        isRemoveAlertPresented = true
-                    }
-                    .alert(isPresented: $isRemoveAlertPresented) {
-                        removeAlert!
-                    }
             }
+        }
+    }
+}
+
+extension AddTempTarget.StateModel {
+    func updatePreset(_ preset: TempTarget, low: Decimal) {
+        if let index = presets.firstIndex(where: { $0.id == preset.id }) {
+            presets[index] = TempTarget(
+                id: preset.id,
+                name: newPresetName,
+                createdAt: preset.createdAt,
+                targetTop: low,
+                targetBottom: low,
+                duration: duration,
+                enteredBy: preset.enteredBy,
+                reason: newPresetName
+            )
+            storage.storePresets(presets)
         }
     }
 }

--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -10,19 +10,19 @@ extension AddTempTarget {
         @State private var isEditing = false
         @State private var selectedPreset: TempTarget?
         @State private var isEditSheetPresented = false
-        
+
         @FetchRequest(
             entity: TempTargetsSlider.entity(),
             sortDescriptors: [NSSortDescriptor(key: "date", ascending: false)]
         ) var isEnabledArray: FetchedResults<TempTargetsSlider>
-        
+
         private var formatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
             formatter.maximumFractionDigits = 1
             return formatter
         }
-        
+
         private var displayString: String {
             guard let preset = selectedPreset else { return "" }
             var low = preset.targetBottom
@@ -31,13 +31,13 @@ extension AddTempTarget {
                 low = low?.asMmolL
                 high = high?.asMmolL
             }
-            
+
             let formattedLow = low.flatMap { formatter.string(from: $0 as NSNumber) } ?? ""
             let formattedDuration = formatter.string(from: preset.duration as NSNumber) ?? ""
-            
+
             return "\(formattedLow) \(state.units.rawValue) for \(formattedDuration) min"
         }
-        
+
         var body: some View {
             Form {
                 if !state.presets.isEmpty {
@@ -66,14 +66,14 @@ extension AddTempTarget {
                         }
                     }
                 }
-                
+
                 HStack {
                     Text("Experimental")
                     Toggle(isOn: $state.viewPercantage) {}.controlSize(.mini)
                     Image(systemName: "figure.highintensity.intervaltraining")
                     Image(systemName: "fork.knife")
                 }
-                
+
                 if state.viewPercantage {
                     Section(
                         header: Text("")
@@ -82,7 +82,7 @@ extension AddTempTarget {
                             Slider(
                                 value: $state.percentage,
                                 in: 15 ...
-                                min(Double(state.maxValue * 100), 200),
+                                    min(Double(state.maxValue * 100), 200),
                                 step: 1,
                                 onEditingChanged: { editing in
                                     isEditing = editing
@@ -96,22 +96,22 @@ extension AddTempTarget {
                             // Only display target slider when not 100 %
                             if state.percentage != 100 {
                                 Divider()
-                                
+
                                 Slider(
                                     value: $state.hbt,
                                     in: 101 ... 295,
                                     step: 1
                                 ).accentColor(.green)
-                                
+
                                 HStack {
                                     Text(
                                         (
                                             state
                                                 .units == .mmolL ?
-                                            "\(state.computeTarget().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L" :
+                                                "\(state.computeTarget().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L" :
                                                 "\(state.computeTarget().formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) mg/dl"
                                         )
-                                        + NSLocalizedString("  Target Glucose", comment: "")
+                                            + NSLocalizedString("  Target Glucose", comment: "")
                                     )
                                     .foregroundColor(.green)
                                 }
@@ -134,7 +134,7 @@ extension AddTempTarget {
                         }
                         DatePicker("Date", selection: $state.date)
                         Button { isPromtPresented = true }
-                    label: { Text("Save as preset") }
+                        label: { Text("Save as preset") }
                     }
                 }
                 if state.viewPercantage {
@@ -147,16 +147,16 @@ extension AddTempTarget {
                         }
                         DatePicker("Date", selection: $state.date)
                         Button { isPromtPresented = true }
-                    label: { Text("Save as preset") }
+                        label: { Text("Save as preset") }
                             .disabled(state.duration == 0)
                     }
                 }
-                
+
                 Section {
                     Button { state.enact() }
-                label: { Text("Enact") }
+                    label: { Text("Enact") }
                     Button { state.cancel() }
-                label: { Text("Cancel Temp Target") }
+                    label: { Text("Cancel Temp Target") }
                 }
             }
             .popover(isPresented: $isPromtPresented) {
@@ -169,9 +169,9 @@ extension AddTempTarget {
                             state.save()
                             isPromtPresented = false
                         }
-                    label: { Text("Save") }
+                        label: { Text("Save") }
                         Button { isPromtPresented = false }
-                    label: { Text("Cancel") }
+                        label: { Text("Cancel") }
                     }
                 }
             }
@@ -187,7 +187,7 @@ extension AddTempTarget {
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarItems(leading: Button("Close", action: state.hideModal))
         }
-        
+
         @ViewBuilder private func editPresetPopover() -> some View {
             Form {
                 Section(header: Text("Edit Preset")) {
@@ -205,7 +205,7 @@ extension AddTempTarget {
                         Text("New Duration")
                         Spacer()
                         DecimalTextField("0", value: $state.duration, formatter: formatter, cleanInput: true)
-                        Text("minutes")
+                        Text("min")
                     }
                 }
                 Section {
@@ -218,14 +218,14 @@ extension AddTempTarget {
                         isEditSheetPresented = false
                     }
                     .disabled(state.newPresetName.isEmpty)
-                    
+
                     Button("Cancel") {
                         isEditSheetPresented = false
                     }
                 }
             }
         }
-        
+
         private func presetView(for preset: TempTarget) -> some View {
             var low = preset.targetBottom
             var high = preset.targetBottom // change to only use targetBottom instead of targetTop
@@ -256,7 +256,7 @@ extension AddTempTarget {
                                 .foregroundColor(.secondary)
                                 .font(.caption)
                         }
-                        
+
                         Text(state.units.rawValue)
                             .foregroundColor(.secondary)
                             .font(.caption)
@@ -269,7 +269,7 @@ extension AddTempTarget {
                         Text("min")
                             .foregroundColor(.secondary)
                             .font(.caption)
-                        
+
                         Spacer()
                     }.padding(.bottom, 2)
                 }

--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -7,6 +7,8 @@ extension AddTempTarget {
         let resolver: Resolver
         @StateObject var state = StateModel()
         @State private var isPromtPresented = false
+        @State private var isRemoveAlertPresented = false
+        @State private var removeAlert: Alert?
         @State private var isEditing = false
         @State private var selectedPreset: TempTarget?
         @State private var isEditSheetPresented = false
@@ -45,11 +47,20 @@ extension AddTempTarget {
                         ForEach(state.presets) { preset in
                             presetView(for: preset)
                                 .swipeActions {
-                                    Button(role: .destructive) {
-                                        state.removePreset(id: preset.id)
-                                    } label: {
+                                    Button(role: .none, action: {
+                                        removeAlert = Alert(
+                                            title: Text("Are you sure?"),
+                                            message: Text("Delete preset \n\(preset.displayName)?"),
+                                            primaryButton: .destructive(Text("Delete"), action: {
+                                                state.removePreset(id: preset.id)
+                                                isRemoveAlertPresented = false
+                                            }),
+                                            secondaryButton: .cancel()
+                                        )
+                                        isRemoveAlertPresented = true
+                                    }) {
                                         Label("Delete", systemImage: "trash")
-                                    }
+                                    }.tint(.red)
                                     Button {
                                         selectedPreset = preset
                                         state.newPresetName = preset.displayName
@@ -62,6 +73,9 @@ extension AddTempTarget {
                                         Label("Edit", systemImage: "square.and.pencil")
                                     }
                                     .tint(.blue)
+                                }
+                                .alert(isPresented: $isRemoveAlertPresented) {
+                                    removeAlert!
                                 }
                         }
                     }

--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -192,7 +192,7 @@ extension AddTempTarget {
             Form {
                 Section(header: Text("Edit Preset")) {
                     TextField("Name", text: $state.newPresetName)
-                    Text(displayString)
+                    Text("Before change: \(displayString)")
                         .foregroundColor(.secondary)
                         .font(.caption)
                     HStack {
@@ -213,7 +213,7 @@ extension AddTempTarget {
                         guard let selectedPreset = selectedPreset else { return }
                         state.updatePreset(
                             selectedPreset,
-                            low: state.units == .mmolL ? state.low.asMgdL : state.low
+                            low: state.low
                         )
                         isEditSheetPresented = false
                     }
@@ -278,24 +278,6 @@ extension AddTempTarget {
                     state.enactPreset(id: preset.id)
                 }
             }
-        }
-    }
-}
-
-extension AddTempTarget.StateModel {
-    func updatePreset(_ preset: TempTarget, low: Decimal) {
-        if let index = presets.firstIndex(where: { $0.id == preset.id }) {
-            presets[index] = TempTarget(
-                id: preset.id,
-                name: newPresetName,
-                createdAt: preset.createdAt,
-                targetTop: low,
-                targetBottom: low,
-                duration: duration,
-                enteredBy: preset.enteredBy,
-                reason: newPresetName
-            )
-            storage.storePresets(presets)
         }
     }
 }

--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -130,6 +130,14 @@ extension AddTempTarget {
                 Text("Experimental")
                 Toggle(isOn: $state.viewPercantage) {}
                     .controlSize(.mini)
+                    .onChange(of: state.viewPercantage) { newValue in
+                        if newValue {
+                            guard let selectedPreset = selectedPreset,
+                                  let targetBottom = selectedPreset.targetBottom else { return }
+                            let computedPercentage = state.computePercentage(target: targetBottom)
+                            state.percentage = Double(truncating: computedPercentage as NSNumber)
+                        }
+                    }
                 Image(systemName: "figure.highintensity.intervaltraining")
                 Image(systemName: "fork.knife")
             }
@@ -226,6 +234,11 @@ extension AddTempTarget {
                         isEditSheetPresented = false
                     }
                 }
+            }
+            .onAppear {
+                guard let selectedPreset = selectedPreset, let targetBottom = selectedPreset.targetBottom else { return }
+                let computedPercentage = state.computePercentage(target: targetBottom)
+                state.percentage = Double(truncating: computedPercentage as NSNumber)
             }
             .onDisappear {
                 if isEditSheetPresented == false {


### PR DESCRIPTION
- Enable editing Name, Target and Duration for preset temp targets
- Swipe left to edit or delete
- Replaced display of "Low target - High target" in presetView since only low target is used
- Edit popup shows current settings, and editing of name, target and duration is done in the popup

Connected to issue #234 and PR #235 

Extra useful when preset temp targets are used with shortcuts (no need to re add changed presets in shortcuts since id remains unchanged after edit - even if you change name on the preset)

**NOTE!** This is not an attempt to redesign the entire UI. This is just to add edit functionality with minimal changes.

**Screenshots**
| Edit or Delete swipe | Edit View |
|--------|--------|
| ![Simulator Screenshot - iPhone 13 mini+ - 2024-05-25 at 09 46 13](https://github.com/nightscout/Trio/assets/72826201/75f9c3f2-112d-4ed4-8dbf-f133fe52010e) | ![Simulator Screenshot - iPhone 13 mini+ - 2024-05-25 at 09 46 19](https://github.com/nightscout/Trio/assets/72826201/7ac869ce-461d-4b9e-833c-4b1ba62ba27c) | 

**Video demo**

https://github.com/nightscout/Trio/assets/72826201/72ac5941-af02-4232-8e6f-e49f366b54ca

