### PR TITLE
Add an option to confirm boluses faster on Apple Watch

### DIFF
--- a/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
+++ b/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
@@ -42,5 +42,6 @@
   "rulerMarks" : true,
   "maxCarbs": 250,
   "displayFatAndProteinOnWatch": false,
+  "confirmBolusFaster": false,
   "lockScreenView": "simple"
 }

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -43,6 +43,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var rulerMarks: Bool = true
     var maxCarbs: Decimal = 250
     var displayFatAndProteinOnWatch: Bool = false
+    var confirmBolusFaster: Bool = false
     var onlyAutotuneBasals: Bool = false
     var useLiveActivity: Bool = false
     var lockScreenView: LockScreenView = .simple
@@ -225,6 +226,10 @@ extension FreeAPSSettings: Decodable {
 
         if let displayFatAndProteinOnWatch = try? container.decode(Bool.self, forKey: .displayFatAndProteinOnWatch) {
             settings.displayFatAndProteinOnWatch = displayFatAndProteinOnWatch
+        }
+
+        if let confirmBolusFaster = try? container.decode(Bool.self, forKey: .confirmBolusFaster) {
+            settings.confirmBolusFaster = confirmBolusFaster
         }
 
         if let onlyAutotuneBasals = try? container.decode(Bool.self, forKey: .onlyAutotuneBasals) {

--- a/FreeAPS/Sources/Modules/WatchConfig/View/WatchConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/WatchConfig/View/WatchConfigRootView.swift
@@ -17,9 +17,9 @@ extension WatchConfig {
                             Text(v.displayName).tag(v)
                         }
                     }
+                    Toggle("Display Protein & Fat", isOn: $state.displayFatAndProteinOnWatch)
+                    Toggle("Confirm Bolus Faster", isOn: $state.confirmBolusFaster)
                 }
-
-                Toggle("Display Protein & Fat", isOn: $state.displayFatAndProteinOnWatch)
 
                 Section(header: Text("Garmin Watch")) {
                     List {

--- a/FreeAPS/Sources/Modules/WatchConfig/WatchConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/WatchConfig/WatchConfigStateModel.swift
@@ -31,6 +31,7 @@ extension WatchConfig {
         @Published var devices: [IQDevice] = []
         @Published var selectedAwConfig: AwConfig = .HR
         @Published var displayFatAndProteinOnWatch = false
+        @Published var confirmBolusFaster = false
 
         private(set) var preferences = Preferences()
 
@@ -38,6 +39,7 @@ extension WatchConfig {
             preferences = provider.preferences
 
             subscribeSetting(\.displayFatAndProteinOnWatch, on: $displayFatAndProteinOnWatch) { displayFatAndProteinOnWatch = $0 }
+            subscribeSetting(\.confirmBolusFaster, on: $confirmBolusFaster) { confirmBolusFaster = $0 }
             subscribeSetting(\.displayOnWatch, on: $selectedAwConfig) { selectedAwConfig = $0 }
             didSet: { [weak self] value in
                 // for compatibility with old displayHR

--- a/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
+++ b/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
@@ -106,6 +106,7 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
             self.state.bolusAfterCarbs = !self.settingsManager.settings.skipBolusScreenAfterCarbs
             self.state.displayOnWatch = self.settingsManager.settings.displayOnWatch
             self.state.displayFatAndProteinOnWatch = self.settingsManager.settings.displayFatAndProteinOnWatch
+            self.state.confirmBolusFaster = self.settingsManager.settings.confirmBolusFaster
 
             let eBG = self.evetualBGStraing()
             self.state.eventualBG = eBG.map { "⇢ " + $0 }

--- a/FreeAPSWatch WatchKit Extension/DataFlow.swift
+++ b/FreeAPSWatch WatchKit Extension/DataFlow.swift
@@ -22,6 +22,7 @@ struct WatchState: Codable {
     var eventualBGRaw: String?
     var displayOnWatch: AwConfig?
     var displayFatAndProteinOnWatch: Bool?
+    var confirmBolusFaster: Bool?
     var isf: Decimal?
     var override: String?
 }

--- a/FreeAPSWatch WatchKit Extension/Views/BolusConfirmationView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/BolusConfirmationView.swift
@@ -75,7 +75,7 @@ struct BolusConfirmationView: View {
             $crownProgress,
             from: 0.0,
             through: 100.0,
-            by: 0.5,
+            by: state.confirmBolusFaster ? 5 : 0.5,
             sensitivity: .high,
             isContinuous: false,
             isHapticFeedbackEnabled: true

--- a/FreeAPSWatch WatchKit Extension/WatchStateModel.swift
+++ b/FreeAPSWatch WatchKit Extension/WatchStateModel.swift
@@ -34,6 +34,7 @@ class WatchStateModel: NSObject, ObservableObject {
     @Published var isBolusViewActive = false
     @Published var displayOnWatch: AwConfig = .BGTarget
     @Published var displayFatAndProteinOnWatch = false
+    @Published var confirmBolusFaster = false
     @Published var eventualBG = ""
     @Published var isConfirmationViewActive = false {
         didSet {
@@ -174,6 +175,7 @@ class WatchStateModel: NSObject, ObservableObject {
         eventualBG = state.eventualBG ?? ""
         displayOnWatch = state.displayOnWatch ?? .BGTarget
         displayFatAndProteinOnWatch = state.displayFatAndProteinOnWatch ?? false
+        confirmBolusFaster = state.confirmBolusFaster ?? false
         isf = state.isf
         override = state.override
     }


### PR DESCRIPTION
Adds an option to reduce the amount you need to spin the crown on an Apple Watch to confirm a bolus.

⚙️>`Watch`>`Confirm Bolus Faster`
<img width="350" alt="Confirm Bolus Faster" src="https://github.com/nightscout/Trio/assets/82073483/2148f92f-ff30-4a06-af3b-91cf9b83b7c2">

Has been in iAPS-dev since 2024-02-09: https://github.com/Artificial-Pancreas/iAPS/pull/508