### PR TITLE
Remove unused Import Settings in JSON that cause errors decoding JSON

### DIFF
--- a/FreeAPS/Sources/Models/RawFetchedProfile.swift
+++ b/FreeAPS/Sources/Models/RawFetchedProfile.swift
@@ -4,16 +4,12 @@ struct FetchedNightscoutProfileStore: JSON {
     let _id: String
     let defaultProfile: String
     let startDate: String
-    let mills: Decimal
     let enteredBy: String
-    let store: [String: ScheduledNightscoutProfile]
-    let created_at: String
+    let store: [String: FetchedNightscoutProfile]
 }
 
 struct FetchedNightscoutProfile: JSON {
     let dia: Decimal
-    let carbs_hr: Int
-    let delay: Decimal
     let timezone: String
     let target_low: [NightscoutTimevalue]
     let target_high: [NightscoutTimevalue]

--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -133,7 +133,9 @@ extension NightscoutConfig {
                 {
                     do {
                         let fetchedProfileStore = try jsonDecoder.decode([FetchedNightscoutProfileStore].self, from: data)
-                        guard let fetchedProfile: ScheduledNightscoutProfile = fetchedProfileStore.first?.store["default"]
+                        let loop = fetchedProfileStore.first?.enteredBy.contains("Loop")
+                        guard let fetchedProfile: FetchedNightscoutProfile = fetchedProfileStore.first?
+                            .store[loop! ? "Default" : "default"]
                         else {
                             error = "\nCan't find the default Nightscout Profile."
                             group.leave()


### PR DESCRIPTION
Resolves [Nightscout CGM Import Settings fails with error](https://github.com/nightscout/Trio/issues/245) by:

1. Removing unused fields from the JSON struct which do not get saved or written to settings/pump.  These unused fields used Types that were inconsistent with Loop JSON.
2. Checks if JSON Profile was entered by Loop to ensure proper Default record is loaded.
