### PR TITLE
Port over pump loss fix via LoopKit/Loop#1702

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -43,10 +43,6 @@ private let staticPumpManagersByIdentifier: [String: PumpManagerUI.Type] = [
     MockPumpManager.pluginIdentifier: MockPumpManager.self
 ]
 
-// private let staticPumpManagersByIdentifier: [String: PumpManagerUI.Type] = staticPumpManagers.reduce(into: [:]) { map, Type in
-//    map[Type.managerIdentifier] = Type
-// }
-
 private let accessLock = NSRecursiveLock(label: "BaseDeviceDataManager.accessLock")
 
 final class BaseDeviceDataManager: DeviceDataManager, Injectable {
@@ -78,7 +74,8 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
         didSet {
             pumpManager?.pumpManagerDelegate = self
             pumpManager?.delegateQueue = processQueue
-            UserDefaults.standard.pumpManagerRawValue = pumpManager?.rawValue
+            rawPumpManager = pumpManager?.rawValue
+            UserDefaults.standard.clearLegacyPumpManagerRawValue()
             if let pumpManager = pumpManager {
                 pumpDisplayState.value = PumpDisplayState(name: pumpManager.localizedTitle, image: pumpManager.smallImage)
                 pumpName.send(pumpManager.localizedTitle)
@@ -105,6 +102,8 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
         }
     }
 
+    @PersistedProperty(key: "PumpManagerState") var rawPumpManager: PumpManager.RawValue?
+
     var bluetoothManager: BluetoothStateManager { bluetoothProvider }
 
     var hasBLEHeartbeat: Bool {
@@ -123,7 +122,11 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
     }
 
     func setupPumpManager() {
-        pumpManager = UserDefaults.standard.pumpManagerRawValue.flatMap { pumpManagerFromRawValue($0) }
+        if let pumpManagerRawValue = rawPumpManager ?? UserDefaults.standard.legacyPumpManagerRawValue {
+            pumpManager = pumpManagerFromRawValue(pumpManagerRawValue)
+        } else {
+            pumpManager = nil
+        }
     }
 
     func createBolusProgressReporter() -> DoseProgressReporter? {
@@ -163,20 +166,6 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
                 self.updateUpdateFinished(true)
             }
         }
-
-//        pumpUpdateCancellable = Future<Bool, Never> { [unowned self] promise in
-//            pumpUpdatePromise = promise
-//            debug(.deviceManager, "Waiting for pump update and loop recommendation")
-//            processQueue.safeSync {
-//                pumpManager.ensureCurrentPumpData { _ in
-//                    debug(.deviceManager, "Pump data updated.")
-//                }
-//            }
-//        }
-//        .timeout(30, scheduler: processQueue)
-//        .replaceError(with: false)
-//        .replaceEmpty(with: false)
-//        .sink(receiveValue: updateUpdateFinished)
     }
 
     private func updateUpdateFinished(_ recommendsLoop: Bool) {
@@ -186,11 +175,6 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
             warning(.deviceManager, "Loop recommendation time out or got error. Trying to loop right now.")
         }
 
-        // directly in loop() function
-//        guard !loopInProgress else {
-//            warning(.deviceManager, "Loop already in progress. Skip recommendation.")
-//            return
-//        }
         self.recommendsLoop.send()
     }
 
