### PR TITLE
Prevent crash when holding backspace

### DIFF
--- a/FreeAPS/Sources/Views/TextFieldWithToolBar.swift
+++ b/FreeAPS/Sources/Views/TextFieldWithToolBar.swift
@@ -290,20 +290,24 @@ extension TextFieldWithToolBarString.Coordinator: UITextFieldDelegate {
         shouldChangeCharactersIn range: NSRange,
         replacementString string: String
     ) -> Bool {
-        if let maxLength = parent.maxLength {
-            // Get the current text, including the proposed change
-            let currentText = textField.text ?? ""
-            let newLength = currentText.count + string.count - range.length
-            if newLength > maxLength {
-                return false
-            }
+        guard let currentText = textField.text as NSString? else {
+            return false
         }
 
+        // Calculate the new text length
+        let newLength = currentText.length + string.count - range.length
+
+        // If there's a maxLength, ensure the new length is within the limit
+        if let maxLength = parent.maxLength, newLength > maxLength {
+            return false
+        }
+
+        // Attempt to replace characters in range with the replacement string
+        let newText = currentText.replacingCharacters(in: range, with: string)
+
+        // Update the binding text state
         DispatchQueue.main.async {
-            if let textFieldText = textField.text as NSString? {
-                let newText = textFieldText.replacingCharacters(in: range, with: string)
-                self.parent.text = newText
-            }
+            self.parent.text = newText
         }
 
         return true


### PR DESCRIPTION
Currently, entering text into `Note` while entering a meal and then holding the backspace button would crash the app. This PR prevents that crash.