### PR TITLE
glucose rounding fix

### DIFF
--- a/FreeAPS/Sources/Modules/DataTable/View/DataTableRootView.swift
+++ b/FreeAPS/Sources/Modules/DataTable/View/DataTableRootView.swift
@@ -45,7 +45,7 @@ extension DataTable {
                 formatter.minimumFractionDigits = 0
                 formatter.maximumFractionDigits = 1
             }
-            formatter.roundingMode = .down
+            formatter.roundingMode = .halfUp
             return formatter
         }
 


### PR DESCRIPTION
This is to address Issue https://github.com/nightscout/Trio/issues/396.

Since rounding is taken care of in BloodGlucose now, the down rounding in the numberFormatter can be changed to round halfUp.

Tested from 8 to 11 in increments of 0.1 mmol/L. Here's a snipped:
<img width="350" alt="Screenshot 2024-08-25 at 3 53 29 PM" src="https://github.com/user-attachments/assets/17d5afcd-c5b7-49b6-8a74-e96e507cd6d0">
