### PR TITLE
Fix override banner in Live activity

### DIFF
--- a/Trio/Sources/APS/Storage/OverrideStorage.swift
+++ b/Trio/Sources/APS/Storage/OverrideStorage.swift
@@ -172,13 +172,14 @@ final class BaseOverrideStorage: @preconcurrency OverrideStorage, Injectable {
     /// otherwise we would edit the Preset
     @MainActor func copyRunningOverride(_ override: OverrideStored) async -> NSManagedObjectID {
         let newOverride = OverrideStored(context: viewContext)
+        newOverride.id = override.id
         newOverride.duration = override.duration
         newOverride.indefinite = override.indefinite
         newOverride.percentage = override.percentage
         newOverride.smbIsOff = override.smbIsOff
         newOverride.name = override.name
         newOverride.isPreset = false // no Preset
-        newOverride.date = override.date
+        newOverride.date = Date()
         newOverride.enabled = override.enabled
         newOverride.target = override.target
         newOverride.advancedSettings = override.advancedSettings


### PR DESCRIPTION
I've noticed that the LA banner disappears in the following situation: 

- start an Override preset -> banner is there as it is supposed to be
- now edit the running override (not the preset) and save -> banner is gone

Debugging this showed me that we are 

1. missing the ID when we are performing our copy override logic and
2. (the "actual fix) are setting the same date as the copied override. This leads to the fetch only showing the first (now) disabled override that we've copied previously. And because of the fact that its disabled, it isn't shown in the UI. Also updating the date to `Date()` fixes this as this override will now be the latest override.

I really hope that this PR doesn't break anything related to overrides, as this logic is pretty well tested and works. I don't think that this small change will cause any issues, but nevertheless, it needs to be tested thoroughly.