### PR TITLE
Use Dynamic Hourglass SF Symbols for Pod Expiration Timer

### DIFF
--- a/Trio/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/PumpView.swift
@@ -26,7 +26,7 @@ struct PumpView: View {
             return "hourglass.bottomhalf.filled"
         case 12 ..< 60:
             return "hourglass"
-        case 0 ..< 12:
+        case -8 ..< 12:
             return "hourglass.tophalf.filled"
         default:
             return "hourglass"

--- a/Trio/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/PumpView.swift
@@ -16,6 +16,23 @@ struct PumpView: View {
         return formatter
     }
 
+    private var hourglassIcon: String {
+        guard let expiration = expiresAtDate else { return "hourglass" }
+
+        let hoursRemaining = expiration.timeIntervalSince(timerDate) / 3600
+
+        switch hoursRemaining {
+        case 60 ... 72:
+            return "hourglass.bottomhalf.filled"
+        case 12 ..< 60:
+            return "hourglass"
+        case 0 ..< 12:
+            return "hourglass.tophalf.filled"
+        default:
+            return "hourglass"
+        }
+    }
+
     var body: some View {
         if let pumpStatusHighlightMessage = pumpStatusHighlightMessage { // display message instead pump info
             VStack(alignment: .center) {
@@ -79,28 +96,28 @@ struct PumpView: View {
                 }
 
                 if let date = expiresAtDate {
-                    HStack {
-                        Image(systemName: "stopwatch.fill")
-                            .font(.callout)
-                            .foregroundStyle(timerColor)
+                HStack {
+                    Image(systemName: hourglassIcon)
+                        .font(.callout)
+                        .foregroundStyle(timerColor)
 
-                        let remainingTimeString = remainingTimeString(time: date.timeIntervalSince(timerDate))
+                    let remainingTimeString = remainingTimeString(time: date.timeIntervalSince(timerDate))
 
-                        Text(remainingTimeString)
-                            .font(date.timeIntervalSince(timerDate) > 0 ? .callout : .subheadline)
-                            .fontWeight(.bold)
-                            .fontDesign(.rounded)
-                            .lineLimit(2)
-                            .multilineTextAlignment(.leading)
-                            .frame(
-                                // If the string is > 6 chars, i.e., exceeds "xd yh", limit width to 80 pts
-                                // This forces the "Replace pod" string to wrap to 2 lines.
-                                maxWidth: remainingTimeString.count > 6 ? 80 : .infinity,
-                                alignment: .leading
-                            )
-                    }
-                    // aligns the stopwatch icon exactly with the first pixel of the reservoir icon
-                    .padding(.leading, date.timeIntervalSince(timerDate) > 0 ? 12 : 0)
+                    Text(remainingTimeString)
+                        .font(date.timeIntervalSince(timerDate) > 0 ? .callout : .subheadline)
+                        .fontWeight(.bold)
+                        .fontDesign(.rounded)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                        .frame(
+                            // If the string is > 6 chars, i.e., exceeds "xd yh", limit width to 80 pts
+                            // This forces the "Replace pod" string to wrap to 2 lines.
+                            maxWidth: remainingTimeString.count > 6 ? 80 : .infinity,
+                            alignment: .leading
+                        )
+                }
+                // aligns the stopwatch icon exactly with the first pixel of the reservoir icon
+                .padding(.leading, date.timeIntervalSince(timerDate) > 0 ? 12 : 0)
                 }
             }
         }

--- a/Trio/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/PumpView.swift
@@ -96,28 +96,28 @@ struct PumpView: View {
                 }
 
                 if let date = expiresAtDate {
-                HStack {
-                    Image(systemName: hourglassIcon)
-                        .font(.callout)
-                        .foregroundStyle(timerColor)
+                    HStack {
+                        Image(systemName: hourglassIcon)
+                            .font(.callout)
+                            .foregroundStyle(timerColor)
 
-                    let remainingTimeString = remainingTimeString(time: date.timeIntervalSince(timerDate))
+                        let remainingTimeString = remainingTimeString(time: date.timeIntervalSince(timerDate))
 
-                    Text(remainingTimeString)
-                        .font(date.timeIntervalSince(timerDate) > 0 ? .callout : .subheadline)
-                        .fontWeight(.bold)
-                        .fontDesign(.rounded)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
-                        .frame(
-                            // If the string is > 6 chars, i.e., exceeds "xd yh", limit width to 80 pts
-                            // This forces the "Replace pod" string to wrap to 2 lines.
-                            maxWidth: remainingTimeString.count > 6 ? 80 : .infinity,
-                            alignment: .leading
-                        )
-                }
-                // aligns the stopwatch icon exactly with the first pixel of the reservoir icon
-                .padding(.leading, date.timeIntervalSince(timerDate) > 0 ? 12 : 0)
+                        Text(remainingTimeString)
+                            .font(date.timeIntervalSince(timerDate) > 0 ? .callout : .subheadline)
+                            .fontWeight(.bold)
+                            .fontDesign(.rounded)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                            .frame(
+                                // If the string is > 6 chars, i.e., exceeds "xd yh", limit width to 80 pts
+                                // This forces the "Replace pod" string to wrap to 2 lines.
+                                maxWidth: remainingTimeString.count > 6 ? 80 : .infinity,
+                                alignment: .leading
+                            )
+                    }
+                    // aligns the stopwatch icon exactly with the first pixel of the reservoir icon
+                    .padding(.leading, date.timeIntervalSince(timerDate) > 0 ? 12 : 0)
                 }
             }
         }

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -177,7 +177,7 @@ extension Home {
                 )
             }
 
-            return rateString + " " + String(localized: " U/hr", comment: "Unit per hour with space") + manualBasalString
+            return rateString + String(localized: " U/hr", comment: "Unit per hour with space") + manualBasalString
         }
 
         var overrideString: String? {


### PR DESCRIPTION
## Summary

Replaces the static `stopwatch.fill` SF Symbol in `HomeRootViews` header element `PumpView` with a dynamic hourglass symbol that changes depending on the remaining time until pod expiration. Addresses #530 .

### Changes

- Introduced a new computed property `hourglassIcon` that selects the appropriate SF Symbol (`hourglass.bottomhalf.filled`, `hourglass`, `hourglass.tophalf.filled`) based on how many hours are left.
- Replaced the use of `stopwatch.fill` with `hourglassIcon` in the `HStack` displaying remaining pod time.
- Preserved styling, alignment, and truncation behavior for the remaining time label.

### Logic for Symbol Selection

| Hours Remaining | SF Symbol String                    | Icon |
|-----------------|------------------------------|----|
| 60–72           | `hourglass.bottomhalf.filled` |  ![hourglass bottomhalf filled](https://github.com/user-attachments/assets/95d52e4d-fda2-4c9e-a79b-0fa7ee863cb5) |
| 12–60           | `hourglass`                  | ![hourglass](https://github.com/user-attachments/assets/68ce82f7-59d8-4757-a8f2-51b564d32a15) |
| 0–12            | `hourglass.tophalf.filled`   | ![hourglass tophalf filled](https://github.com/user-attachments/assets/61eefd5c-def9-44b1-8c7c-0835958bc363) |
| Else            | `hourglass` (fallback)       | ![hourglass](https://github.com/user-attachments/assets/68ce82f7-59d8-4757-a8f2-51b564d32a15) |

Chore: Fix double whitespace in tempBasal view in `HomeRootView`(addresses #536)
