### PR TITLE
Update CODEOWNERS: Add @marv-out and remove inactive reviewers/owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @dnzxy @bjornoleh @MikePlante1 @aug0211 @AndreasStokholm @Sjoerd-Bo3 @t1dude @marv-out
+*    @dnzxy @bjornoleh @MikePlante1 @AndreasStokholm @Sjoerd-Bo3 @t1dude @marv-out

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*    @dnzxy @bjornoleh @MikePlante1 @aug0211 @AndreasStokholm @Sjoerd-Bo3 @t1dude
-*.js @dnzxy @bjornoleh @MikePlante1 @aug0211 @AndreasStokholm @Sjoerd-Bo3 @t1dude @jeremystorring
+*    @dnzxy @bjornoleh @MikePlante1 @aug0211 @AndreasStokholm @Sjoerd-Bo3 @t1dude @marv-out


### PR DESCRIPTION
 This PR updates the CODEOWNERS file to reflect current team membership and remove inactive contributors.

  Changes Made

  - Added: @marv-out as a code owner for all files
  - Removed: JavaScript-specific ownership line (previously assigned additional reviewer @jeremystorring for .js files)

  Rationale

  - Updates team membership to include @marv-out who has been actively contributing to the project
  - Removes @jeremystorring from JavaScript file ownership as they are no longer actively contributing
  - Simplifies the review process by having a single ownership rule for all files
