### PR TITLE
Fix Tap Target Size for Save Buttons in Contact Image Views

### DIFF
--- a/Trio/Sources/Modules/ContactImage/View/AddContactImageSheet.swift
+++ b/Trio/Sources/Modules/ContactImage/View/AddContactImageSheet.swift
@@ -189,7 +189,9 @@ struct AddContactImageSheet: View {
             Button(action: {
                 saveNewEntry()
             }, label: {
-                Text("Save").padding(10)
+                Text("Save")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(10)
             })
                 .frame(width: UIScreen.main.bounds.width * 0.9, alignment: .center)
                 .background(Color(.systemBlue))

--- a/Trio/Sources/Modules/ContactImage/View/ContactImageDetailView.swift
+++ b/Trio/Sources/Modules/ContactImage/View/ContactImageDetailView.swift
@@ -164,7 +164,9 @@ struct ContactImageDetailView: View {
             Button(action: {
                 saveChanges()
             }, label: {
-                Text("Save").padding(10)
+                Text("Save")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(10)
             })
                 .frame(width: UIScreen.main.bounds.width * 0.9, alignment: .center)
                 .background(isUnchanged ? Color(.systemGray4) : Color(.systemBlue))


### PR DESCRIPTION
## Summary
This PR resolves #517 , which reported difficult-to-tap "Save" buttons in the Contact Image creation and detail views, as only the text was tappable.

### Changes
* Updated the **"Save"** buttons in both `AddContactImageSheet` and `ContactImageDetailView` to:
  * Expand to full width using `.frame(maxWidth: .infinity)`
  * Maintain appropriate vertical padding for accessibility