### PR TITLE
PreferencesEditorDataFlow: commit Xcode auto formatting related to #232

### DIFF
--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorDataFlow.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorDataFlow.swift
@@ -63,7 +63,9 @@ enum PreferencesEditor {
                 settable?.set(keypath, value: value)
             case let (.decimal(keypath, minVal, maxVal), value as Decimal):
                 let constrainedValue: Decimal
-                if let minValue = minVal, let minValueDecimal: Decimal = settable?.get(minValue), let maxValue = maxVal, let maxValueDecimal: Decimal = settable?.get(maxValue) {
+                if let minValue = minVal, let minValueDecimal: Decimal = settable?.get(minValue), let maxValue = maxVal,
+                   let maxValueDecimal: Decimal = settable?.get(maxValue)
+                {
                     constrainedValue = min(max(value, minValueDecimal), maxValueDecimal)
                 } else if let minValue = minVal, let minValueDecimal: Decimal = settable?.get(minValue) {
                     constrainedValue = max(value, minValueDecimal)


### PR DESCRIPTION
Xcode automatically changed the formatting of L66 in FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorDataFlow.swift upon build. We'll have to commit this to avoid uncommitted changes on every build.