### PR TITLE
Adding CODEOWNERS to the Repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+*    @dnzxy
+*    @bjornoleh
+*    @MikePlante1
+*    @aug0211
+*    @AndreasStokholm
+*    @Sjoerd-Bo3
+*    @t1dude
+
+*.js @dnzxy
+*.js @bjornoleh
+*.js @MikePlante1
+*.js @aug0211
+*.js @AndreasStokholm
+*.js @Sjoerd-Bo3
+*.js @t1dude
+*.js @jeremystorring


### PR DESCRIPTION
Codeowners are auto added to PR and one of these needs to approve before a merge.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners