### PR TITLE
direct user where to flip Upload Glucose toggle

### DIFF
--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutUploadView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutUploadView.swift
@@ -13,6 +13,10 @@ struct NightscoutUploadView: View {
                         "The Upload Treatments toggle enables uploading of carbs, temp targets, device status, preferences and settings."
                     )
                     Text("\nThe Upload Glucose toggle enables uploading of CGM readings.")
+
+                    if !state.changeUploadGlucose {
+                        Text("\nTo flip the Upload Glucose toggle, go to ⚙️ > CGM > CGM Configuration")
+                    }
                 }
             )
                 {


### PR DESCRIPTION
Since the `Upload Glucose` toggle is disabled when using a plugin for the cgm source (Dexcom or LibreTransmitter), display text to direct the user to where they can flip the toggle. If they aren't using a plugin for their cgm source, then this text won't be displayed.

> To flip the Upload Glucose toggle, go to ⚙️ > CGM > CGM Configuration

<img width="350" alt="Screenshot 2024-06-29 at 1 36 51 PM" src="https://github.com/nightscout/Trio/assets/82073483/36422b47-008b-4999-9bc2-e2c65447bf21">

Addresses issue https://github.com/nightscout/Trio/issues/199