### PR TITLE
add observer on pump deactivated to initialize pump status

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -431,6 +431,9 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
     func pumpManagerWillDeactivate(_: PumpManager) {
         dispatchPrecondition(condition: .onQueue(processQueue))
         pumpManager = nil
+        broadcaster.notify(PumpDeactivatedObserver.self, on: processQueue) {
+            $0.pumpDeactivatedDidChange()
+        }
     }
 
     func pumpManager(_: PumpManager, didUpdatePumpRecordsBasalProfileStartEvents _: Bool) {}
@@ -666,4 +669,8 @@ protocol PumpReservoirObserver {
 
 protocol PumpBatteryObserver {
     func pumpBatteryDidChange(_ battery: Battery)
+}
+
+protocol PumpDeactivatedObserver {
+    func pumpDeactivatedDidChange()
 }


### PR DESCRIPTION
This resolves Issue [Home View shows "No Pod" or "Signal Loss" despite insulin delivery system removal](https://github.com/nightscout/Trio/issues/283#top)
#283 

Tested Omnipod and Medtronics on Simulator