### PR TITLE
Replace logic for check for backdated carbs

### DIFF
--- a/Trio/Sources/Modules/Treatments/TreatmentsStateModel.swift
+++ b/Trio/Sources/Modules/Treatments/TreatmentsStateModel.swift
@@ -391,8 +391,8 @@ extension Treatments {
                 simulatedCOB = min(maxCobInt16, cobInt16)
             }
 
-            // Check if this is a backdated entry by comparing with the default date
-            let isBackdated = date != defaultDate
+            // Check if this is a backdated entry by comparing with the default date using a tolerance
+            let isBackdated = abs(date.timeIntervalSince(defaultDate)) > 1.0
 
             let result = await bolusCalculationManager.handleBolusCalculation(
                 carbs: carbs,

--- a/Trio/Sources/Modules/Treatments/View/ForecastChart.swift
+++ b/Trio/Sources/Modules/Treatments/View/ForecastChart.swift
@@ -50,9 +50,9 @@ struct ForecastChart: View {
     }
 
     private var forecastChartLabels: some View {
-        // Check if this is a backdated entry by comparing with the default date
-        let isBackdated = state.date != state.defaultDate
-        
+        // Check if this is a backdated entry by comparing with the default date using a tolerance
+        let isBackdated = abs(state.date.timeIntervalSince(state.defaultDate)) > 1.0
+
         // When backdated, display no carbs as this label is only supposed to show current entered carbs
         let displayedCarbs = isBackdated ? 0 : state.carbs
 

--- a/Trio/Sources/Modules/Treatments/View/ForecastChart.swift
+++ b/Trio/Sources/Modules/Treatments/View/ForecastChart.swift
@@ -50,11 +50,9 @@ struct ForecastChart: View {
     }
 
     private var forecastChartLabels: some View {
-        // Check if carbs are actually backdated (more than 15 minutes in the past)
-        // This ensures we only consider it backdated if the user has deliberately changed the date
-        let minutesThreshold = 15.0 // 15 minutes threshold
-        let isBackdated = state.date.timeIntervalSinceNow < -minutesThreshold * 60 && state.simulatedDetermination != nil
-
+        // Check if this is a backdated entry by comparing with the default date
+        let isBackdated = state.date != state.defaultDate
+        
         // When backdated, display no carbs as this label is only supposed to show current entered carbs
         let displayedCarbs = isBackdated ? 0 : state.carbs
 

--- a/Trio/Sources/Modules/Treatments/View/PopupView.swift
+++ b/Trio/Sources/Modules/Treatments/View/PopupView.swift
@@ -312,10 +312,8 @@ struct PopupView: View {
     /// Don't allow total carbs to exceed Max IOB setting.
     /// Formula: (Current COB + New Carbs) / Carb Ratio = COB Correction Dose
     private var cobCardContent: some View {
-        // Check if carbs are actually backdated (more than 15 minutes in the past)
-        // This ensures we only consider it backdated if the user has deliberately changed the date
-        let minutesThreshold = 15.0 // 15 minutes threshold
-        let isBackdated = state.date.timeIntervalSinceNow < -minutesThreshold * 60 && state.simulatedDetermination != nil
+        // Check if this is a backdated entry by comparing with the default date
+        let isBackdated = state.date != state.defaultDate
 
         // Determine COB and carbs to display based on backdating status
         let displayedCOB = isBackdated ? (state.simulatedDetermination?.cob ?? Decimal(state.cob)) : Decimal(state.cob)

--- a/Trio/Sources/Modules/Treatments/View/PopupView.swift
+++ b/Trio/Sources/Modules/Treatments/View/PopupView.swift
@@ -312,8 +312,8 @@ struct PopupView: View {
     /// Don't allow total carbs to exceed Max IOB setting.
     /// Formula: (Current COB + New Carbs) / Carb Ratio = COB Correction Dose
     private var cobCardContent: some View {
-        // Check if this is a backdated entry by comparing with the default date
-        let isBackdated = state.date != state.defaultDate
+        // Check if this is a backdated entry by comparing with the default date using a tolerance
+        let isBackdated = abs(state.date.timeIntervalSince(state.defaultDate)) > 1.0
 
         // Determine COB and carbs to display based on backdating status
         let displayedCOB = isBackdated ? (state.simulatedDetermination?.cob ?? Decimal(state.cob)) : Decimal(state.cob)


### PR DESCRIPTION
This PR replaces the logic for the check for backdated carbs in `PopupView.swift` and `ForecastChart.swift` with the updated logic I've already used in line 395 in `calculateInsulin()` in `TreatmentsStateModel.swift`. I just forgot to use it there as well and the PR was merged before I got the chance to change this. 