### PR TITLE
Automated unit tests on pull and PR as a GitHub action

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,67 @@
+name: zzz [DO NOT RUN] Automated unit tests
+
+on:
+  workflow_dispatch: # TODO: remove this after testing
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
+      - main
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: macos-15
+    if: github.repository_owner == 'nightscout'
+
+    steps:
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Build for testing
+        run: |
+          set -o pipefail && \
+          time xcodebuild build-for-testing \
+            -workspace Trio.xcworkspace \
+            -scheme "Trio Tests" \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
+      - name: Run tests
+        run: |
+          set -o pipefail
+          time xcodebuild test-without-building \
+            -workspace Trio.xcworkspace \
+            -scheme "Trio Tests" \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
+          2>&1 | tee xcodebuild.log
+
+      - name: Annotate test results
+        if: always()
+        run: |
+          if [ -f xcodebuild.log ]; then
+            if grep -q "Failing tests:" xcodebuild.log; then
+              echo "::error title=Unit Tests Failed::Some tests failed"
+              echo "## ❌ Some tests failed:" >> $GITHUB_STEP_SUMMARY
+              grep -A 20 "Failing tests:" xcodebuild.log | \
+                grep -E '^\s+[A-Za-z0-9]+\..+\(\)' | \
+                sed 's/^/  - /' >> $GITHUB_STEP_SUMMARY
+              echo "::group::Failed Test List"
+              grep -A 20 "Failing tests:" xcodebuild.log | \
+                grep -E '^\s+[A-Za-z0-9]+\..+\(\)' | \
+                sed 's/^/  - /'
+              echo "::endgroup::"
+            else
+              echo "::notice title=Unit Tests Passed::✅ All tests passed"
+              echo "✅ All tests passed" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "::warning::Test log (xcodebuild.log) not found"
+          fi

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     name: Run Unit Tests
     runs-on: macos-15
-    if: github.repository_owner == 'nightscout'
+    #if: github.repository_owner == 'nightscout' # TODO: remove comment after testing
 
     steps:
       - name: Select Xcode version


### PR DESCRIPTION
Create unit_tests.yml: Automated unit tests on push and PR to main and dev

- Adds automated unit tests on push and PR to `main` and `dev`.
- Runs Trio Tests, but currently not Watch App tests or LoopKit tests
- Annotates the result and fails on failing tests.
- Before merging it will be changed to only run for repository owner `nightscout` (Todo: revert 97b1c44a25dcd064cf0ad3be6998301bd1e35273)

Attempts to solve https://github.com/nightscout/Trio/issues/529

Tested:

- [x]  Runs on push and PR
- [x] Fails on failing tests
- [x] Emits annotations that indicate that tests failed:
<img src="https://github.com/user-attachments/assets/67eb7847-99dc-465f-bf08-ddfaa16d60b0" width="300">


TODO:

- [ ] Revert 97b1c44a25dcd064cf0ad3be6998301bd1e35273 before merging so that the workflow only runs for repository owner `nightscout`
- [ ] Add conditionals for `Flaky tests`? One or more tests currently typically fail (mostly `BolusCalculatorTests.testHandleBolusCalculationFunction()`)
- [ ] Add  Watch App tests or LoopKit tests?