### PR TITLE
Include `high` and `low` values in TIR in Statistics

### DIFF
--- a/FreeAPS/Sources/Modules/Stat/View/ChartsView.swift
+++ b/FreeAPS/Sources/Modules/Stat/View/ChartsView.swift
@@ -114,7 +114,7 @@ struct ChartsView: View {
                 type: NSLocalizedString(
                     "Low",
                     comment: ""
-                ) + " (≤\(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))",
+                ) + " (<\(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))",
                 percent: fetched[0].decimal
             ),
             .init(type: NSLocalizedString("In Range", comment: ""), percent: fetched[1].decimal),
@@ -122,7 +122,7 @@ struct ChartsView: View {
                 type: NSLocalizedString(
                     "High",
                     comment: ""
-                ) + " (≥\(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))",
+                ) + " (>\(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))",
                 percent: fetched[2].decimal
             )
         ]
@@ -142,12 +142,12 @@ struct ChartsView: View {
             NSLocalizedString(
                 "Low",
                 comment: ""
-            ) + " (≤\(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))": .red,
+            ) + " (<\(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))": .red,
             NSLocalizedString("In Range", comment: ""): .green,
             NSLocalizedString(
                 "High",
                 comment: ""
-            ) + " (≥\(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))": .orange
+            ) + " (>\(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))": .orange
         ]).frame(maxHeight: 25)
     }
 
@@ -161,18 +161,18 @@ struct ChartsView: View {
                 type: NSLocalizedString(
                     "Low",
                     comment: ""
-                ) + " (≤ \(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))",
+                ) + " (< \(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))",
                 percent: fetched[0].decimal
             ),
             .init(
-                type: "> \(low.formatted(.number.precision(.fractionLength(fraction)))) - < \(high.formatted(.number.precision(.fractionLength(fraction))))",
+                type: "\(low.formatted(.number.precision(.fractionLength(fraction)))) - \(high.formatted(.number.precision(.fractionLength(fraction))))",
                 percent: fetched[1].decimal
             ),
             .init(
                 type: NSLocalizedString(
                     "High",
                     comment: ""
-                ) + " (≥ \(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))",
+                ) + " (> \(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))",
                 percent: fetched[2].decimal
             )
         ]
@@ -196,12 +196,12 @@ struct ChartsView: View {
             NSLocalizedString(
                 "Low",
                 comment: ""
-            ) + " (≤ \(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))": .red,
-            "> \(low.formatted(.number.precision(.fractionLength(fraction)))) - < \(high.formatted(.number.precision(.fractionLength(fraction))))": .green,
+            ) + " (< \(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))": .red,
+            "\(low.formatted(.number.precision(.fractionLength(fraction)))) - \(high.formatted(.number.precision(.fractionLength(fraction))))": .green,
             NSLocalizedString(
                 "High",
                 comment: ""
-            ) + " (≥ \(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))": .orange
+            ) + " (> \(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))))": .orange
         ])
     }
 
@@ -276,11 +276,11 @@ struct ChartsView: View {
         let justGlucoseArray = glucose.compactMap({ each in Int(each.glucose as Int16) })
         let totalReadings = justGlucoseArray.count
 
-        let hyperArray = glucose.filter({ $0.glucose >= hyperLimit })
+        let hyperArray = glucose.filter({ $0.glucose > hyperLimit })
         let hyperReadings = hyperArray.compactMap({ each in each.glucose as Int16 }).count
         let hyperPercentage = Double(hyperReadings) / Double(totalReadings) * 100
 
-        let hypoArray = glucose.filter({ $0.glucose <= hypoLimit })
+        let hypoArray = glucose.filter({ $0.glucose < hypoLimit })
         let hypoReadings = hypoArray.compactMap({ each in each.glucose as Int16 }).count
         let hypoPercentage = Double(hypoReadings) / Double(totalReadings) * 100
 


### PR DESCRIPTION
This changes the statistics to include the `high` and `low` values in the normal range instead of the high and low ranges. This would match the colors of the glucose dots on the Statistics screen.

For this example in a simulator, I kept `high`/`low` to the default `70`/`180` and manually entered these values:

<img width="350" alt="glucose values" src="https://github.com/nightscout/Trio/assets/82073483/ba64a29c-c71b-4de6-a022-39cf064082b1">

| Before this PR (standing) | Before this PR (laying) |
| --- | --- |
| <img width="350" alt="old standing" src="https://github.com/nightscout/Trio/assets/82073483/2aa03925-6fa4-4f47-8640-6eb7043ccc77"> | <img width="350" alt="old laying" src="https://github.com/nightscout/Trio/assets/82073483/d3965727-1328-494b-8d4d-eb5c1311ddbc"> |
|  After this PR (standing) |  After this PR (laying) |
| <img width="350" alt="new standing" src="https://github.com/nightscout/Trio/assets/82073483/11796b44-119f-4a2b-b76f-71dd940f02a6"> | <img width="350" alt="new laying" src="https://github.com/nightscout/Trio/assets/82073483/74957a1c-5f18-4c39-a4d3-a03a3a15b8f9"> |


