### PR TITLE
[DanaKit] Progress update 02-06-2024

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -1,5 +1,6 @@
 import Algorithms
 import Combine
+import DanaKit
 import Foundation
 import LoopKit
 import LoopKitUI
@@ -33,6 +34,7 @@ private let staticPumpManagers: [PumpManagerUI.Type] = [
     MinimedPumpManager.self,
     OmnipodPumpManager.self,
     OmniBLEPumpManager.self,
+    DanaKitPumpManager.self,
     MockPumpManager.self
 ]
 
@@ -40,6 +42,7 @@ private let staticPumpManagersByIdentifier: [String: PumpManagerUI.Type] = [
     MinimedPumpManager.pluginIdentifier: MinimedPumpManager.self,
     OmnipodPumpManager.pluginIdentifier: OmnipodPumpManager.self,
     OmniBLEPumpManager.pluginIdentifier: OmniBLEPumpManager.self,
+    DanaKitPumpManager.pluginIdentifier: DanaKitPumpManager.self,
     MockPumpManager.pluginIdentifier: MockPumpManager.self
 ]
 

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -8,7 +8,8 @@ extension AddCarbs {
         @StateObject var state = StateModel()
         @State var dish: String = ""
         @State var isPromtPresented = false
-        @State var saved = false
+        @State var noteSaved = false
+        @State var mealSaved = false
         @State private var showAlert = false
         @FocusState private var isFocused: Bool
 
@@ -117,9 +118,12 @@ extension AddCarbs {
                 }
 
                 Section {
-                    Button { state.add() }
+                    Button {
+                        mealSaved = true
+                        state.add()
+                    }
                     label: { Text("Save and continue").font(.title3) }
-                        .disabled(state.carbs <= 0 && state.fat <= 0 && state.protein <= 0)
+                        .disabled(mealSaved || state.carbs <= 0 && state.fat <= 0 && state.protein <= 0)
                         .frame(maxWidth: .infinity, alignment: .center)
                 } footer: { Text(state.waitersNotepad().description) }
 
@@ -138,8 +142,8 @@ extension AddCarbs {
                 Section {
                     TextField("Name Of Dish", text: $dish)
                     Button {
-                        saved = true
-                        if dish != "", saved {
+                        noteSaved = true
+                        if dish != "", noteSaved {
                             let preset = Presets(context: moc)
                             preset.dish = dish
                             preset.fat = state.fat as NSDecimalNumber
@@ -147,14 +151,14 @@ extension AddCarbs {
                             preset.carbs = state.carbs as NSDecimalNumber
                             try? moc.save()
                             state.addNewPresetToWaitersNotepad(dish)
-                            saved = false
+                            noteSaved = false
                             isPromtPresented = false
                         }
                     }
                     label: { Text("Save") }
                     Button {
                         dish = ""
-                        saved = false
+                        noteSaved = false
                         isPromtPresented = false }
                     label: { Text("Cancel") }
                 } header: { Text("Enter Meal Preset Name") }


### PR DESCRIPTION
A long overdue update for the DanaKit project. This PR contains (but not limited to) the following changes:
- fix for Loop cycle hangs
- Lower limit of time difference (was 1 minute, but caused double insulin entries)
- Rename all the hardcoded Loop to the dynamic appName (thanks @marionbarker!)
- Added error messages for failed bolus (daily limit violation or bolus timeout error, i.e.)
- Improved static basal steps (since a Dana pump supports basal steps of 0.01U/hr)
- Optimize connection logic/sync (some data will only be synced during the sync function instead of at every connection)

And a sync with dev :)