### PR TITLE
Fix G7 plist File State Management

### DIFF
--- a/FreeAPS/Sources/APS/CGM/CGMType.swift
+++ b/FreeAPS/Sources/APS/CGM/CGMType.swift
@@ -108,5 +108,4 @@ enum CGMType: String, JSON, CaseIterable, Identifiable {
 enum GlucoseDataError: Error {
     case noData
     case unreliableData
-    case noGlucoseSource
 }

--- a/FreeAPS/Sources/APS/CGM/CGMType.swift
+++ b/FreeAPS/Sources/APS/CGM/CGMType.swift
@@ -108,4 +108,5 @@ enum CGMType: String, JSON, CaseIterable, Identifiable {
 enum GlucoseDataError: Error {
     case noData
     case unreliableData
+    case noGlucoseSource
 }

--- a/FreeAPS/Sources/APS/CGM/PluginSource.swift
+++ b/FreeAPS/Sources/APS/CGM/PluginSource.swift
@@ -177,7 +177,6 @@ extension PluginSource: CGMManagerDelegate {
                 .deviceManager,
                 "No glucose source available."
             )
-            return .failure(GlucoseDataError.noGlucoseSource)
         }
 
         switch readingResult {

--- a/FreeAPS/Sources/APS/CGM/PluginSource.swift
+++ b/FreeAPS/Sources/APS/CGM/PluginSource.swift
@@ -141,7 +141,7 @@ extension PluginSource: CGMManagerDelegate {
         guard let trioFetchGlucoseManager = glucoseManager else {
             debug(
                 .deviceManager,
-                "Could not gracefully unwrap Trio FetchGlucoseManager upon observing LoopKit's cgmManangerDidUpdateState"
+                "Could not gracefully unwrap Trio FetchGlucoseManager upon observing LoopKit's cgmManagerDidUpdateState"
             )
             return
         }

--- a/FreeAPS/Sources/APS/CGM/PluginSource.swift
+++ b/FreeAPS/Sources/APS/CGM/PluginSource.swift
@@ -145,13 +145,14 @@ extension PluginSource: CGMManagerDelegate {
             )
             return
         }
-        // Adjust Trio-specific NS Upload setting to true, when CGM setting is changed
+        // Adjust Trio-specific NS Upload setting value when CGM setting is changed
         trioFetchGlucoseManager.settingsManager.settings.uploadGlucose = cgmManager.shouldSyncToRemoteService
 
         // Update glucose source upon state change, e.g. when user switches G7 which is basically a transmitter change without removing and adding a transmitter.
         trioFetchGlucoseManager.updateGlucoseSource(
             cgmGlucoseSourceType: trioFetchGlucoseManager.settingsManager.settings.cgm,
-            cgmGlucosePluginId: trioFetchGlucoseManager.settingsManager.settings.cgmPluginIdentifier
+            cgmGlucosePluginId: trioFetchGlucoseManager.settingsManager.settings.cgmPluginIdentifier,
+            newManager: cgmManager as? CGMManagerUI
         )
     }
 

--- a/FreeAPS/Sources/APS/FetchGlucoseManager.swift
+++ b/FreeAPS/Sources/APS/FetchGlucoseManager.swift
@@ -103,11 +103,13 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
         if self.cgmGlucoseSourceType != cgmGlucoseSourceType || self.cgmGlucosePluginId != cgmGlucosePluginId {
             removeCalibrations()
             cgmManager = nil
+            glucoseSource = nil
         }
 
         self.cgmGlucoseSourceType = cgmGlucoseSourceType
         self.cgmGlucosePluginId = cgmGlucosePluginId
 
+        
         // if not plugin, manager is not changed and stay with the "old" value if the user come back to previous cgmtype
         // if plugin, if the same pluginID, no change required because the manager is available
         // if plugin, if not the same pluginID, need to reset the cgmManager
@@ -122,24 +124,26 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
         } else {
             saveConfigManager()
         }
