### PR TITLE
Advanced TempTarget slider

### DIFF
--- a/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
@@ -198,8 +198,7 @@ extension AddTempTarget {
             if units == .mmolL, !viewPercantage {
                 lowTarget = Decimal(round(Double(lowTarget.asMgdL)))
             }
-            let highTarget = lowTarget
-            
+
             if viewPercantage {
                 hbt = computeHBT()
             }
@@ -220,8 +219,7 @@ extension AddTempTarget {
                 storage.storePresets(presets)
             }
         }
-        
-        
+
         func computePercentage(target: Decimal) -> Decimal {
             let c = Decimal(hbt - 100)
             var ratio = c / (c + target - 100)
@@ -234,7 +232,6 @@ extension AddTempTarget {
             let roundedPercentage = (adjustedPercentage as NSDecimalNumber).rounding(accordingToBehavior: nil)
             return roundedPercentage as Decimal
         }
-
 
         func computeHBT() -> Double {
             let ratio = Decimal(percentage / 100)

--- a/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
@@ -33,9 +33,13 @@ extension AddTempTarget {
                 return
             }
             var lowTarget = low
+            if units == .mmolL {
+                lowTarget = Decimal(round(Double(lowTarget.asMgdL)))
+            }
+            let highTarget = lowTarget
 
             if viewPercantage {
-                lowTarget = Decimal(round(Double(computeTarget())))
+                hbt = computeHBT()
                 coredataContext.performAndWait {
                     let saveToCoreData = TempTargets(context: self.coredataContext)
                     saveToCoreData.id = UUID().uuidString
@@ -54,12 +58,6 @@ extension AddTempTarget {
                     saveToCoreData.date = Date()
                     try? coredataContext.save()
                 }
-            }
-            var highTarget = lowTarget
-
-            if units == .mmolL, !viewPercantage {
-                lowTarget = Decimal(round(Double(lowTarget.asMgdL)))
-                highTarget = lowTarget
             }
 
             let entry = TempTarget(
@@ -105,16 +103,14 @@ extension AddTempTarget {
                 return
             }
             var lowTarget = low
+            if units == .mmolL {
+                lowTarget = Decimal(round(Double(lowTarget.asMgdL)))
+            }
+            let highTarget = lowTarget
 
             if viewPercantage {
-                lowTarget = Decimal(round(Double(computeTarget())))
+                hbt = computeHBT()
                 saveSettings = true
-            }
-            var highTarget = lowTarget
-
-            if units == .mmolL, !viewPercantage {
-                lowTarget = Decimal(round(Double(lowTarget.asMgdL)))
-                highTarget = lowTarget
             }
 
             let entry = TempTarget(
@@ -196,28 +192,16 @@ extension AddTempTarget {
             return Decimal(Double(target))
         }
 
-        func computePercentage(target: Decimal) -> Decimal {
-            let c = Decimal(hbt - 100)
-            var ratio = c / (c + target - 100)
-
-            if ratio > maxValue {
-                ratio = maxValue
-            }
-
-            let adjustedPercentage = ratio * 100
-            let roundedPercentage = (adjustedPercentage as NSDecimalNumber).rounding(accordingToBehavior: nil)
-            return roundedPercentage as Decimal
-        }
-
         func updatePreset(_ preset: TempTarget) {
             var lowTarget = low
 
-            if viewPercantage {
-                lowTarget = Decimal(round(Double(computeTarget())))
-            }
-
             if units == .mmolL, !viewPercantage {
                 lowTarget = Decimal(round(Double(lowTarget.asMgdL)))
+            }
+            let highTarget = lowTarget
+            
+            if viewPercantage {
+                hbt = computeHBT()
             }
 
             let updatedPreset = TempTarget(
@@ -235,6 +219,34 @@ extension AddTempTarget {
                 presets[index] = updatedPreset
                 storage.storePresets(presets)
             }
+        }
+        
+        
+        func computePercentage(target: Decimal) -> Decimal {
+            let c = Decimal(hbt - 100)
+            var ratio = c / (c + target - 100)
+
+            if ratio > maxValue {
+                ratio = maxValue
+            }
+
+            let adjustedPercentage = ratio * 100
+            let roundedPercentage = (adjustedPercentage as NSDecimalNumber).rounding(accordingToBehavior: nil)
+            return roundedPercentage as Decimal
+        }
+
+
+        func computeHBT() -> Double {
+            let ratio = Decimal(percentage / 100)
+            let normalTarget: Decimal = 100
+            var target: Decimal = low
+            if units == .mmolL {
+                target = target.asMgdL }
+            var hbtcalc = Decimal(hbt)
+            if ratio != 1 {
+                hbtcalc = ((2 * ratio * normalTarget) - normalTarget - (ratio * target)) / (ratio - 1)
+            }
+            return round(Double(hbtcalc))
         }
     }
 }

--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -135,7 +135,12 @@ extension AddTempTarget {
                             guard let selectedPreset = selectedPreset,
                                   let targetBottom = selectedPreset.targetBottom else { return }
                             let computedPercentage = state.computePercentage(target: targetBottom)
-                            state.percentage = Double(truncating: computedPercentage as NSNumber)
+                            state.hbt = isEnabledArray.first?
+                                .hbt ??
+                                160 // how to get hbt from previously saved preset? this takes the last enacted temptarget hbt?
+                            state
+                                .percentage =
+                                Double(truncating: computedPercentage as NSNumber) // now I guess state.percentage needs to become whatever I do on slider
                         }
                     }
                 Image(systemName: "figure.highintensity.intervaltraining")
@@ -248,7 +253,9 @@ extension AddTempTarget {
             .onAppear {
                 guard let selectedPreset = selectedPreset, let targetBottom = selectedPreset.targetBottom else { return }
                 let computedPercentage = state.computePercentage(target: targetBottom)
-                state.percentage = Double(truncating: computedPercentage as NSNumber)
+                state
+                    .percentage =
+                    Double(truncating: computedPercentage as NSNumber) // I guess this needs to come directly from the slider
             }
             .onDisappear {
                 if isEditSheetPresented == false {

--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -127,7 +127,7 @@ extension AddTempTarget {
 
         @ViewBuilder func settingsSection(header: String) -> some View {
             HStack {
-                Text("Experimental")
+                Text("Advanced TT")
                 Toggle(isOn: $state.viewPercantage) {}
                     .controlSize(.mini)
                     .onChange(of: state.viewPercantage) { newValue in
@@ -143,42 +143,52 @@ extension AddTempTarget {
             }
 
             if state.viewPercantage {
-                Section {
+                Section(
+                    header: Text("TT Effect on Insulin")
+                ) {
                     VStack {
-                        Text("\(state.percentage.formatted(.number)) % Insulin")
-                            .foregroundColor(isEditing ? .orange : .blue)
-                            .font(.largeTitle)
-                            .padding(.vertical)
-                        Slider(
-                            value: $state.percentage,
-                            in: 15 ...
-                                min(Double(state.maxValue * 100), 200),
-                            step: 1,
-                            onEditingChanged: { editing in
-                                isEditing = editing
-                            }
-                        )
-                        HStack {}
-                        // Only display target slider when not 100 %
-                        if state.percentage != 100 {
+                        HStack {
+                            Text(NSLocalizedString("Target", comment: ""))
                             Spacer()
+                            DecimalTextField(
+                                "0",
+                                value: $state.low,
+                                formatter: formatter,
+                                cleanInput: true
+                            )
+                            Text(state.units.rawValue).foregroundColor(.secondary)
+                        }
+
+                        if computeSliderLow() != computeSliderHigh() {
+                            Text("\(state.percentage.formatted(.number)) % Insulin")
+                                .foregroundColor(isEditing ? .orange : .blue)
+                                .font(.largeTitle)
+                            Slider(
+                                value: $state.percentage,
+                                in: computeSliderLow() ... computeSliderHigh(),
+                                step: 5
+                            ) {}
+                            minimumValueLabel: { Text("\(computeSliderLow(), specifier: "%.0f")%") }
+                            maximumValueLabel: { Text("\(computeSliderHigh(), specifier: "%.0f")%") }
+                            onEditingChanged: { editing in
+                                isEditing = editing }
                             Divider()
                             Text(
-                                (
-                                    state
-                                        .units == .mmolL ?
-                                        "\(state.computeTarget().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L" :
-                                        "\(state.computeTarget().formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) mg/dl"
-                                )
-                                    + NSLocalizedString(" Target Glucose", comment: "")
+                                state
+                                    .units == .mgdL ?
+                                    "Half Basal Exercise Target at: \(state.computeHBT().formatted(.number)) mg/dl" :
+                                    "Half Basal Exercise Target at: \(state.computeHBT().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L"
                             )
-                            .foregroundColor(.green)
-                            .padding(.vertical)
-                            Slider(
-                                value: $state.hbt,
-                                in: 101 ... 295,
-                                step: 1
-                            ).accentColor(.green)
+                            .foregroundColor(.secondary)
+                            .font(.caption).italic()
+                        } else {
+                            Text(
+                                "You have not enabled the proper Preferences to change sensitivity with chosen TempTarget. Verify Autosens Max > 1 & lowTT lowers Sens is on for lowTT's. For high TTs check highTT raises Sens is on (or Exercise Mode)!"
+                            )
+                            // .foregroundColor(.loopRed)
+                            .font(.caption).italic()
+                            .fixedSize(horizontal: false, vertical: true)
+                            .multilineTextAlignment(.leading)
                         }
                     }
                 }
@@ -296,5 +306,30 @@ extension AddTempTarget {
                     state.enactPreset(id: preset.id)
                 }
             }
-        } }
+        }
+
+        func computeSliderLow() -> Double {
+            var minSens: Double = 15
+            var target = state.low
+            if state.units == .mmolL {
+                target = Decimal(round(Double(state.low.asMgdL))) }
+            if target == 0 { return minSens }
+            if target < 100 ||
+                (
+                    !state.settingsManager.preferences.highTemptargetRaisesSensitivity && !state.settingsManager.preferences
+                        .exerciseMode
+                ) { minSens = 100 }
+            return minSens
+        }
+
+        func computeSliderHigh() -> Double {
+            var maxSens = Double(state.maxValue * 100)
+            var target = state.low
+            if target == 0 { return maxSens }
+            if state.units == .mmolL {
+                target = Decimal(round(Double(state.low.asMgdL))) }
+            if target > 100 || !state.settingsManager.preferences.lowTemptargetLowersSensitivity { maxSens = 100 }
+            return maxSens
+        }
+    }
 }


### PR DESCRIPTION
The **current Experimental TT slider** has disadvantages.
| old Slider | arguments |
| --- | --- |
| ![Simulator Screenshot - Dev 12 mini - 2024-05-26 at 22 19 27](https://github.com/nightscout/Trio/assets/539276/7866ae6a-7065-42e9-bcbb-44dc37830882) | The slider for the Target Glucose actualy slides HalfBasalExercixeTarget (HBT) and shows the calculated TempTarget with that HBT and the the chosen Insulin fraction above. This will result in above shown example that with a high sensitivity of 75% Insulin one could set a High TT of max 165mg/dL. This bears no justification. Also from my sports activities, which is the major application, I first choose at which target glucose I want to exercise and when at which sensitivity. The refactored slider adjusts the desired Insulin % (sensitivity ratio) and calculates HBT. So here the boundaries are not applied like in the old solution to HBT but to the sensitivity ratio. For highTT the min sensitivity ratio is 15%, for lowTT the autosensMax defines the border of low sensitivity applied by the TT. |

**New Advanced TT slider**:

https://github.com/nightscout/Trio/assets/539276/73477905-623b-4546-adc0-ce1ca0f7fa63

The feature itself is standard oref, but it requires setting an HBT to arrive at desired sensitivity. This is a comfortable solution to use that feature for exercise TT's. The new slider addresses the issues of boundaries and also increments the single slider by 5% points. This solution still uses Jon's oref2 variable injection of HBT into oref as a variable that overrides the HBT as defined in user preferences. This PR could be a good playing ground to change that and make the HBT calculation result the new user preference for the time the TT is active. Once the TT is not active anymore the user preference should revert to the state before TT. Unfortunately I would need assistance with that.

Once this is discussed and implemented it could be also conceptually used for Overrides and how the temporary replace user preferences. This  way no additional injections into oref are needed for TT's and Profile Overrides.