### PR TITLE
fix: Exclude FPU entries from carb statistics calculation

### DIFF
--- a/Model/Helper/CarbEntryStored+helper.swift
+++ b/Model/Helper/CarbEntryStored+helper.swift
@@ -14,7 +14,7 @@ extension NSPredicate {
 
     static var carbsForStats: NSPredicate {
         let date = Date.threeMonthsAgo
-        return NSPredicate(format: "date >= %@", date as NSDate)
+        return NSPredicate(format: "date >= %@ AND isFPU == %@", date as NSDate, false as NSNumber)
     }
 
     static var carbsNotYetUploadedToNightscout: NSPredicate {


### PR DESCRIPTION
## Summary
- Fixes inflated carb counts in meal statistics by excluding FPU (Fat-Protein Unit) entries from calculations

## Description

This PR fixes issue #580 where users with FPU conversion enabled were seeing inflated carbohydrate counts in their meal statistics. The app was counting both actual carbs AND the carb equivalents calculated from fat and protein, effectively double-counting meals.

### Root Cause

When FPU conversion is enabled, Trio creates additional `CarbEntryStored` entries with `isFPU = true` to represent the carbohydrate equivalents from fat and protein. The `carbsForStats` predicate was fetching ALL carb entries without filtering out these FPU entries, causing them to be included in the statistics calculations.

### Solution

Updated the `carbsForStats` predicate to explicitly exclude FPU entries by adding `AND isFPU == false` to the predicate condition. This ensures that only actual carbohydrate entries are counted in the meal statistics.

### Testing

- The fix has been tested to ensure it properly filters out FPU entries
- Meal statistics will now show only actual carbs consumed, not the calculated equivalents
- This change only affects the statistics display and does not impact the actual FPU functionality

Fixes #580

## Screenshots
*Statistics will now show accurate carb counts for low-carb users with FPU conversion enabled*