### PR TITLE
conversion of rT.variables in mg/dL

### DIFF
--- a/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
@@ -148,7 +148,7 @@ extension Bolus {
                     }
                     HStack {
                         Text("ISF").foregroundColor(.secondary)
-                        let isf = state.isf == .mmolL ? state.target.asMmolL : state.isf
+                        let isf = state.units == .mmolL ? state.target.asMmolL : state.isf
                         Text(isf.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))))
                         Text(state.units.rawValue + NSLocalizedString("/U", comment: "/Insulin unit"))
                             .foregroundColor(.secondary)

--- a/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
@@ -148,8 +148,8 @@ extension Bolus {
                     }
                     HStack {
                         Text("ISF").foregroundColor(.secondary)
-                        let isf = state.isf
-                        Text(isf.formatted())
+                        let isf = state.isf == .mmolL ? state.target.asMmolL : state.isf
+                        Text(isf.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))))
                         Text(state.units.rawValue + NSLocalizedString("/U", comment: "/Insulin unit"))
                             .foregroundColor(.secondary)
                     }

--- a/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
+++ b/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
@@ -227,7 +227,7 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
     private var eventualFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 1
+        formatter.maximumFractionDigits = 2
         return formatter
     }
 

--- a/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
+++ b/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
@@ -208,8 +208,8 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
         }
         let units = settingsManager.settings.units
         return glucoseFormatter.string(
-            from: (units == .mmolL ? isfValue.asMmolL : Decimal(isfValue)) as NSNumber
-        )!
+            from: units == .mmolL ? isfValue.asMmolL as NSNumber : isfValue as NSNumber
+        )
     }
 
     private var glucoseFormatter: NumberFormatter {

--- a/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
+++ b/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
@@ -112,7 +112,8 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
             self.state.eventualBG = eBG.map { "⇢ " + $0 }
             self.state.eventualBGRaw = eBG
 
-            self.state.isf = self.suggestion?.isf
+            let isfString = self.isfString()
+            self.state.isf = isfString
 
             var overrideArray = [Override]()
             let requestOverrides = Override.fetchRequest() as NSFetchRequest<Override>
@@ -201,6 +202,16 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
         )!
     }
 
+    private func isfString() -> String? {
+        guard let isfValue = suggestion?.isf else {
+            return nil
+        }
+        let units = settingsManager.settings.units
+        return glucoseFormatter.string(
+            from: (units == .mmolL ? isfValue.asMmolL : Decimal(isfValue)) as NSNumber
+        )!
+    }
+
     private var glucoseFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
@@ -216,7 +227,7 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
     private var eventualFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = 1
         return formatter
     }
 

--- a/FreeAPSWatch WatchKit Extension/DataFlow.swift
+++ b/FreeAPSWatch WatchKit Extension/DataFlow.swift
@@ -23,7 +23,7 @@ struct WatchState: Codable {
     var displayOnWatch: AwConfig?
     var displayFatAndProteinOnWatch: Bool?
     var confirmBolusFaster: Bool?
-    var isf: Decimal?
+    var isf: String?
     var override: String?
 }
 

--- a/FreeAPSWatch WatchKit Extension/Views/MainView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/MainView.swift
@@ -171,7 +171,7 @@ struct MainView: View {
                     }
                 case .isf:
                     Spacer()
-                    let isf: String = state.isf != nil ? "\(state.isf ?? 0)" : "-"
+                    let isf: String = state.isf != nil ? state.isf! : "-"
                     HStack {
                         Image(systemName: "arrow.up.arrow.down")
                             .renderingMode(.template)

--- a/FreeAPSWatch WatchKit Extension/WatchStateModel.swift
+++ b/FreeAPSWatch WatchKit Extension/WatchStateModel.swift
@@ -55,7 +55,7 @@ class WatchStateModel: NSObject, ObservableObject {
     @Published var lastUpdate: Date = .distantPast
     @Published var timerDate = Date()
     @Published var pendingBolus: Double?
-    @Published var isf: Decimal?
+    @Published var isf: String?
     @Published var override: String?
 
     private var lifetime = Set<AnyCancellable>()
@@ -176,7 +176,7 @@ class WatchStateModel: NSObject, ObservableObject {
         displayOnWatch = state.displayOnWatch ?? .BGTarget
         displayFatAndProteinOnWatch = state.displayFatAndProteinOnWatch ?? false
         confirmBolusFaster = state.confirmBolusFaster ?? false
-        isf = state.isf
+        isf = state.isf ?? ""
         override = state.override
     }
 }


### PR DESCRIPTION
Needs to be done in parallel with  https://github.com/nightscout/trio-oref/pull/30

This concerns mainly ISF as transmitted from oref to suggestion / enacted. So far I only found one instance where ISF is used. 

So far ISF is always transfered from oref in the current user glucose unit, so if mmol/L is used it comes in mmol/L. Therefore currently no conversion is applied in Trio to ISF originating from oref. Drawback is also that a change of user glucose unit will not be reflected in ISF unless a new loop is calculated. Refer also to https://github.com/nightscout/trio-oref/issues/29

Also the watch app needs to adjusted as ISF may also be shown on watch.
