### PR TITLE
Update Table of Identifiers

### DIFF
--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -166,8 +166,8 @@ _Referring to the table below, tap on each **IDENTIFIER** that has a different *
 |:--|:--|:--|
 | Trio | XC org nightscout TEAMID trio | org.nightscout.TEAMID.trio |
 | Trio LiveActivity | - | org.nightscout.TEAMID.trio.LiveActivity |
-| Trio Watch | XC IDENTIFIER | org.nightscout.TEAMID.trio.watchkitapp |
-| Trio WatchKit Extension | XC IDENTIFIER | org.nightscout.TEAMID.trio.watchkitapp.watchkitextension |
+| Trio Watch App | XC IDENTIFIER | org.nightscout.TEAMID.trio.watchkitapp |
+| Trio Watch Complication | XC IDENTIFIER | org.nightscout.TEAMID.trio.watchkitapp.TrioWatchComplication |
 
 ## Add App Group to Bundle Identifiers
 


### PR DESCRIPTION
Inspired by https://github.com/nightscout/trio-docs/pull/175

This update matches what's seen in Xcode in Project Navigator > Trio > Signing & Capabilities > (clicking through each Target) > Bundle Identifier, as well as in [Fastfile](https://github.com/nightscout/Trio/blob/dev/fastlane/Fastfile)