### PR TITLE
Don't reset CAGE for non-fixed prime events

### DIFF
--- a/Trio/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/Trio/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -176,7 +176,8 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
                     newPumpEvent.isUploadedToHealth = false
                     newPumpEvent.isUploadedToTidepool = false
 
-                case .prime:
+                case .replaceComponent(componentType: .infusionSet),
+                     .replaceComponent(componentType: .pump):
                     guard existingEvents.isEmpty else {
                         // Duplicate found, do not store the event
                         debug(.coreData, "Duplicate event found with timestamp: \(event.date)")


### PR DESCRIPTION
This changes the event trigger for resetting CAGE from `.prime` to `.replaceComponent(componentType: X)` where `X` can be `.infusionSet` (used by MinimedKit) or `.pump` (used by OmniBLE and OmniKit).

Marked as Draft, because DanaKit does not yet implemented `.replaceComponent(componentType: .infusionSet)` events