### PR TITLE
exclude cancelling from bolusTrigger, comment out updateStatus

### DIFF
--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -921,7 +921,7 @@ final class BaseAPSManager: APSManager, Injectable {
         bolusReporter = nil
         processQueue.asyncAfter(deadline: .now() + 0.5) {
             self.bolusProgress.send(nil)
-            self.updateStatus()
+            // self.updateStatus()
         }
     }
 }

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -470,6 +470,7 @@ final class BaseAPSManager: APSManager, Injectable {
                 debug(.apsManager, "Bolus cancelled")
             }
 
+            self.updateStatus()
             self.bolusReporter?.removeObserver(self)
             self.bolusReporter = nil
             self.bolusProgress.send(nil)
@@ -921,7 +922,6 @@ final class BaseAPSManager: APSManager, Injectable {
         bolusReporter = nil
         processQueue.asyncAfter(deadline: .now() + 0.5) {
             self.bolusProgress.send(nil)
-            // self.updateStatus()
         }
     }
 }

--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -326,7 +326,7 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
 
         if case .inProgress = status.bolusState {
             bolusTrigger.send(true)
-        } else {
+        } else if status.bolusState != .canceling {
             bolusTrigger.send(false)
         }
 


### PR DESCRIPTION
This PR resolves this issue by excluding `BolusState.canceling` from sending a `bolusTrigger.send(false)` to APSManager which would tripper a `bolusReporter?.removeObserver`.

This is because if the `bolusReporter` observer is prematurely removed then the cancel completion will not be observed. APSManager separately observes [CancelBolus](https://github.com/nightscout/Trio/blob/217d1d65d7e40753d2c8988fef517d2687acdb07/FreeAPS/Sources/APS/APSManager.swift#L463) and then will remove the `bolusReporter` so there is no reason to include `BolusState.canceling` in the trigger.

I tested this in Mock and Cancel Bolus succeeds. I also commented out `updateStatus()`.  Once PR is tested, `updateStatus()` func should be removed.