### PR TITLE
Fix Overrides being ended after 2 days

### DIFF
--- a/Model/Helper/OverrideStored+helper.swift
+++ b/Model/Helper/OverrideStored+helper.swift
@@ -7,10 +7,12 @@ extension NSPredicate {
     }
 
     static var lastActiveOverride: NSPredicate {
-        let date = Date.oneDayAgo
-        return NSPredicate(
-            format: "date >= %@ AND enabled == %@",
-            date as NSDate,
+        // For non-indefinite overrides, we still want to filter by date
+        // For indefinite overrides, we want them regardless of date
+        NSPredicate(
+            format: "(date >= %@ OR indefinite == %@) AND enabled == %@",
+            Date.oneDayAgo as NSDate,
+            true as NSNumber,
             true as NSNumber
         )
     }


### PR DESCRIPTION
Currently, it seems that indefinite Overrides are ended after >24h as described in #621. This PR aims at fixing this behaviour by editing the NSPredicate that we are using to fetch th latest active Override to exclude the date check for indefinite overrides and instead check for the `indefinite` property. 