### PR TITLE
Resolve issue #289: implement NS-provided display of fat/protein

### DIFF
--- a/FreeAPS/Sources/APS/Storage/CarbsStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/CarbsStorage.swift
@@ -232,8 +232,8 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
                 bolus: nil,
                 insulin: nil,
                 carbs: $0.carbs,
-                fat: nil,
-                protein: nil,
+                fat: $0.fat,
+                protein: $0.protein,
                 foodType: $0.note,
                 targetTop: nil,
                 targetBottom: nil

--- a/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -332,8 +332,8 @@ extension NightscoutTreatment {
                 insulin: nil,
                 notes: nil,
                 carbs: Decimal(event.carbInput ?? 0),
-                fat: nil,
-                protein: nil,
+                fat: Decimal(event.fatInput ?? 0),
+                protein: Decimal(event.proteinInput ?? 0),
                 targetTop: nil,
                 targetBottom: nil
             )

--- a/FreeAPS/Sources/Models/PumpHistoryEvent.swift
+++ b/FreeAPS/Sources/Models/PumpHistoryEvent.swift
@@ -11,6 +11,8 @@ struct PumpHistoryEvent: JSON, Equatable {
     let rate: Decimal?
     let temp: TempType?
     let carbInput: Int?
+    let fatInput: Int?
+    let proteinInput: Int?
     let note: String?
     let isSMB: Bool?
     let isExternalInsulin: Bool?
@@ -25,6 +27,8 @@ struct PumpHistoryEvent: JSON, Equatable {
         rate: Decimal? = nil,
         temp: TempType? = nil,
         carbInput: Int? = nil,
+        fatInput: Int? = nil,
+        proteinInput: Int? = nil,
         note: String? = nil,
         isSMB: Bool? = nil,
         isExternalInsulin: Bool? = nil
@@ -38,6 +42,8 @@ struct PumpHistoryEvent: JSON, Equatable {
         self.rate = rate
         self.temp = temp
         self.carbInput = carbInput
+        self.fatInput = fatInput
+        self.proteinInput = proteinInput
         self.note = note
         self.isSMB = isSMB
         self.isExternalInsulin = isExternalInsulin
@@ -88,6 +94,8 @@ extension PumpHistoryEvent {
         case rate
         case temp
         case carbInput = "carb_input"
+        case fatInput
+        case proteinInput
         case note
         case isSMB
         case isExternalInsulin


### PR DESCRIPTION
- Resolves #289
- Implements Nightscout's provided graph display for fat and protein in meal entries
- Trio had partially implemented this but did not pass fat and protein values to Nightscout (it dropped them but carried carbs)
- This PR follows the identical pattern used for carbs and carries fat and protein values along for NS to display