### PR TITLE
Rename Fatty Meal to Slow Meal

### DIFF
--- a/Trio/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
+++ b/Trio/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
@@ -98,8 +98,8 @@ extension BolusCalculatorConfig {
                     ),
                     units: state.units,
                     type: .conditionalDecimal("fattyMealFactor"),
-                    label: String(localized: "Enable Fatty Meal Option"),
-                    conditionalLabel: String(localized: "Fatty Meal Bolus Percentage"),
+                    label: String(localized: "Enable Slow Meal Option"),
+                    conditionalLabel: String(localized: "Slow Meal Bolus Percentage"),
                     miniHint: String(localized: "Add and set a bolus option for meals that absorb slowly."),
                     verboseHint:
                     VStack(alignment: .leading, spacing: 10) {
@@ -110,10 +110,10 @@ extension BolusCalculatorConfig {
                             "Enabling this setting adds a \"Fatty Meal\" option to the bolus calculator. Once this feature is enabled, a percentage setting will appear for you to select."
                         )
                         Text(
-                            "When \"Fatty Meal\" is selected in the bolus calculator, the recommended bolus will be multiplied by the \"Fatty Meal Bolus Percentage\" as well as the \"Recommended Bolus Percentage\"."
+                            "When \"Fatty Meal\" is selected in the bolus calculator, the recommended bolus will be multiplied by the \"Slow Meal Bolus Percentage\" as well as the \"Recommended Bolus Percentage\"."
                         )
                         Text(
-                            "If you have a \"Recommended Bolus Percentage\" of 80%, and a \"Fatty Meal Bolus Percentage\" of 70%, your recommended bolus will be multiplied by: (80 × 70) / 100 = 56%."
+                            "If you have a \"Recommended Bolus Percentage\" of 80%, and a \"Slow Meal Bolus Percentage\" of 70%, your recommended bolus will be multiplied by: (80 × 70) / 100 = 56%."
                         )
                         Text("This could be useful for slow absorbing meals like pizza.")
                     }

--- a/Trio/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
+++ b/Trio/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
@@ -93,7 +93,7 @@ extension BolusCalculatorConfig {
                         get: { selectedVerboseHint },
                         set: {
                             selectedVerboseHint = $0.map { AnyView($0) }
-                            hintLabel = String(localized: "Fatty Meal")
+                            hintLabel = String(localized: "Slow Meal")
                         }
                     ),
                     units: state.units,
@@ -107,10 +107,10 @@ extension BolusCalculatorConfig {
                         Text("Default Percent: 70%").bold()
                         Text("Do not enable this feature until you have optimized your CR (carb ratio) setting.").bold()
                         Text(
-                            "Enabling this setting adds a \"Fatty Meal\" option to the bolus calculator. Once this feature is enabled, a percentage setting will appear for you to select."
+                            "Enabling this setting adds a \"Slow Meal\" option to the bolus calculator. Once this feature is enabled, a percentage setting will appear for you to select."
                         )
                         Text(
-                            "When \"Fatty Meal\" is selected in the bolus calculator, the recommended bolus will be multiplied by the \"Slow Meal Bolus Percentage\" as well as the \"Recommended Bolus Percentage\"."
+                            "When \"Slow Meal\" is selected in the bolus calculator, the recommended bolus will be multiplied by the \"Slow Meal Bolus Percentage\" as well as the \"Recommended Bolus Percentage\"."
                         )
                         Text(
                             "If you have a \"Recommended Bolus Percentage\" of 80%, and a \"Slow Meal Bolus Percentage\" of 70%, your recommended bolus will be multiplied by: (80 × 70) / 100 = 56%."

--- a/Trio/Sources/Modules/Settings/SettingItems.swift
+++ b/Trio/Sources/Modules/Settings/SettingItems.swift
@@ -181,8 +181,8 @@ enum SettingItems {
             searchContents: [
                 "Display Meal Presets",
                 "Recommended Bolus Percentage",
-                "Enable Fatty Meal Factor",
-                "Fatty Meal Factor",
+                "Enable Slow Meal Factor",
+                "Slow Meal Factor",
                 "Enable Super Bolus",
                 "Super Bolus Factor",
                 "Very Low Glucose Warning"

--- a/Trio/Sources/Modules/Treatments/View/PopupView.swift
+++ b/Trio/Sources/Modules/Treatments/View/PopupView.swift
@@ -588,7 +588,7 @@ struct PopupView: View {
 
     /// Card showing applied factors to the final insulin calculation.
     /// Dynamically changes card based on user's selection in the Treatment view.
-    /// User can choose Fatty Meal, Super Bolus, or neither, but not both.
+    /// User can choose Slow Meal, Super Bolus, or neither, but not both.
     private var factorsCardContent: some View {
         Grid(alignment: .center) {
             // Choose the layout based on which options are selected
@@ -630,7 +630,7 @@ struct PopupView: View {
                 }
                 .unitStyle()
 
-            // Case: Full Bolus × Rec. Bolus % × Fatty Meal %
+            // Case: Full Bolus × Rec. Bolus % × Slow Meal %
             case (false, true):
                 // Row 1: Header.
                 GridRow(alignment: .lastTextBaseline) {
@@ -762,7 +762,7 @@ struct PopupView: View {
                     .unitStyle()
                 }
 
-            // This case should never occur as you can't apply a Super Bolus to a Fatty Meal
+            // This case should never occur as you can't apply a Super Bolus to a Slow Meal
             // Per app logic, these options are mutually exclusive
             case (true, true):
                 Text("")

--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -247,7 +247,7 @@ extension Treatments {
                                 HStack(spacing: 10) {
                                     if state.fattyMeals {
                                         Toggle(isOn: $state.useFattyMealCorrectionFactor) {
-                                            Text("Fatty Meal")
+                                            Text("Slow Meal")
                                         }
                                         .toggleStyle(RadioButtonToggleStyle())
                                         .font(.footnote)

--- a/Trio/Sources/Services/BolusCalculator/BolusCalculationManager.swift
+++ b/Trio/Sources/Services/BolusCalculator/BolusCalculationManager.swift
@@ -415,7 +415,7 @@ final class BaseBolusCalculationManager: BolusCalculationManager, Injectable {
         var factoredInsulin = wholeCalc
         debug(.default, "Initial factored insulin: \(factoredInsulin)")
 
-        // Apply Recommended Bolus Percentage (input.fraction) and if selected apply Fatty Meal Bolus Percentage (input.fattyMealFactor)
+        // Apply Recommended Bolus Percentage (input.fraction) and if selected apply Slow Meal Bolus Percentage (input.fattyMealFactor)
         // If factoredInsulin is negative, though, don't apply either
         if factoredInsulin > 0 {
             factoredInsulin *= input.fraction


### PR DESCRIPTION
Renames "Enable Fatty Meal Option" to "Enable Slow Meal Option" and "Fatty Meal Bolus Percentage" to "Slow Meal Bolus Percentage".

Closes https://github.com/nightscout/Trio/pull/566