@@ -319,7 +303,8 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
     }
 
     func pumpManagerDidUpdateState(_ pumpManager: PumpManager) {
-        UserDefaults.standard.pumpManagerRawValue = pumpManager.rawValue
+        rawPumpManager = pumpManager.rawValue
+        UserDefaults.standard.clearLegacyPumpManagerRawValue()
         if self.pumpManager == nil, let newPumpManager = pumpManager as? PumpManagerUI {
             self.pumpManager = newPumpManager
         }
@@ -536,29 +521,6 @@ extension BaseDeviceDataManager: DeviceManagerDelegate {
     ) {}
 
     func recordRetractedAlert(_: Alert, at _: Date) {}
-
-//    func scheduleNotification(
-//        for _: DeviceManager,
-//        identifier: String,
-//        content: UNNotificationContent,
-//        trigger: UNNotificationTrigger?
-//    ) {
-//        let request = UNNotificationRequest(
-//            identifier: identifier,
-//            content: content,
-//            trigger: trigger
-//        )
-//
-//        DispatchQueue.main.async {
-//            UNUserNotificationCenter.current().add(request)
-//        }
-//    }
-//
-//    func clearNotification(for _: DeviceManager, identifier: String) {
-//        DispatchQueue.main.async {
-//            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [identifier])
-//        }
-//    }
 
     func removeNotificationRequests(for _: DeviceManager, identifiers: [String]) {
         DispatchQueue.main.async {

--- a/FreeAPS/Sources/APS/Extensions/PumpManagerExtensions.swift
+++ b/FreeAPS/Sources/APS/Extensions/PumpManagerExtensions.swift
@@ -2,6 +2,8 @@ import LoopKit
 import LoopKitUI
 
 extension PumpManager {
+    typealias RawValue = [String: Any]
+
     var rawValue: [String: Any] {
         [
             "managerIdentifier": pluginIdentifier, // "managerIdentifier": type(of: self).managerIdentifier,
@@ -11,14 +13,6 @@ extension PumpManager {
 }
 
 extension PumpManagerUI {
-//    static func setupViewController() -> PumpManagerSetupViewController & UIViewController & CompletionNotifying {
-//        setupViewController(
-//            insulinTintColor: .accentColor,
-//            guidanceColors: GuidanceColors(acceptable: .green, warning: .orange, critical: .red),
-//            allowedInsulinTypes: [.apidra, .humalog, .novolog, .fiasp, .lyumjev]
-//        )
-//    }
-
     func settingsViewController(
         bluetoothProvider: BluetoothProvider,
         pumpManagerOnboardingDelegate: PumpManagerOnboardingDelegate?
@@ -32,14 +26,6 @@ extension PumpManagerUI {
         vc.pumpManagerOnboardingDelegate = pumpManagerOnboardingDelegate
         return vc
     }
-
-//    func settingsViewController() -> UIViewController & CompletionNotifying {
-//        settingsViewController(
-//            insulinTintColor: .accentColor,
-//            guidanceColors: GuidanceColors(acceptable: .green, warning: .orange, critical: .red),
-//            allowedInsulinTypes: [.apidra, .humalog, .novolog, .fiasp, .lyumjev]
-//        )
-//    }
 }
 
 protocol PumpSettingsBuilder {

--- a/FreeAPS/Sources/APS/Extensions/UserDefaultsExtensions.swift
+++ b/FreeAPS/Sources/APS/Extensions/UserDefaultsExtensions.swift
@@ -5,17 +5,10 @@ import RileyLinkKit
 
 extension UserDefaults {
     private enum Key: String {
-        case pumpManagerRawValue = "com.rileylink.PumpManagerRawValue"
+        case legacyPumpManagerRawValue = "com.rileylink.PumpManagerRawValue"
         case rileyLinkConnectionManagerState = "com.rileylink.RileyLinkConnectionManagerState"
-    }
-
-    var pumpManagerRawValue: PumpManager.RawStateValue? {
-        get {
-            dictionary(forKey: Key.pumpManagerRawValue.rawValue)
-        }
-        set {
-            set(newValue, forKey: Key.pumpManagerRawValue.rawValue)
-        }
+        case legacyPumpManagerState = "com.loopkit.Loop.PumpManagerState"
+        case legacyCGMManagerState = "com.loopkit.Loop.CGMManagerState"
     }
 
     var rileyLinkConnectionManagerState: RileyLinkConnectionState? {
@@ -29,5 +22,21 @@ extension UserDefaults {
         set {
             set(newValue?.rawValue, forKey: Key.rileyLinkConnectionManagerState.rawValue)
         }
+    }
+
+    var legacyPumpManagerRawValue: PumpManager.RawValue? {
+        dictionary(forKey: Key.legacyPumpManagerState.rawValue)
+    }
+
+    func clearLegacyPumpManagerRawValue() {
+        set(nil, forKey: Key.legacyPumpManagerState.rawValue)
+    }
+
+    var legacyCGMManagerRawValue: CGMManager.RawValue? {
+        dictionary(forKey: Key.legacyCGMManagerState.rawValue)
+    }
+
+    func clearLegacyCGMManagerRawValue() {
+        set(nil, forKey: Key.legacyCGMManagerState.rawValue)
     }
 }

--- a/FreeAPS/Sources/APS/FetchGlucoseManager.swift
+++ b/FreeAPS/Sources/APS/FetchGlucoseManager.swift
@@ -45,6 +45,7 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
     var cgmManager: CGMManagerUI? {
         didSet {
             rawCGMManager = cgmManager?.rawValue
+            UserDefaults.standard.clearLegacyCGMManagerRawValue()
         }
     }
 

--- a/FreeAPS/Sources/Helpers/PropertyWrappers/PersistedProperty.swift
+++ b/FreeAPS/Sources/Helpers/PropertyWrappers/PersistedProperty.swift
@@ -57,7 +57,6 @@ import Foundation
         self.key = key
 
         let documents: URL
-
         guard let localDocuments = try? FileManager.default.url(
             for: .documentDirectory,
             in: .userDomainMask,

--- a/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
@@ -62,19 +62,22 @@ extension Settings {
         func hideSettingsModal() {
             hideModal()
         }
-
-        func resetLoopDocuments() {
-            guard let localDocuments = try? FileManager.default.url(
-                for: .documentDirectory,
-                in: .userDomainMask,
-                appropriateFor: nil,
-                create: true
-            ) else {
-                preconditionFailure("Could not get a documents directory URL.")
-            }
-            let storageURL = localDocuments.appendingPathComponent("PumpManagerState" + ".plist")
-            try? FileManager.default.removeItem(at: storageURL)
-        }
+// Commenting this out for now, as not needed and possibly dangerous for users to be able to nuke their pump pairing informations via the debug menu
+// Leaving it in here, as it may be a handy functionality for further testing or developers.
+// See https://github.com/nightscout/Trio/pull/277 for more information
+//
+//        func resetLoopDocuments() {
+//            guard let localDocuments = try? FileManager.default.url(
+//                for: .documentDirectory,
+//                in: .userDomainMask,
+//                appropriateFor: nil,
+//                create: true
+//            ) else {
+//                preconditionFailure("Could not get a documents directory URL.")
+//            }
+//            let storageURL = localDocuments.appendingPathComponent("PumpManagerState" + ".plist")
+//            try? FileManager.default.removeItem(at: storageURL)
+//        }
     }
 }
 

--- a/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
@@ -62,9 +62,10 @@ extension Settings {
         func hideSettingsModal() {
             hideModal()
         }
-// Commenting this out for now, as not needed and possibly dangerous for users to be able to nuke their pump pairing informations via the debug menu
-// Leaving it in here, as it may be a handy functionality for further testing or developers.
-// See https://github.com/nightscout/Trio/pull/277 for more information
+
+        // Commenting this out for now, as not needed and possibly dangerous for users to be able to nuke their pump pairing informations via the debug menu
+        // Leaving it in here, as it may be a handy functionality for further testing or developers.
+        // See https://github.com/nightscout/Trio/pull/277 for more information
 //
 //        func resetLoopDocuments() {
 //            guard let localDocuments = try? FileManager.default.url(

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -61,12 +61,16 @@ extension Settings {
                                     .frame(maxWidth: .infinity, alignment: .trailing)
                                     .buttonStyle(.borderedProminent)
                             }
-                            HStack {
-                                Text("Delete Pump State nlist")
-                                Button("Delete") { state.resetLoopDocuments() }
-                                    .frame(maxWidth: .infinity, alignment: .trailing)
-                                    .buttonStyle(.borderedProminent)
-                            }
+// Commenting this out for now, as not needed and possibly dangerous for users to be able to nuke their pump pairing informations via the debug menu
+// Leaving it in here, as it may be a handy functionality for further testing or developers.
+// See https://github.com/nightscout/Trio/pull/277 for more information
+//
+//                            HStack {
+//                                Text("Delete Stored Pump State Binary Files")
+//                                Button("Delete") { state.resetLoopDocuments() }
+//                                    .frame(maxWidth: .infinity, alignment: .trailing)
+//                                    .buttonStyle(.borderedProminent)
+//                            }
                         }
                         Group {
                             Text("Preferences")

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -61,9 +61,9 @@ extension Settings {
                                     .frame(maxWidth: .infinity, alignment: .trailing)
                                     .buttonStyle(.borderedProminent)
                             }
-// Commenting this out for now, as not needed and possibly dangerous for users to be able to nuke their pump pairing informations via the debug menu
-// Leaving it in here, as it may be a handy functionality for further testing or developers.
-// See https://github.com/nightscout/Trio/pull/277 for more information
+                            // Commenting this out for now, as not needed and possibly dangerous for users to be able to nuke their pump pairing informations via the debug menu
+                            // Leaving it in here, as it may be a handy functionality for further testing or developers.
+                            // See https://github.com/nightscout/Trio/pull/277 for more information
 //
 //                            HStack {
 //                                Text("Delete Stored Pump State Binary Files")


### PR DESCRIPTION
Ports over Loopkit/Loop#1702 to fix the loss of pumps and CGMs by no longer storing them as UserDefaults entry but via binary plist files. Storage of CGM info was already done via PR #15 back before Trio was opened for beta. This PR also migrates information storage for pump information.

Quoting from Loop PR:
> It's an attempt to fix the issue […] where Loop appears to revert to an old version of device state.
> Migration is supported coming from **previous versions of Loop that used UserDefaults**, but **reverting to a previous version of Loop will mean loss of Pump, CGM** […] as the previous version of Loop will not know to load the data from the binary plist files.

Thank you to @kskandis and @avouspierre for the great collaboration.

Addresses and solves #231 