### PR TITLE
Decrease HealthKitManager debug logging

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -459,7 +459,6 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
         completion: @escaping (_ error: Error?) -> Void
     ) {
         dispatchPrecondition(condition: .onQueue(processQueue))
-        // debug(.deviceManager, "New pump events:\n\(events.map(\.title).joined(separator: "\n"))")
 
         // filter buggy TBRs > maxBasal from MDT
         let events = events.filter {

--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -459,7 +459,7 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
         completion: @escaping (_ error: Error?) -> Void
     ) {
         dispatchPrecondition(condition: .onQueue(processQueue))
-        debug(.deviceManager, "New pump events:\n\(events.map(\.title).joined(separator: "\n"))")
+        // debug(.deviceManager, "New pump events:\n\(events.map(\.title).joined(separator: "\n"))")
 
         // filter buggy TBRs > maxBasal from MDT
         let events = events.filter {

--- a/FreeAPS/Sources/Services/HealthKit/HealthKitManager.swift
+++ b/FreeAPS/Sources/Services/HealthKit/HealthKitManager.swift
@@ -168,14 +168,7 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
                 }
 
             healthKitStore.save(samplesToSave) { (success: Bool, error: Error?) -> Void in
-                if success {
-                    // for sample in samplesToSave {
-                    //     debug(
-                    //         .service,
-                    //         "Stored blood glucose \(sample.quantity) in HealthKit Store! Metadata: \(String(describing: sample.metadata?.values))"
-                    //     )
-                    // }
-                } else {
+                if !success {
                     debug(.service, "Failed to store blood glucose in HealthKit Store!")
                     debug(.service, error?.localizedDescription ?? "Unknown error")
                 }
@@ -220,14 +213,7 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
                 }
 
             healthKitStore.save(samplesToSave) { (success: Bool, error: Error?) -> Void in
-                if success {
-                    // for sample in samplesToSave {
-                    //    debug(
-                    //        .service,
-                    //        "Stored carb entry \(sample.quantity) in HealthKit Store! Metadata: \(String(describing: sample.metadata?.values))"
-                    //    )
-                    // }
-                } else {
+                if !success {
                     debug(.service, "Failed to store carb entry in HealthKit Store!")
                     debug(.service, error?.localizedDescription ?? "Unknown error")
                 }
@@ -296,14 +282,7 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
                 }
 
             healthKitStore.save(bolusSamples + basalSamples) { (success: Bool, error: Error?) -> Void in
-                if success {
-                    // for sample in bolusSamples + basalSamples {
-                    //    debug(
-                    //    .service,
-                    //        "Stored insulin entry in HealthKit Store! Metadata: \(String(describing: sample.metadata?.values))"
-                    //    )
-                    // }
-                } else {
+                if !success {
                     debug(.service, "Failed to store insulin entry in HealthKit Store!")
                     debug(.service, error?.localizedDescription ?? "Unknown error")
                 }
@@ -491,7 +470,6 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
 
     private func prepareBGSamplesToPublisherFetch(_ samples: [HKQuantitySample]) {
         dispatchPrecondition(condition: .onQueue(processQueue))
-        // debug(.service, "Start preparing samples: \(String(describing: samples))")
 
         newGlucose += samples
             .compactMap { sample -> HealthKitSample? in
@@ -520,11 +498,6 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
             .filter { $0.dateString >= Date().addingTimeInterval(-1.days.timeInterval) }
 
         newGlucose = newGlucose.removeDublicates()
-
-        // debug(
-        //    .service,
-        //    "Current BloodGlucose.Type objects will be send from Publisher during fetch: \(String(describing: newGlucose))"
-        // )
     }
 
     // MARK: - GlucoseSource
@@ -540,9 +513,7 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
             }
 
             self.processQueue.async {
-                //   debug(.service, "Start fetching HealthKitManager")
                 guard self.settingsManager.settings.useAppleHealth else {
-                    // debug(.service, "HealthKitManager can't return any data, because useAppleHealth option is disabled")
                     promise(.success([]))
                     return
                 }

--- a/FreeAPS/Sources/Services/HealthKit/HealthKitManager.swift
+++ b/FreeAPS/Sources/Services/HealthKit/HealthKitManager.swift
@@ -169,12 +169,12 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
 
             healthKitStore.save(samplesToSave) { (success: Bool, error: Error?) -> Void in
                 if success {
-                    for sample in samplesToSave {
-                        debug(
-                            .service,
-                            "Stored blood glucose \(sample.quantity) in HealthKit Store! Metadata: \(String(describing: sample.metadata?.values))"
-                        )
-                    }
+                    // for sample in samplesToSave {
+                    //     debug(
+                    //         .service,
+                    //         "Stored blood glucose \(sample.quantity) in HealthKit Store! Metadata: \(String(describing: sample.metadata?.values))"
+                    //     )
+                    // }
                 } else {
                     debug(.service, "Failed to store blood glucose in HealthKit Store!")
                     debug(.service, error?.localizedDescription ?? "Unknown error")
@@ -221,12 +221,12 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
 
             healthKitStore.save(samplesToSave) { (success: Bool, error: Error?) -> Void in
                 if success {
-                    for sample in samplesToSave {
-                        debug(
-                            .service,
-                            "Stored carb entry \(sample.quantity) in HealthKit Store! Metadata: \(String(describing: sample.metadata?.values))"
-                        )
-                    }
+                    // for sample in samplesToSave {
+                    //    debug(
+                    //        .service,
+                    //        "Stored carb entry \(sample.quantity) in HealthKit Store! Metadata: \(String(describing: sample.metadata?.values))"
+                    //    )
+                    // }
                 } else {
                     debug(.service, "Failed to store carb entry in HealthKit Store!")
                     debug(.service, error?.localizedDescription ?? "Unknown error")
@@ -297,12 +297,12 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
 
             healthKitStore.save(bolusSamples + basalSamples) { (success: Bool, error: Error?) -> Void in
                 if success {
-                    for sample in bolusSamples + basalSamples {
-                        debug(
-                            .service,
-                            "Stored insulin entry in HealthKit Store! Metadata: \(String(describing: sample.metadata?.values))"
-                        )
-                    }
+                    // for sample in bolusSamples + basalSamples {
+                    //    debug(
+                    //    .service,
+                    //        "Stored insulin entry in HealthKit Store! Metadata: \(String(describing: sample.metadata?.values))"
+                    //    )
+                    // }
                 } else {
                     debug(.service, "Failed to store insulin entry in HealthKit Store!")
                     debug(.service, error?.localizedDescription ?? "Unknown error")
@@ -491,7 +491,7 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
 
     private func prepareBGSamplesToPublisherFetch(_ samples: [HKQuantitySample]) {
         dispatchPrecondition(condition: .onQueue(processQueue))
-        debug(.service, "Start preparing samples: \(String(describing: samples))")
+        // debug(.service, "Start preparing samples: \(String(describing: samples))")
 
         newGlucose += samples
             .compactMap { sample -> HealthKitSample? in
@@ -521,10 +521,10 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
 
         newGlucose = newGlucose.removeDublicates()
 
-        debug(
-            .service,
-            "Current BloodGlucose.Type objects will be send from Publisher during fetch: \(String(describing: newGlucose))"
-        )
+        // debug(
+        //    .service,
+        //    "Current BloodGlucose.Type objects will be send from Publisher during fetch: \(String(describing: newGlucose))"
+        // )
     }
 
     // MARK: - GlucoseSource
@@ -542,7 +542,7 @@ final class BaseHealthKitManager: HealthKitManager, Injectable, CarbsObserver, P
             self.processQueue.async {
                 //   debug(.service, "Start fetching HealthKitManager")
                 guard self.settingsManager.settings.useAppleHealth else {
-                    debug(.service, "HealthKitManager cant return any data, because useAppleHealth option is disable")
+                    // debug(.service, "HealthKitManager can't return any data, because useAppleHealth option is disabled")
                     promise(.success([]))
                     return
                 }


### PR DESCRIPTION
* disable some debug logging when AppleHealth is enabled

See Issue #371 for explanation for this PR.

## Additional comments

* most of the excessive lines came in as debug logging in PR #22
* other debug log lines have been removed over time in various commits
* these particular lines were identified by @itsmojo as being unnecessary when he analyzed results

## Testing

* I confirmed the extra lines appeared when Apple Health and Dynamic Features are enabled
* I tested the patch supplied by @itsmojo and confirm the excessive debug logging (for this case) is removed
