### PR TITLE
Fix glucoseSource Crash

### DIFF
--- a/Trio/Sources/APS/FetchGlucoseManager.swift
+++ b/Trio/Sources/APS/FetchGlucoseManager.swift
@@ -11,7 +11,7 @@ protocol FetchGlucoseManager: SourceInfoProvider {
     func updateGlucoseSource(cgmGlucoseSourceType: CGMType, cgmGlucosePluginId: String, newManager: CGMManagerUI?)
     func deleteGlucoseSource() async
     func removeCalibrations()
-    var glucoseSource: GlucoseSource! { get }
+    var glucoseSource: GlucoseSource? { get }
     var cgmManager: CGMManagerUI? { get }
     var cgmGlucoseSourceType: CGMType { get set }
     var cgmGlucosePluginId: String { get }
@@ -113,7 +113,7 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
         timer.resume()
     }
 
-    var glucoseSource: GlucoseSource!
+    var glucoseSource: GlucoseSource?
 
     func removeCalibrations() {
         calibrationService.removeAllCalibrations()
@@ -286,7 +286,7 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
     }
 
     func sourceInfo() -> [String: Any]? {
-        glucoseSource.sourceInfo()
+        glucoseSource?.sourceInfo()
     }
 
     private func overcalibrate(entries: [BloodGlucose]) -> [BloodGlucose] {


### PR DESCRIPTION
### Summary

This PR updates `BaseFetchGlucoseManager.sourceInfo()` to safely unwrap `glucoseSource` using optional chaining. This resolves a crash reported via Crashlytics caused by force-unwrapping a `nil` `glucoseSource` during notification dispatch.

### Bug


**Crashlytics issue** `4ff6327254cd44f6bc557c6bb618a1ab`
**Crash on** force-unwrapped `glucoseSource` in `sourceInfo()`
**Cause**: `glucoseSource` was nil when `sourceInfo()` was called (e.g., after `deleteGlucoseSource()`), leading to a crash on an implicitly unwrapped optional.

### Changes

* Updated `glucoseSource` from `GlucoseSource!` to `GlucoseSource?` in both the protocol and `BaseFetchGlucoseManager`
* Updated `sourceInfo()` to use optional chaining: `glucoseSource?.sourceInfo()`
* Preserved protocol conformance by aligning with the default `nil`-returning implementation in `GlucoseSource`