### PR TITLE
Fix missing live activity determination

### DIFF
--- a/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
@@ -89,6 +89,7 @@ final class LiveActivityManager: Injectable, ObservableObject, SettingsObserver 
         registerHandler()
         monitorForLiveActivityAuthorizationChanges()
         setupGlucoseArray()
+        setupDetermination()
         broadcaster.register(SettingsObserver.self, observer: self)
     }
 
@@ -257,6 +258,12 @@ final class LiveActivityManager: Injectable, ObservableObject, SettingsObserver 
             } catch {
                 debug(.default, "\(DebuggingIdentifiers.failed) failed to fetch glucose with error: \(error)")
             }
+        }
+    }
+
+    private func setupDetermination() {
+        Task { @MainActor in
+            self.determination = try await fetchAndMapDetermination()
         }
     }
 

--- a/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
@@ -286,9 +286,7 @@ final class LiveActivityManager: Injectable, ObservableObject, SettingsObserver 
     /// Otherwise, it ends the current live activity.
     @MainActor private func forceActivityUpdate() {
         if settings.useLiveActivity {
-            if currentActivity?.needsRecreation() ?? true {
-                glucoseDidUpdate(glucoseFromPersistence ?? [])
-            }
+            glucoseDidUpdate(glucoseFromPersistence ?? [])
         } else {
             Task {
                 await self.endActivity()
@@ -319,13 +317,8 @@ final class LiveActivityManager: Injectable, ObservableObject, SettingsObserver 
                 await endActivity()
                 // After endActivity(), currentActivity is guaranteed to be nil
                 // No recursive task, but explicitly restart
-                if self.currentActivity == nil {
-                    debug(.default, "[LiveActivityManager] Re-pushing update after recreation.")
-                    await pushUpdate(state)
-                } else {
-                    debug(.default, "[LiveActivityManager] Warning: currentActivity was not nil after endActivity!")
-                }
-                return
+                debug(.default, "[LiveActivityManager] Re-pushing update after recreation.")
+                await pushUpdate(state)
             } else {
                 let content = ActivityContent(
                     state: state,
@@ -396,11 +389,6 @@ final class LiveActivityManager: Injectable, ObservableObject, SettingsObserver 
             self.currentActivity = nil
         }
 
-        for activity in Activity<LiveActivityAttributes>.activities {
-            debug(.default, "Ending lingering activity: \(activity.id)")
-            await activity.end(nil, dismissalPolicy: .immediate)
-        }
-
         for unknownActivity in Activity<LiveActivityAttributes>.activities {
             debug(.default, "Ending unknown activity: \(unknownActivity.id)")
             await unknownActivity.end(nil, dismissalPolicy: .immediate)
@@ -414,27 +402,6 @@ final class LiveActivityManager: Injectable, ObservableObject, SettingsObserver 
     /// This method mimics xdrip's `restartActivityFromLiveActivityIntent()` behavior by verifying that a valid content state exists,
     /// ending the current live activity, and starting a new one using the current state.
     @MainActor func restartActivityFromLiveActivityIntent() async {
-        guard let latestGlucose = latestGlucose,
-              let determination = determination
-        else {
-            debug(.default, "Cannot restart live activity because required persistent state is not available. Fetching data...")
-            return
-        }
-
-        guard let contentState = LiveActivityAttributes.ContentState(
-            new: latestGlucose,
-            prev: latestGlucose,
-            units: settings.units,
-            chart: glucoseFromPersistence ?? [],
-            settings: settings,
-            determination: determination,
-            override: override,
-            widgetItems: widgetItems
-        ) else {
-            debug(.default, "Cannot restart live activity because content state cannot be created")
-            return
-        }
-
         await endActivity()
 
         while (currentActivity != nil && currentActivity!.activity.activityState != .ended) || Activity<LiveActivityAttributes>
@@ -448,9 +415,8 @@ final class LiveActivityManager: Injectable, ObservableObject, SettingsObserver 
         debug(.default, "Waiting additional time for iOS to clean up...")
         try? await Task.sleep(nanoseconds: 1_000_000_000) // 1s additional delay
 
-        Task { @MainActor in
-            await self.pushUpdate(contentState)
-        }
+        forceActivityUpdate()
+
         debug(.default, "Restarted Live Activity from LiveActivityIntent (via iOS Shortcut)")
     }
 }


### PR DESCRIPTION
Fixes #630. Explanation of this fix:

> The culprit seems to be that no `determination` is set when `LiveActivityManager` is created when the app starts. Without a determination, [no live activity will be created](https://github.com/nightscout/Trio/blob/3dac85256016a93708ceba175932367c0e0c4109/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift#L478). Trio _tries_ to create the LA while the app is still active, but due to the missing determination, it doesn't have all the information available to be able to actually create a live activity (see previous link). A `determination` only eventually becomes available in `LiveActivityManager` when the first loop happens ([`cobOrIobDidUpdate`](https://github.com/nightscout/Trio/blob/3dac85256016a93708ceba175932367c0e0c4109/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift#L160)). If the app is already in the background, it's too late to create a live activity.
>
> Fix for that is to load an initial value for determination to make sure that a LA can be created when the app is still in active.

The fix is fully contained in the first commit. The second commit just does various cleanups and is strictly seen not necessary to fix #630. But I figured I do these cleanups while I was going through the Live Activity code.