### PR TITLE
Localize info log message notifications

### DIFF
--- a/Trio/Sources/Logger/Logger.swift
+++ b/Trio/Sources/Logger/Logger.swift
@@ -40,6 +40,29 @@ func info(
     }.perform()
 }
 
+func info(
+    _ category: Logger.Category,
+    _ message: String,
+    notificationText: String,
+    type: MessageType = .info,
+    file: String = #file,
+    function: String = #function,
+    line: UInt = #line
+) {
+    DispatchWorkItem(qos: .background, flags: .enforceQoS) {
+        loggerLock.perform {
+            category.logger.info(
+                message,
+                notificationText: notificationText,
+                type: type,
+                file: file,
+                function: function,
+                line: line
+            )
+        }
+    }.perform()
+}
+
 func warning(
     _ category: Logger.Category,
     _ message: String,
@@ -246,11 +269,22 @@ final class Logger {
         function: String = #function,
         line: UInt = #line
     ) {
+        info(message, notificationText: message, type: type, file: file, function: function, line: line)
+    }
+
+    func info(
+        _ message: String,
+        notificationText: String,
+        type: MessageType = .info,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line
+    ) {
         let printedMessage = "INFO: \(message)"
         os_log("%@ - %@ - %d %{public}@", log: log, type: .info, file.file, function, line, printedMessage)
         reporter.log(category.name, printedMessage, file: file, function: function, line: line)
 
-        showAlert(message, type: type)
+        showAlert(notificationText, type: type)
     }
 
     func warning(

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -335,7 +335,7 @@ extension Home {
                 .map { [weak self] error in
                     self?.errorDate = error == nil ? nil : Date()
                     if let error = error {
-                        info(.default, String(describing: error))
+                        info(.default, String(describing: error), notificationText: error.localizedDescription)
                     }
                     return error?.localizedDescription
                 }


### PR DESCRIPTION
When we switched our logging system to use non localized errors, we inadvertently caused the notifications sent to also not be localized. This PR exposes a new log.info interface that allows callers to set the notificationText explicitly.

This issue was reported on discord by @kskandis 

As a side note: in my testing there were some cases of double notifications from the log.info call invoking a notification, but that is a separate issue. My goal is this PR is to restore the previous functionality, we can take on the question of whether our log.info message should send notifications later.