-
-        switch self.cgmGlucoseSourceType {
-        case .none:
-            glucoseSource = nil
-        case .xdrip:
-            glucoseSource = AppGroupSource(from: "xDrip", cgmType: .xdrip)
-        case .nightscout:
-            glucoseSource = nightscoutManager
-        case .simulator:
-            glucoseSource = simulatorSource
-        case .glucoseDirect:
-            glucoseSource = AppGroupSource(from: "GlucoseDirect", cgmType: .glucoseDirect)
-        case .enlite:
-            glucoseSource = deviceDataManager
-        case .plugin:
-            glucoseSource = PluginSource(glucoseStorage: glucoseStorage, glucoseManager: self)
+            
+        if glucoseSource == nil {
+            switch self.cgmGlucoseSourceType {
+            case .none:
+                glucoseSource = nil
+            case .xdrip:
+                glucoseSource = AppGroupSource(from: "xDrip", cgmType: .xdrip)
+            case .nightscout:
+                glucoseSource = nightscoutManager
+            case .simulator:
+                glucoseSource = simulatorSource
+            case .glucoseDirect:
+                glucoseSource = AppGroupSource(from: "GlucoseDirect", cgmType: .glucoseDirect)
+            case .enlite:
+                glucoseSource = deviceDataManager
+            case .plugin:
+                glucoseSource = PluginSource(glucoseStorage: glucoseStorage, glucoseManager: self)
+            }
+            // update the config
         }
-        // update the config
     }
 
     /// Upload cgmManager from raw value

--- a/FreeAPS/Sources/APS/FetchGlucoseManager.swift
+++ b/FreeAPS/Sources/APS/FetchGlucoseManager.swift
@@ -125,27 +125,22 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
         }
 
         if glucoseSource == nil {
-            debug(
-                .deviceManager,
-                "Updating glucose source."
-            )
-        }
-
-        switch self.cgmGlucoseSourceType {
-        case .none:
-            glucoseSource = nil
-        case .xdrip:
-            glucoseSource = AppGroupSource(from: "xDrip", cgmType: .xdrip)
-        case .nightscout:
-            glucoseSource = nightscoutManager
-        case .simulator:
-            glucoseSource = simulatorSource
-        case .glucoseDirect:
-            glucoseSource = AppGroupSource(from: "GlucoseDirect", cgmType: .glucoseDirect)
-        case .enlite:
-            glucoseSource = deviceDataManager
-        case .plugin:
-            glucoseSource = PluginSource(glucoseStorage: glucoseStorage, glucoseManager: self)
+            switch self.cgmGlucoseSourceType {
+            case .none:
+                glucoseSource = nil
+            case .xdrip:
+                glucoseSource = AppGroupSource(from: "xDrip", cgmType: .xdrip)
+            case .nightscout:
+                glucoseSource = nightscoutManager
+            case .simulator:
+                glucoseSource = simulatorSource
+            case .glucoseDirect:
+                glucoseSource = AppGroupSource(from: "GlucoseDirect", cgmType: .glucoseDirect)
+            case .enlite:
+                glucoseSource = deviceDataManager
+            case .plugin:
+                glucoseSource = PluginSource(glucoseStorage: glucoseStorage, glucoseManager: self)
+            }
         }
     }
 

--- a/FreeAPS/Sources/APS/FetchGlucoseManager.swift
+++ b/FreeAPS/Sources/APS/FetchGlucoseManager.swift
@@ -109,7 +109,6 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
         self.cgmGlucoseSourceType = cgmGlucoseSourceType
         self.cgmGlucosePluginId = cgmGlucosePluginId
 
-        
         // if not plugin, manager is not changed and stay with the "old" value if the user come back to previous cgmtype
         // if plugin, if the same pluginID, no change required because the manager is available
         // if plugin, if not the same pluginID, need to reset the cgmManager
@@ -124,25 +123,29 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
         } else {
             saveConfigManager()
         }
