### PR TITLE
Filter out carbs and temp targets for non manual entries

### DIFF
--- a/Trio/Sources/APS/FetchTreatmentsManager.swift
+++ b/Trio/Sources/APS/FetchTreatmentsManager.swift
@@ -35,17 +35,17 @@ final class BaseFetchTreatmentsManager: FetchTreatmentsManager, Injectable {
                         async let carbs = self.nightscoutManager.fetchCarbs()
                         async let tempTargets = self.nightscoutManager.fetchTempTargets()
 
-                        // Filter and store if not from "Trio"
-                        let filteredCarbs = await carbs.filter { $0.enteredBy != CarbsEntry.local }
-                        if filteredCarbs.isNotEmpty {
-                            try await self.carbsStorage.storeCarbs(filteredCarbs, areFetchedFromRemote: true)
+                        // Store carbs directly (no filtering, as it's done in fetchCarbs)
+                        let fetchedCarbs = await carbs
+                        if fetchedCarbs.isNotEmpty {
+                            try await self.carbsStorage.storeCarbs(fetchedCarbs, areFetchedFromRemote: true)
                         }
 
-                        // Filter and store if not from Trio
-                        let filteredTargets = await tempTargets.filter { $0.enteredBy != TempTarget.local }
-                        if filteredTargets.isNotEmpty {
+                        // Store temp targets directly (no filtering, as it's done in fetchTempTargets)
+                        let fetchedTargets = await tempTargets
+                        if fetchedTargets.isNotEmpty {
                             // Sort temp targets by creation date
-                            let sortedTargets = filteredTargets.sorted { $0.createdAt < $1.createdAt }
+                            let sortedTargets = fetchedTargets.sorted { $0.createdAt < $1.createdAt }
 
                             // Iterate and store each temp target
                             for (index, tempTarget) in sortedTargets.enumerated() {


### PR DESCRIPTION
## Summary

This PR addresses [#544](https://github.com/nightscout/Trio/issues/544) by ensuring that Trio ignores Nightscout treatment entries (carbs and temp targets) that originate from other closed loop systems such as iAPS, AndroidAPS, or Loop.

Previously, Trio could inadvertently read and act on entries written by other apps, possibly leading to unsafe automatic insulin dosing.

## Changes

- Introduced a `makeNeQueryItems()` helper in `NightscoutAPI.swift` that builds a safe Nightscout `$and` + `$ne` query to filter out unwanted `enteredBy` sources.
- Replaced ad-hoc filtering in `FetchTreatmentsManager` with filtering done directly at the Nightscout API request level.
- Removed now-unnecessary filtering of carbs and temp targets after fetching.
- Ensured values like `loop://iPhone` are correctly filtered without causing 500 errors from Nightscout (which occurs when such strings are passed in `$nin` arrays).
- Preserved entries with custom or no `enteredBy`, to maintain compatibility with Care Portal usage.

## Filtered `enteredBy` sources

These are excluded from remote treatment imports:
- `NightscoutTreatment.local` (Trio itself)
- `AndroidAPS`
- `openaps://AndroidAPS`
- `iAPS`
- `loop://iPhone`

## Why `$ne` instead of `$nin`?

Nightscout's query validator incorrectly fails when `$nin` contains values like `loop://iPhone`, due to how it sanitizes array elements.

## Testing

- ✅ Verified that `loop://iPhone` and similar values are excluded as expected.
- ✅ Confirmed that no `500` errors occur when the Nightscout query includes complex `enteredBy` strings.
- ✅ Confirmed that entries where enteredBy is empty or contain custom values (from Care Portal) are preserved and stored.
