### PR TITLE
feat: Add automated certificate check and renewal workflows

### DIFF
--- a/.github/workflows/build_trio.yml
+++ b/.github/workflows/build_trio.yml
@@ -23,6 +23,14 @@ jobs:
     uses: ./.github/workflows/validate_secrets.yml
     secrets: inherit
 
+  # Checks if Distribution certificate is present and valid, optionally nukes and
+  # creates new certs if the repository variable ENABLE_NUKE_CERTS == 'true'
+  check_certs:
+      name: Check certificates
+      needs: validate
+      uses: ./.github/workflows/check_certs.yml
+      secrets: inherit
+
   # Checks if GH_PAT holds workflow permissions
   # Checks for existence of alive branch; if non-existent creates it
   check_alive_and_permissions:
@@ -185,7 +193,7 @@ jobs:
   # Builds Trio
   build:
     name: Build
-    needs: [validate, check_alive_and_permissions, check_latest_from_upstream]
+    needs: [validate, check_alive_and_permissions, check_latest_from_upstream, check_certs]
     runs-on: macos-14
     permissions:
       contents: write

--- a/.github/workflows/check_certs.yml
+++ b/.github/workflows/check_certs.yml
@@ -1,0 +1,126 @@
+name: Check Certificates
+run-name: Check Certificates (${{ github.ref_name }})
+
+on: [workflow_call, workflow_dispatch]
+
+env:
+  EXPIRATION_WARNING_DAYS: 7
+
+jobs:
+  check_certs:
+    runs-on: ubuntu-latest
+    env:
+      FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
+      FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
+      FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
+    outputs:
+      new_certificate_needed: ${{ steps.set_output.outputs.new_certificate_needed }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Check Certificates and create or renew if needed
+        env:
+          FASTLANE_USER: ${{ secrets.APPLE_ID }}
+          FASTLANE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        run: bundle exec fastlane check_and_renew_certificates
+        id: check_certs
+
+      - name: Set output based on Fastlane result
+        id: set_output
+        run: |
+          CERT_STATUS_FILE="${{ github.workspace }}/fastlane/new_certificate_needed.txt"
+          ENABLE_NUKE_CERTS=${{ vars.ENABLE_NUKE_CERTS }}
+
+          if [ -f "$CERT_STATUS_FILE" ]; then
+            CERT_STATUS=$(cat "$CERT_STATUS_FILE" | tr -d '\n' | tr -d '\r') # Read file content and strip newlines
+            echo "new_certificate_needed: $CERT_STATUS"
+            echo "new_certificate_needed=$CERT_STATUS" >> $GITHUB_OUTPUT
+          else
+            echo "Certificate status file not found. Defaulting to false."
+            echo "new_certificate_needed=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Check if certs are valid
+          if [ "$CERT_STATUS" != "true" ]; then
+            echo "::notice::✅ Distribution certificate is present and valid. No action required."
+          fi
+
+          # Check if ENABLE_NUKE_CERTS is not set to true when certs are valid
+          if [ "$CERT_STATUS" != "true" ] && [ "$ENABLE_NUKE_CERTS" != "true" ]; then
+            echo "::notice::🔔 Automated renewal of certificates is disabled because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
+          fi
+
+          # Check if ENABLE_NUKE_CERTS is not set to true when certs are not valid
+          if [ "$CERT_STATUS" = "true" ] && [ "$ENABLE_NUKE_CERTS" != "true" ]; then
+            echo "::error::❌ No valid distribution certificate found. Automated renewal of certificates was skipped because the repository variable ENABLE_NUKE_CERTS is not set to 'true'."
+            exit 1
+          fi
+
+          # Check if vars.FORCE_NUKE_CERTS is not set to true
+          if [ vars.FORCE_NUKE_CERTS = "true" ]; then
+            echo "::warning::‼️ Nuking of certificates was forced because the repository variable FORCE_NUKE_CERTS is set to 'true'."
+          fi
+
+  # Nuke Certs if needed, and if the repository variable ENABLE_NUKE_CERTS is set to 'true', or if FORCE_NUKE_CERTS is set to 'true', which will always force certs to be nuked
+  nuke_certs:
+    needs: check_certs
+    runs-on: macos-14
+    if: ${{ (needs.check_certs.outputs.new_certificate_needed == 'true' && vars.ENABLE_NUKE_CERTS == 'true') || vars.FORCE_NUKE_CERTS == 'true' }}
+    steps:
+      - name: Debug check_certs output
+        run: echo "new_certificate_needed=${{ needs.check_certs.outputs.new_certificate_needed }}"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run Fastlane nuke_certs
+        run: bundle exec fastlane nuke_certs
+        env:
+          TEAMID: ${{ secrets.TEAMID }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          FASTLANE_USER: ${{ secrets.FASTLANE_USER }}
+          FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
+          FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
+          FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
+          FASTLANE_SKIP_ALL_LANE_SUMMARIES: "true"
+
+      - name: Annotate Summary after Nuke
+        run: |
+          echo "::warning::⚠️⚠️⚠️   All Distribution certificates and TestFlight profiles have been revoked."
+
+
+  # Trigger create_certs.yml if nuke_certs ran
+  trigger_create_certs:
+    needs: [check_certs, nuke_certs]
+    uses: ./.github/workflows/create_certs.yml
+    secrets: inherit
+
+  # Annotate Summary after Certificate Creation
+  annotate_summary:
+    needs: trigger_create_certs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Annotate Summary
+        run: |
+          echo "::warning::⚠️⚠️⚠️   Certificates have been recreated successfully."
+          echo "::warning::⚠️⚠️⚠️   If you have other apps being distributed by GitHub Actions / Fastlane / TestFlight, please run the '3. Create Certificates' workflow for each of these apps to allow these apps to be built."
+          echo "::warning::✅✅✅   But don't worry about your existing TestFlight builds, they will keep working!"

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -1,7 +1,6 @@
 name: 3. Create Certificates
 run-name: Create Certificates (${{ github.ref_name }})
-on:
-  workflow_dispatch:
+on: [workflow_call, workflow_dispatch]
 
 jobs:
   validate:

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -184,10 +184,13 @@ jobs:
               echo "::error::Unable to decrypt the Match-Secrets repository using the MATCH_PASSWORD secret. Verify that it is set correctly and try again."
             elif grep -q -e "required agreement" -e "license agreement" fastlane.log; then
               failed=true
-              echo "::error::Unable to create a valid authorization token for the App Store Connect API. Verify that the latest developer program license agreement has been accepted at https://developer.apple.com/account (review and accept any updated agreement), then wait a few minutes for changes to propagate and try again."
+              echo "::error::Unable to create a valid authorization token for the App Store Connect API."
+              echo "::error::❗️ Verify that the latest developer program license agreement has been accepted at https://developer.apple.com/account (review and accept any updated agreement), then wait a few minutes for changes to take effect and try again."
             elif ! grep -q -e "No code signing identity found" -e "Could not install WWDR certificate" fastlane.log; then
               failed=true
-              echo "::error::Unable to create a valid authorization token for the App Store Connect API. Verify that the FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY secrets are set correctly and try again."
+              echo "::error::Unable to create a valid authorization token for the App Store Connect API."
+              echo "::error::❗️ Verify that the latest developer program license agreement has been accepted at https://developer.apple.com/account (review and accept any updated agreement), then wait a few minutes for changes to take effect and try again."
+              echo "::error::❗️ Also verify that the FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, and FASTLANE_KEY secrets are set correctly and try again."
             fi
           fi
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -271,4 +271,69 @@ platform :ios do
       git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}")
     )
   end