-            
+
         if glucoseSource == nil {
-            switch self.cgmGlucoseSourceType {
-            case .none:
-                glucoseSource = nil
-            case .xdrip:
-                glucoseSource = AppGroupSource(from: "xDrip", cgmType: .xdrip)
-            case .nightscout:
-                glucoseSource = nightscoutManager
-            case .simulator:
-                glucoseSource = simulatorSource
-            case .glucoseDirect:
-                glucoseSource = AppGroupSource(from: "GlucoseDirect", cgmType: .glucoseDirect)
-            case .enlite:
-                glucoseSource = deviceDataManager
-            case .plugin:
-                glucoseSource = PluginSource(glucoseStorage: glucoseStorage, glucoseManager: self)
-            }
-            // update the config
+            debug(
+                .deviceManager,
+                "Updating glucose source."
+            )
+        }
+
+        switch self.cgmGlucoseSourceType {
+        case .none:
+            glucoseSource = nil
+        case .xdrip:
+            glucoseSource = AppGroupSource(from: "xDrip", cgmType: .xdrip)
+        case .nightscout:
+            glucoseSource = nightscoutManager
+        case .simulator:
+            glucoseSource = simulatorSource
+        case .glucoseDirect:
+            glucoseSource = AppGroupSource(from: "GlucoseDirect", cgmType: .glucoseDirect)
+        case .enlite:
+            glucoseSource = deviceDataManager
+        case .plugin:
+            glucoseSource = PluginSource(glucoseStorage: glucoseStorage, glucoseManager: self)
         }
     }
 

--- a/scripts/capture-build-details.sh
+++ b/scripts/capture-build-details.sh
@@ -20,8 +20,8 @@ else
     # Capture the current date and write it to BuildDetails.plist
     plutil -replace com-trio-build-date -string "$(date)" "${info_plist_path}"
 
-    # Retrieve the current branch, if available
-    git_branch=$(git symbolic-ref --short -q HEAD || echo "")
+    # Retrieve the current branch
+    git_branch=$(git symbolic-ref --short -q HEAD)
 
     # Attempt to retrieve the current tag
     git_tag=$(git describe --tags --exact-match 2>/dev/null || echo "")
@@ -29,11 +29,8 @@ else
     # Retrieve the current SHA of the latest commit
     git_commit_sha=$(git log -1 --format="%h" --abbrev=7)
 
-    # Determine the branch or tag information, or fallback to SHA if in detached state
+    # Determine the branch or tag information
     git_branch_or_tag="${git_branch:-${git_tag}}"
-    if [ -z "${git_branch_or_tag}" ]; then
-        git_branch_or_tag="detached"
-    fi
 
     # Update BuildDetails.plist with the branch or tag information
     plutil -replace com-trio-branch -string "${git_branch_or_tag}" "${info_plist_path}"

--- a/scripts/capture-build-details.sh
+++ b/scripts/capture-build-details.sh
@@ -20,8 +20,8 @@ else
     # Capture the current date and write it to BuildDetails.plist
     plutil -replace com-trio-build-date -string "$(date)" "${info_plist_path}"
 
-    # Retrieve the current branch
-    git_branch=$(git symbolic-ref --short -q HEAD)
+    # Retrieve the current branch, if available
+    git_branch=$(git symbolic-ref --short -q HEAD || echo "")
 
     # Attempt to retrieve the current tag
     git_tag=$(git describe --tags --exact-match 2>/dev/null || echo "")
@@ -29,8 +29,11 @@ else
     # Retrieve the current SHA of the latest commit
     git_commit_sha=$(git log -1 --format="%h" --abbrev=7)
 
-    # Determine the branch or tag information
+    # Determine the branch or tag information, or fallback to SHA if in detached state
     git_branch_or_tag="${git_branch:-${git_tag}}"
+    if [ -z "${git_branch_or_tag}" ]; then
+        git_branch_or_tag="detached"
+    fi
 
     # Update BuildDetails.plist with the branch or tag information
     plutil -replace com-trio-branch -string "${git_branch_or_tag}" "${info_plist_path}"


### PR DESCRIPTION
Addresses #354 and handles glucose source changes so that the binary file is properly updated, solving an issue where Trio reverts back to old G7 transmitter IDs. 

Additionally, this PR also holds a small fix by @bjorkert to be able to build Trio when the code base sits at a tag or a detached head. 