### PR TITLE
Issue template updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,7 +3,7 @@ name: "\U0001F41B Bug report"
 about: Create a report to help us fix things
 title: ''
 labels: ['needs-triage']
-type: ['bug']
+type: "bug"
 assignees: ''
 projects: ['nightscout/2']
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,8 @@
 name: "\U0001F41B Bug report"
 about: Create a report to help us fix things
 title: ''
-labels: ['bug', 'needs-triage']
+labels: ['needs-triage']
+type: 'bug'
 assignees: ''
 projects: ['nightscout/2']
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -3,7 +3,7 @@ name: "\U0001F41B Bug report"
 about: Create a report to help us fix things
 title: ''
 labels: ['needs-triage']
-type: 'bug'
+type: ['bug']
 assignees: ''
 projects: ['nightscout/2']
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,8 @@
 name: "\U0001F4A1 Feature request \U0001F4A1"
 about: Suggest an idea for this project
 title: ''
-labels: ['enhancement', 'needs-triage']
+labels: ['needs-triage']
+types: 'feature'
 assignees: ''
 projects: ['nightscout/2']
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: "\U0001F4A1 Feature request \U0001F4A1"
 about: Suggest an idea for this project
 title: ''
 labels: ['needs-triage']
-types: 'feature'
+types: ['feature']
 assignees: ''
 projects: ['nightscout/2']
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -3,7 +3,7 @@ name: "\U0001F4A1 Feature request \U0001F4A1"
 about: Suggest an idea for this project
 title: ''
 labels: ['needs-triage']
-types: ['feature']
+types: "feature"
 assignees: ''
 projects: ['nightscout/2']
 


### PR DESCRIPTION
Moving from Tags for Bug and Features to Types as per the new GH Features for Issues.
https://github.blog/changelog/2025-01-13-evolving-github-issues-public-preview/?utm_source=tldrnewsletter

Tested only own Org repo https://github.com/Bo3Dev/Trio/issues/2 :
![image](https://github.com/user-attachments/assets/ed022023-414c-4739-bda2-eafb80f1c797)
