### PR TITLE
Disable saving autotune to pump

### DIFF
--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -96,14 +96,14 @@ extension AutotuneConfig {
                             .foregroundColor(.red)
                     }
 
-                    Section {
-                        Button {
-                            replaceAlert = true
-                        }
-                        label: { Text("Save as your Normal Basal Rates") }
-                    } header: {
-                        Text("Replace Normal Basal")
-                    }
+                    /* Section {
+                         Button {
+                             replaceAlert = true
+                         }
+                         label: { Text("Save as your Normal Basal Rates") }
+                     } header: {
+                         Text("Replace Normal Basal")
+                     } */
                 }
             }
             .onAppear(perform: configureView)


### PR DESCRIPTION
0 U/hr basal rates seem to be causing a problem with this functionality.

This just comments out the button for now to prevent users from getting hit with this bug until the old bug is squashed.