### PR TITLE
Remove feature to save autotune basal profile to pump

### DIFF
--- a/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
@@ -61,35 +61,5 @@ extension AutotuneConfig {
                 .cancellable()
                 .store(in: &lifetime)
         }
-
-        func replace() {
-            if let autotunedBasals = autotune {
-                let basals = autotunedBasals.basalProfile
-                    .map { basal -> BasalProfileEntry in
-                        BasalProfileEntry(
-                            start: String(basal.start.prefix(5)),
-                            minutes: basal.minutes,
-                            rate: basal.rate
-                        )
-                    }
-                guard let pump = apsManager.pumpManager else {
-                    storage.save(basals, as: OpenAPS.Settings.basalProfile)
-                    debug(.service, "Basals have been replaced with Autotuned Basals by user.")
-                    return
-                }
-                let syncValues = basals.map {
-                    RepeatingScheduleValue(startTime: TimeInterval($0.minutes * 60), value: Double($0.rate))
-                }
-                pump.syncBasalRateSchedule(items: syncValues) { result in
-                    switch result {
-                    case .success:
-                        self.storage.save(basals, as: OpenAPS.Settings.basalProfile)
-                        debug(.service, "Basals saved to pump!")
-                    case .failure:
-                        debug(.service, "Basals couldn't be save to pump")
-                    }
-                }
-            }
-        }
     }
 }

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -5,7 +5,6 @@ extension AutotuneConfig {
     struct RootView: BaseView {
         let resolver: Resolver
         @StateObject var state = StateModel()
-        @State var replaceAlert = false
 
         private var isfFormatter: NumberFormatter {
             let formatter = NumberFormatter()
@@ -95,27 +94,11 @@ extension AutotuneConfig {
                         label: { Text("Delete autotune data") }
                             .foregroundColor(.red)
                     }
-
-                    Section {
-                        Button {
-                            replaceAlert = true
-                        }
-                        label: { Text("Save as your Normal Basal Rates") }
-                    } header: {
-                        Text("Replace Normal Basal")
-                    }
                 }
             }
             .onAppear(perform: configureView)
             .navigationTitle("Autotune")
             .navigationBarTitleDisplayMode(.automatic)
-            .alert(Text("Are you sure?"), isPresented: $replaceAlert) {
-                Button("Yes", action: {
-                    state.replace()
-                    replaceAlert.toggle()
-                })
-                Button("No", action: { replaceAlert.toggle() })
-            }
         }
     }
 }


### PR DESCRIPTION
Based on [this issue report](https://github.com/Artificial-Pancreas/iAPS/issues/711) on iAPS, this feature is buggy and potentially dangerous anyway.