### PR TITLE
Fix possible incorrect total basal units in profile editor

### DIFF
--- a/FreeAPS/Sources/Modules/BasalProfileEditor/BasalProfileEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/BasalProfileEditor/BasalProfileEditorStateModel.swift
@@ -82,6 +82,7 @@ extension BasalProfileEditor {
                 let sorted = uniq.sorted { $0.timeIndex < $1.timeIndex }
                 sorted.first?.timeIndex = 0
                 self.items = sorted
+                self.calcTotal()
             }
         }
     }

--- a/FreeAPS/Sources/Modules/BasalProfileEditor/BasalProfileEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/BasalProfileEditor/BasalProfileEditorStateModel.swift
@@ -86,9 +86,9 @@ extension BasalProfileEditor {
             }
         }
 
-        func availableTimeIndices(forItemIndex: Int) -> [Int]
+        func availableTimeIndices(_ itemIndex: Int) -> [Int]
         {
-            let usedIndicesByOtherItems = items.filter { $0 != items[forItemIndex] }.map(\.timeIndex)
+            let usedIndicesByOtherItems = items.filter { $0 != items[itemIndex] }.map(\.timeIndex)
             return (0 ..< timeValues.count).filter { !usedIndicesByOtherItems.contains($0) }
         }
     }

--- a/FreeAPS/Sources/Modules/BasalProfileEditor/BasalProfileEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/BasalProfileEditor/BasalProfileEditorStateModel.swift
@@ -85,5 +85,11 @@ extension BasalProfileEditor {
                 self.calcTotal()
             }
         }
+
+        func availableTimeIndices(forItemIndex: Int) -> [Int]
+        {
+            let usedIndicesByOtherItems = items.filter { $0 != items[forItemIndex] }.map(\.timeIndex)
+            return (0 ..< timeValues.count).filter { !usedIndicesByOtherItems.contains($0) }
+        }
     }
 }

--- a/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
@@ -85,7 +85,7 @@ extension BasalProfileEditor {
                         .clipped()
 
                         Picker(selection: $state.items[index].timeIndex, label: EmptyView()) {
-                            ForEach(state.availableTimeIndices(forItemIndex: index), id: \.self) { i in
+                            ForEach(state.availableTimeIndices(index), id: \.self) { i in
                                 Text(
                                     self.dateFormatter
                                         .string(from: Date(

--- a/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
@@ -81,7 +81,6 @@ extension BasalProfileEditor {
                                 ).tag(i)
                             }
                         }
-                        .onChange(of: state.items[index].rateIndex, perform: { _ in state.calcTotal() })
                         .frame(maxWidth: geometry.size.width / 2)
                         .clipped()
 
@@ -96,7 +95,6 @@ extension BasalProfileEditor {
                                 ).tag(i)
                             }
                         }
-                        .onChange(of: state.items[index].timeIndex, perform: { _ in state.calcTotal() })
                         .frame(maxWidth: geometry.size.width / 2)
                         .clipped()
                     }

--- a/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/BasalProfileEditor/View/BasalProfileEditorRootView.swift
@@ -85,7 +85,7 @@ extension BasalProfileEditor {
                         .clipped()
 
                         Picker(selection: $state.items[index].timeIndex, label: EmptyView()) {
-                            ForEach(0 ..< state.timeValues.count, id: \.self) { i in
+                            ForEach(state.availableTimeIndices(forItemIndex: index), id: \.self) { i in
                                 Text(
                                     self.dateFormatter
                                         .string(from: Date(


### PR DESCRIPTION
Fixes possible incorrect total basal units in profile editor


**Steps to reproduce**
* Edit simple basal profile eg. 00:00 1 u/hr, 12:00 0.5 u/hr
    * Total shows 18 u/day, which is correct.
* Add a new entry and let it start at 10:00 with 0.75 u/hr
    * Total units now shows 21.5 u/day which is incorrect. It should be 17.5 u/day.

**Cause**\
This is caused by the fact that the total is calculated before the entries are sorted.

**Effects**\
It seems to be a visual problem only, saving on pump seems to save the profile correctly. And after reopening the profile editor, the total is calulated correctly aswell.


**Priority**\
Even though this might not be a problem when 1.0 comes with reworked settings, this bug got me scared when editing my basal profile. So I figured this might be worth fixing.


**Deduplication of items**\
Furthermore, upon inspecing the validate() function I noticed that entries will get deduplicated based on the start time. As this method is called .onAppear of the RootView it's possible that while editing an entry it will get depulicated if one selects an already used start time. after that happens, changing the time or rate of this entry will cause the application to crash

I included a fix for that particular situation by making it impossible to select an already used start time, which I feel like is a nice addition from a users perspective aswell.
But this is more of an edge case and this problem also exists in other similar views like the ISF profile editor. So if we think it's worth fixing, I could also fix that in a separate PR and then include the other views aswell.


This is my first PR to this project, so feedback is welcome :)