### PR TITLE
Fix Auto Dev Version GH Action: 

### DIFF
--- a/.github/workflows/auto_version_dev.yml
+++ b/.github/workflows/auto_version_dev.yml
@@ -25,7 +25,11 @@
 # - Second push to `dev`:     → `APP_DEV_VERSION = 0.5.0.2`
 # - ...
 #
+# Commit Handling:
 # The updated value is committed and pushed back to the `dev` branch.
+# - The bump commit includes the `[skip ci]` tag in its message
+# - This prevents the workflow from re-triggering itself in a loop
+# 
 #
 # Prerequisites:
 # - `APP_VERSION` must be present in `Config.xcconfig` in the form `x.y.z`
@@ -49,6 +53,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+         token: ${{ secrets.TRIO_TOKEN_AUTOBUMP }}
 
       - name: Set up Git
         run: |
@@ -96,5 +102,5 @@ jobs:
       - name: Commit and push updated dev version
         run: |
           git add Config.xcconfig
-          git commit -m "CI: Bump APP_DEV_VERSION to $NEW_DEV_VERSION"
+          git commit -m "CI: Bump APP_DEV_VERSION to $NEW_DEV_VERSION [skip ci]"
           git push


### PR DESCRIPTION
## Summary
This PR updates the version bump workflow to explicitly use a fine-grained GitHub token (`TRIO_TOKEN_AUTOBUMP`) when pushing the updated `Config.xcconfig` to the `dev` branch. This resolves permission issues caused by `actions/checkout` defaulting to the limited `GITHUB_TOKEN`, which cannot push to protected branches.

### Changes

* Passes `with` `token: ${{ secrets.TRIO_TOKEN_AUTOBUMP }}` to `actions/checkout`
  → ensures `git` is configured with correct credentials from the start
* Includes `[skip ci]` in the commit message to prevent re-triggering the workflow from its own commit
* Added `TRIO_TOKEN_AUTOBUMP` to Trio repository's Action > Secrets & Variables > Secrets (only mentioning here as that is not visible in committed changes)

### Additional Context

* `actions/checkout` sets Git credentials based on the token passed to it — even if a custom token is provided via `env` in a later (sub-)step, it will not override the `checkout`-configured credentials.
* Using `[skip ci]` is a clean, native way to prevent infinite loops when workflows commit to the same branch they’re listening on. It is offered by default by Github for Actions, [see documentation](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs).