### PR TITLE
Fix for Data race and build adaptations for iOS 26

### DIFF
--- a/Trio/Resources/InfoPlist.xcstrings
+++ b/Trio/Resources/InfoPlist.xcstrings
@@ -457,6 +457,18 @@
         }
       }
     },
+    "NSCalendarsFullAccessUsageDescription" : {
+      "comment" : "Privacy - Calendars Full Access Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay"
+          }
+        }
+      }
+    },
     "NSCalendarsUsageDescription" : {
       "comment" : "Privacy - Calendars Usage Description",
       "extractionState" : "extracted_with_value",

--- a/Trio/Sources/Application/AppState.swift
+++ b/Trio/Sources/Application/AppState.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Observation
-import SwiftUICore
+import SwiftUI
 import UIKit
 
 @Observable class AppState {

--- a/Trio/Sources/Helpers/MainChartHelper.swift
+++ b/Trio/Sources/Helpers/MainChartHelper.swift
@@ -1,7 +1,7 @@
 import Charts
 import CoreData
 import Foundation
-import SwiftUICore
+import SwiftUI
 
 enum MainChartHelper {
     // Calculates the glucose value thats the nearest to parameter 'time'

--- a/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+Overrides.swift
+++ b/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+Overrides.swift
@@ -1,7 +1,7 @@
 import Combine
 import CoreData
 import Foundation
-import SwiftUICore
+import SwiftUI
 
 extension Adjustments.StateModel {
     // MARK: - Enact Overrides

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/SelectionPopoverView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/SelectionPopoverView.swift
@@ -1,6 +1,6 @@
 import Charts
 import Foundation
-import SwiftUICore
+import SwiftUI
 
 struct SelectionPopoverView: ChartContent {
     let selectedGlucose: GlucoseStored


### PR DESCRIPTION
This pull request addresses a data race issue in the `fetchForecastHierarchy()` function within the BaseDeterminationStorage class. Additionally, it swaps the SwiftUICore library with SwiftUI in some files. This popped up as build errors when I tried to build on a iOS26 simulator and this shouldn't destroy anything. So I changed it as well. Building on a iOS 18 device still works. The other changes were automatic changes made by xcode.