### PR TITLE
add observer, notify on ClearButttonTapped to set state value in Deci…

### DIFF
--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -57,7 +57,7 @@ extension AddCarbs {
                     }
                     HStack {
                         Text("Note").foregroundColor(.secondary)
-                        TextField("", text: $state.note).multilineTextAlignment(.trailing)
+                        RightAdjustedTextField(text: $state.note, textAlignment: .right)
                         if isFocused {
                             Button { isFocused = false } label: { Image(systemName: "keyboard.chevron.compact.down") }
                                 .controlSize(.mini)

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -58,10 +58,6 @@ extension AddCarbs {
                     HStack {
                         Text("Note").foregroundColor(.secondary)
                         RightAdjustedTextField(text: $state.note, textAlignment: .right)
-                        if isFocused {
-                            Button { isFocused = false } label: { Image(systemName: "keyboard.chevron.compact.down") }
-                                .controlSize(.mini)
-                        }
                     }.focused($isFocused)
                     HStack {
                         Button {

--- a/FreeAPS/Sources/Views/DecimalTextField.swift
+++ b/FreeAPS/Sources/Views/DecimalTextField.swift
@@ -21,9 +21,6 @@ struct DecimalTextField: UIViewRepresentable {
         self.formatter = formatter
         self.autofocus = autofocus
         self.cleanInput = cleanInput
-        NotificationBroadcaster.shared.register(event: "ClearButtonTappedObserver") { [self] _ in
-            self.clearButtonTappedDidUpdate()
-        }
     }
 
     func clearButtonTappedDidUpdate() {
@@ -117,6 +114,9 @@ struct DecimalTextField: UIViewRepresentable {
             if isNumber || withDecimal,
                let currentValue = textField.text as NSString?
             {
+                NotificationBroadcaster.shared.register(event: "ClearButtonTappedObserver") { [self] _ in
+                    parent.clearButtonTappedDidUpdate()
+                }
                 // Update Value
                 let proposedValue = currentValue.replacingCharacters(in: range, with: string) as String
 

--- a/FreeAPS/Sources/Views/DecimalTextField.swift
+++ b/FreeAPS/Sources/Views/DecimalTextField.swift
@@ -216,3 +216,48 @@ extension UIApplication {
         sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 }
+
+struct RightAdjustedTextField: UIViewRepresentable {
+    @Binding var text: String
+    var textAlignment: NSTextAlignment
+
+    class Coordinator: NSObject, UITextFieldDelegate {
+        var parent: RightAdjustedTextField
+
+        init(parent: RightAdjustedTextField) {
+            self.parent = parent
+        }
+
+        // Position cursor at end of text
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            DispatchQueue.main.async {
+                let endPosition = textField.endOfDocument
+                textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition)
+            }
+        }
+
+        @objc func textFieldEditingChanged(_ textField: UITextField) {
+            parent.text = textField.text ?? ""
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeUIView(context: Context) -> UITextField {
+        let textField = UITextField()
+        textField.delegate = context.coordinator
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textField.textAlignment = textAlignment
+        textField.addTarget(context.coordinator, action: #selector(Coordinator.textFieldEditingChanged(_:)), for: .editingChanged)
+        return textField
+    }
+
+    func updateUIView(_ uiView: UITextField, context _: Context) {
+        uiView.text = text
+        uiView.textAlignment = textAlignment
+    }
+}

--- a/FreeAPS/Sources/Views/DecimalTextField.swift
+++ b/FreeAPS/Sources/Views/DecimalTextField.swift
@@ -249,6 +249,11 @@ struct RightAdjustedTextField: UIViewRepresentable {
             NotificationBroadcaster.shared.removeListeners(for: "ClearButtonTappedObserver")
         }
 
+        func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+            textField.resignFirstResponder()
+            return true
+        }
+
         func clearButtonTappedDidUpdate(object _: Any) {
             parent.text = ""
         }


### PR DESCRIPTION
This PR resolves [“Clear” button for bolus and carb entries does not work as expected](https://github.com/nightscout/Trio/issues/273#top)
#273

Observer / notify added to ClearButtonTapped action.  On doneButtonTapped action, Observers are removed.

Tested on Simulator and iPhone SE