### PR TITLE
Add GitHub actions workflow to test-build pull request branches

### DIFF
--- a/.github/workflows/PR_test_build.yml
+++ b/.github/workflows/PR_test_build.yml
@@ -1,0 +1,98 @@
+name: Test-build pull request
+run-name: PR ${{ vars.PR_NUMBER }}
+on:
+  workflow_dispatch:
+
+jobs:
+  # Builds Trio
+  build:
+    name: Build
+    runs-on: macos-15
+    permissions:
+      contents: write
+
+    steps:
+      - name: Select Xcode version
+        run: "sudo xcode-select --switch /Applications/Xcode_16.3.app/Contents/Developer"
+            
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          repository: nightscout/Trio
+          ref: dev
+          token: ${{ secrets.GH_PAT }}
+          submodules: recursive
+          fetch-depth: 1
+          
+      - name: Checkout pull request for building
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          gh pr checkout ${{ vars.PR_NUMBER }} --repo nightscout/Trio --recurse-submodules
+          git submodule
+      - name: Add PR number to APP_DISPLAY_NAME and optionally add BUNDLE_ID_SUFFIX to BUNDLE_IDENTIFIER in Config.xcconfig
+        run: |
+          CONFIG_FILE="Config.xcconfig"
+          # 1) Update APP_DISPLAY_NAME to include PR number
+          PR_NO="${{ vars.PR_NUMBER }}"
+          DISPLAY_NAME="Trio_PR${PR_NO}"
+          if grep -q "^APP_DISPLAY_NAME *=.*" "$CONFIG_FILE"; then
+            sed -i '' "s|^APP_DISPLAY_NAME *=.*|APP_DISPLAY_NAME = ${DISPLAY_NAME}|" "$CONFIG_FILE"
+          else
+            echo "APP_DISPLAY_NAME = ${DISPLAY_NAME}" >> "$CONFIG_FILE"
+          fi
+          echo "APP_DISPLAY_NAME: $(grep '^APP_DISPLAY_NAME' $CONFIG_FILE)"
+          # 2) If suffix provided, patch BUNDLE_IDENTIFIER
+          SUFFIX="${{ vars.BUNDLE_ID_SUFFIX }}"
+          if [[ -n "$SUFFIX" ]]; then
+            BASE="trio${SUFFIX}"
+            BUNDLE_ID="org.nightscout.\$(DEVELOPMENT_TEAM).${BASE}"
+            if grep -q "^BUNDLE_IDENTIFIER *=.*" "$CONFIG_FILE"; then
+              sed -i '' "s|^BUNDLE_IDENTIFIER *=.*|BUNDLE_IDENTIFIER = ${BUNDLE_ID}|" "$CONFIG_FILE"
+            else
+              echo "BUNDLE_IDENTIFIER = ${BUNDLE_ID}" >> "$CONFIG_FILE"
+            fi
+            echo "BUNDLE_IDENTIFIER: $(grep '^BUNDLE_IDENTIFIER' $CONFIG_FILE)"
+          else
+            echo "No BUNDLE_ID_SUFFIX set, leaving bundle ID as-is:"
+            grep '^BUNDLE_IDENTIFIER' "$CONFIG_FILE" || echo "(not defined)"
+          fi
+      # Patch Fastlane Match to not print tables
+      - name: Patch Match Tables
+        run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
+      
+      # Install project dependencies
+      - name: Install project dependencies
+        run: bundle install
+      
+      # Build signed Trio IPA file
+      - name: Fastlane Build & Archive
+        run: bundle exec fastlane build_trio
+        env:
+          TEAMID: ${{ secrets.TEAMID }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
+          FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
+          FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      
+      # Upload to TestFlight
+      - name: Fastlane upload to TestFlight
+        run: bundle exec fastlane release
+        env:
+          TEAMID: ${{ secrets.TEAMID }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
+          FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
+          FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+
+      # Upload Build artifacts
+      - name: Upload build log, IPA and Symbol artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            artifacts
+            buildlog

--- a/.github/workflows/PR_test_build.yml
+++ b/.github/workflows/PR_test_build.yml
@@ -22,7 +22,7 @@ jobs:
           ref: dev
           token: ${{ secrets.GH_PAT }}
           submodules: recursive
-          fetch-depth: 1
+          fetch-depth: 0
           
       - name: Checkout pull request for building
         env:
@@ -30,6 +30,30 @@ jobs:
         run: |
           gh pr checkout ${{ vars.PR_NUMBER }} --repo nightscout/Trio --recurse-submodules
           git submodule
+
+      - name: Revert commits if REVERT_COMMITS is set
+        if: ${{ vars.REVERT_COMMITS != '' }}
+        run: |
+          echo "Reverting commits from REVERT_COMMITS variable..."
+          echo "${{ vars.REVERT_COMMITS }}" | while IFS= read -r line; do
+            # Skip empty lines and lines starting with #
+            [[ -z "$line" || "$line" =~ ^# ]] && continue
+
+            # Extract the first word as commit hash (ignore inline comments)
+            commit_hash=$(echo "$line" | awk '{print $1}')
+
+            if [[ -n "$commit_hash" ]]; then
+              echo "Reverting commit: $commit_hash"
+              if ! git revert "$commit_hash" --no-edit; then
+                echo "❌ Failed to revert $commit_hash. Exiting."
+                exit 1
+              fi
+              echo "✅ Successfully reverted $commit_hash"
+            fi
+          done
+          echo "Final commit log after reverts:"
+          git log -n 5 --oneline
+
       - name: Add PR number to APP_DISPLAY_NAME and optionally add BUNDLE_ID_SUFFIX to BUNDLE_IDENTIFIER in Config.xcconfig
         run: |
           CONFIG_FILE="Config.xcconfig"
@@ -57,6 +81,7 @@ jobs:
             echo "No BUNDLE_ID_SUFFIX set, leaving bundle ID as-is:"
             grep '^BUNDLE_IDENTIFIER' "$CONFIG_FILE" || echo "(not defined)"
           fi
+          
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"


### PR DESCRIPTION
The new `.github/workflows/PR_test_build.yml` workflow checks out the pull request number that is entered as a repository variable.

It is possible to add an optional bundle ID suffix to not overwrite the TestFlight “production app” that one might be using live.

The checkout action starts with nightscout/Trio dev when setting up the git repository, so that the workflow is independent of any changes in the private fork.

## Setup:
Add repository variables:

### Mandatory:
- PR_NUMBER (Pull-request number in the nightscout/Trio repository)

### Optional:
- BUNDLE_ID_SUFFIX (appended to BUNDLE_IDENTIFIER = org.nightscout.$(DEVELOPMENT_TEAM).trio, which must match the bundle ID which is associated with the TestFlight app you wish to build to)

## Usage: 
- Run the workflow named “Test-build pull request”
- Wait for the build to complete and be processed at Apple
-  Install/update Trio in the TestFlight app. 
- The app display name will include the PR number (Trio_PRXXX) to easily distinguish it from other instances if the app one might have installed, or to see that the production app is in fact a PR build

Resolves #315 


---

**PR summary**

```
Add workflow to build and deploy pull request to TestFlight

This new GitHub Actions workflow (`PR_test_build.yml`) automates the process of building pull requests from the `nightscout/Trio` repository and deploying them to TestFlight.

Key features and changes:
- Adds a new workflow triggered manually via `workflow_dispatch`.
- Requires repository variable `PR_NUMBER` to specify the pull request to build.
- Optional variable `BUNDLE_ID_SUFFIX` can be used to modify the bundle identifier for test builds.
- In-place patching of BUNDLE_IDENTIFIER in `Config.xcconfig`
- Injects `APP_DISPLAY_NAME = Trio_PR<PR_NUMBER>` automatically to identify the app name as a PR build.
- If `BUNDLE_ID_SUFFIX` is set, updates `BUNDLE_IDENTIFIER` in place accordingly.
- Includes debug output for final `APP_DISPLAY_NAME` and `BUNDLE_IDENTIFIER`.

This enables easier, isolated testing of PRs directly via TestFlight with clearly labeled builds.
```
