### PR TITLE
Eventual BG with 1 decimal in the app and in the watch app

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -344,7 +344,7 @@ extension Home {
 
                     if let eventualBG = state.eventualBG {
                         Text(
-                            "⇢ " + numberFormatter.string(
+                            "⇢ " + targetFormatter.string(
                                 from: (state.units == .mmolL ? eventualBG.asMmolL : Decimal(eventualBG)) as NSNumber
                             )!
                         )

--- a/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
+++ b/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
@@ -216,7 +216,7 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
     private var eventualFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = 1
         return formatter
     }
 


### PR DESCRIPTION
- Use `targetFormatter` instead of `numberFormater` for `eventualBG` in the app, since this has the appropriate `maximumFractionDigits = 1`

- Change eventualFormatter to use `maximumFractionDigits = 1` instead of `2` on the watch

Resolves #319 