### PR TITLE
fix(projectmanagment): only run in nightscout repo, use of general token, rename

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,4 +1,4 @@
-name: Add bugs to bugs project
+name: 8. DONT RUN - Add bugs to bugs project
 
 on:
   issues:
@@ -9,6 +9,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'nightscout'
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:
@@ -18,3 +19,4 @@ jobs:
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           labeled: bug, needs-triage
           label-operator: OR
+

--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,4 +1,4 @@
-name: 8. DONT RUN - Add bugs to bugs project
+name: 8. DONT RUN Add bugs to bugs project
 
 on:
   issues:

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,4 +1,4 @@
-name: close inactive issues
+name: 8. DONT RUN - close inactive issues
 on:
   schedule:
     - cron: "30 1 * * *"
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
+    if: github.repository_owner == 'nightscout'
     steps:
       - uses: actions/stale@v9.0.0
         with:
@@ -20,12 +22,15 @@ jobs:
           exempt-issue-labels: "needs-triage, long-term, in-progress"
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          repo-token: ${{ secrets.STALE_ISSUES_PAT }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
 
   close-issues-triage:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
+    if: github.repository_owner == 'nightscout'
     steps:
       - uses: actions/stale@v9.0.0
         with:
@@ -39,5 +44,5 @@ jobs:
           any-of-labels: "needs-triage"
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          repo-token: ${{ secrets.STALE_ISSUES_PAT }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,4 +1,4 @@
-name: 8. DONT RUN - close inactive issues
+name: 8. DONT RUN close inactive issues
 on:
   schedule:
     - cron: "30 1 * * *"


### PR DESCRIPTION
This makes:
- 'Stale Issues' and 'Add to Project' only run in the Nightscout Repo
- Rename of 'Stale Issues' and 'Add to Project' to be add the bottom of the workflows
- Let 'Stale Issues' use the general GH token generation. So it will be a Bot commenting on it.