### PR TITLE
Fix the dexcom share in Trio

### DIFF
--- a/FreeAPS/Sources/APS/CGM/PluginSource.swift
+++ b/FreeAPS/Sources/APS/CGM/PluginSource.swift
@@ -199,14 +199,6 @@ extension PluginSource: CGMManagerDelegate {
             return .failure(error)
         }
     }
-
-    private func processCGMReadingResultCompletion(
-        _: CGMManager,
-        readingResult: CGMReadingResult,
-        completion: @escaping (Result<[BloodGlucose], Error>) -> Void
-    ) {
-        completion(readCGMResult(readingResult: readingResult))
-    }
 }
 
 extension PluginSource {


### PR DESCRIPTION
The PR allows to fetch BG of Dexcom share as a CGM as well as to fetch BG of Dexcom share with the Dexcom G6 CGM.

The PR updates the logic of the CGM fetch for all CGM based on Loop submodules (PluginSource).

## Test requirements  
- Activate the dexcom share in the Dexcom App in the IRL device 
- Check the dexcom share is operational with the dexcom follower apps

## 1. - IOS Simulator - Add Dexcom Share CGM 
- enter credentials
- the BG is updated immediatly :✅
- the BG is updated after 5 minutes  ✅

## 2. - Iphone 8 - Add G6 CGM 
- enter a fake number for the G6 CGM
- enter credentials for dexcom share 
- the BG is fetched and updated immediatly ✅
- the BG is updated after 5 minutes with the use of the dexcom share  ✅

## 3. - iphone 15 - Add G6 CGM with G6 sensor
- enter the correct number for the G6 sensor
- enter credentials for dexcom share ✅
- the BG is updated after 5 minutes with the use of the “BLE” heartbeat. ✅


Need to be tested with Libre and Dexcom G7.  Both implement the fetchIfNeeded function with noData response.