+
+  desc "Check Certificates and Trigger Workflow for Expired or Missing Certificates"
+  lane :check_and_renew_certificates do
+    setup_ci if ENV['CI']
+    ENV["MATCH_READONLY"] = false.to_s
+
+    # Authenticate using App Store Connect API Key
+    api_key = app_store_connect_api_key(
+      key_id: ENV["FASTLANE_KEY_ID"],
+      issuer_id: ENV["FASTLANE_ISSUER_ID"],
+      key_content: ENV["FASTLANE_KEY"] # Ensure valid key content
+    )
+
+    # Initialize flag to track if renewall of certificates is needed
+    new_certificate_needed = false
+
+    # Fetch all certificates
+    certificates = Spaceship::ConnectAPI::Certificate.all
+
+    # Filter for Distribution Certificates
+    distribution_certs = certificates.select { |cert| cert.certificate_type == "DISTRIBUTION" }
+
+    # Handle case where no distribution certificates are found
+    if distribution_certs.empty?
+      puts "⚠️ No distribution certificates found! Triggering workflow to create new certificates."
+      new_certificate_needed = true
+    else
+      # Get expiration warning days from ENV or default to 7
+      expiration_warning_days = (ENV['EXPIRATION_WARNING_DAYS'] || 7).to_i
+
+      # Check for expiration
+      distribution_certs.each do |cert|
+        expiration_date = Time.parse(cert.expiration_date)
+
+        puts "Checking Distribution Certificate: #{cert.id}, Expiration: #{expiration_date}"
+
+        if expiration_date < Time.now
+          puts "❌ Certificate #{cert.id} is already expired!"
+          new_certificate_needed = true
+        elsif expiration_date < Time.now + expiration_warning_days * 24 * 60 * 60
+          puts "⚠️ Certificate #{cert.id} is expiring in #{expiration_warning_days} days"
+          new_certificate_needed = false
+        else
+          puts "✅ Certificate #{cert.id} is valid, and will not expire during the next #{expiration_warning_days} days"
+        end
+      end
+    end
+
+    # Write result to new_certificate_needed.txt
+    file_path = File.expand_path('new_certificate_needed.txt')
+    File.write(file_path, new_certificate_needed ? 'true' : 'false')
+
+    # Handle output for triggering workflow
+    if new_certificate_needed
+      puts "❌ Certificate is expired or no certificates found. Creating flag file to trigger renewal or creation of certificate."
+    else
+      puts "✅ Distribution certificate is present and valid. No action required."
+    end
+
+    # Log the absolute path and contents of the new_certificate_needed.txt file
+    puts ""
+    puts "Absolute path of new_certificate_needed.txt: #{file_path}"
+    new_certificate_needed_content = File.read(file_path)
+    puts "Certificate creation or renewal needed: #{new_certificate_needed_content}"
+  end
 end


### PR DESCRIPTION
- Introduced `check_certs.yml` workflow to validate the presence and validity of distribution certificates, with options to renew or recreate certificates.
- Updated `build_trio.yml` to integrate certificate checks as a dependency for the build job.
- Enhanced `validate_secrets.yml` with clearer error messages for App Store Connect API authorization issues.
- Modified `create_certs.yml` to allow `workflow_call` triggers.
- Added `check_and_renew_certificates` lane in Fastlane for certificate validation and renewal.
- Nuke certs only if repository variable ENABLE_NUKE_CERTS == 'true'
- Set failure and output annotation if nuke_certs were skipped due to ENABLE_NUKE_CERTS != true
