### PR TITLE
Set median of lower and upper correction range bound when importing L…

### DIFF
--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -241,7 +241,8 @@ extension NightscoutConfig {
                                 let median = loop! ? self.getMedianTarget(
                                     lowTargetValue: target.value,
                                     lowTargetTime: target.time,
-                                    highTarget: fetchedProfile.target_high, units: self.units
+                                    highTarget: fetchedProfile.target_high,
+                                    units: self.units
                                 ) : target.value
                                 return BGTargetEntry(
                                     low: median,

--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -151,9 +151,12 @@ extension NightscoutConfig {
                 {
                     do {
                         let fetchedProfileStore = try jsonDecoder.decode([FetchedNightscoutProfileStore].self, from: data)
-                        let loop = fetchedProfileStore.first?.enteredBy.contains("Loop")
-                        guard let fetchedProfile: FetchedNightscoutProfile = fetchedProfileStore.first?
-                            .store[loop! ? "Default" : "default"]
+                        let loop = ((fetchedProfileStore.first?.enteredBy.contains("Loop")) != nil) ||
+                            ((fetchedProfileStore.first?.enteredBy.contains("AndroidAPS")) != nil)
+                        guard let fetchedProfile: FetchedNightscoutProfile =
+                            (fetchedProfileStore.first?.store["default"] != nil) ?
+                            fetchedProfileStore.first?.store["default"] :
+                            fetchedProfileStore.first?.store["Default"]
                         else {
                             error = "\nCan't find the default Nightscout Profile."
                             group.leave()
@@ -238,7 +241,7 @@ extension NightscoutConfig {
 
                         let targets = fetchedProfile.target_low
                             .map { target -> BGTargetEntry in
-                                let median = loop! ? self.getMedianTarget(
+                                let median = loop ? self.getMedianTarget(
                                     lowTargetValue: target.value,
                                     lowTargetTime: target.time,
                                     highTarget: fetchedProfile.target_high,

--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -151,8 +151,7 @@ extension NightscoutConfig {
                 {
                     do {
                         let fetchedProfileStore = try jsonDecoder.decode([FetchedNightscoutProfileStore].self, from: data)
-                        let loop = ((fetchedProfileStore.first?.enteredBy.contains("Loop")) != nil) ||
-                            ((fetchedProfileStore.first?.enteredBy.contains("AndroidAPS")) != nil)
+                        let loop = fetchedProfileStore.first?.enteredBy.contains("Loop")
                         guard let fetchedProfile: FetchedNightscoutProfile =
                             (fetchedProfileStore.first?.store["default"] != nil) ?
                             fetchedProfileStore.first?.store["default"] :
@@ -241,7 +240,7 @@ extension NightscoutConfig {
 
                         let targets = fetchedProfile.target_low
                             .map { target -> BGTargetEntry in
-                                let median = loop ? self.getMedianTarget(
+                                let median = loop! ? self.getMedianTarget(
                                     lowTargetValue: target.value,
                                     lowTargetTime: target.time,
                                     highTarget: fetchedProfile.target_high,


### PR DESCRIPTION
Resolves [NS Settings Import: Set median of lower and upper correction range bound when importing Loop settings](https://github.com/nightscout/Trio/issues/252) by:

Sets Trio's target correction low and high to median of lower and upper target range when NS profile's enteredBy is Loop.  Rounds median value to 0 or 1 significant digits depending on Glucose unit (0 for mg/dL, 1 for mmol/L).

EDIT:
This issue probably applies to AAPS, too, since it also uses a low and high target.  [examples.json](https://github.com/nightscout/AndroidAPS/blob/3df83535f9f8f3246308121900c2785c50915fa8/core/nssdk/src/main/kotlin/app/aaps/core/nssdk/remotemodel/examples.json#L332) shows its `profileJson` with `target_low` and `target_high`.  I cannot test it w/out having an actual "openaps://AndroidAPS" profile though.

I think merged PR, Remove unused Import Settings in JSON that cause errors decoding JSON #249, also applies to AAPS.