### PR TITLE
Change .nsSiteChange trigger to .replaceComponent(...) instead of .prime

### DIFF
--- a/Model/Helper/PumpEvent+helper.swift
+++ b/Model/Helper/PumpEvent+helper.swift
@@ -58,6 +58,7 @@ public extension PumpEventStored {
         case rewind = "Rewind"
         case prime = "Prime"
         case journalCarbs = "JournalEntryMealMarker"
+        case siteChange = "SiteChange"
 
         case nsNote = "Note"
         case nsTempBasal = "Temp Basal"

--- a/Trio/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/Trio/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -205,6 +205,21 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
                     newPumpEvent.isUploadedToTidepool = false
                     newPumpEvent.note = event.title
 
+                case .replaceComponent(componentType: .infusionSet),
+                     .replaceComponent(componentType: .pump):
+                    guard existingEvents.isEmpty else {
+                        // Duplicate found, do not store the event
+                        debug(.coreData, "Duplicate event found with timestamp: \(event.date)")
+                        continue
+                    }
+                    let newPumpEvent = PumpEventStored(context: self.context)
+                    newPumpEvent.id = UUID().uuidString
+                    newPumpEvent.timestamp = event.date
+                    newPumpEvent.type = PumpEvent.siteChange.rawValue
+                    newPumpEvent.isUploadedToNS = false
+                    newPumpEvent.isUploadedToHealth = false
+                    newPumpEvent.isUploadedToTidepool = false
+
                 default:
                     continue
                 }
@@ -418,7 +433,7 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
                         targetTop: nil,
                         targetBottom: nil
                     )
-                case PumpEvent.prime.rawValue:
+                case PumpEvent.siteChange.rawValue:
                     return NightscoutTreatment(
                         duration: nil,
                         rawDuration: nil,

--- a/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
+++ b/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
@@ -582,10 +582,6 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
         } catch {
             debug(.nightscout, String(describing: error))
         }
-
-        Task.detached {
-            await self.uploadPodAge()
-        }
     }
 
     private func updateOrefDeterminationAsUploaded(_ determination: [Determination]) async {
@@ -607,33 +603,6 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
                     "\(DebuggingIdentifiers.failed) \(#file) \(#function) Failed to update isUploadedToNS: \(error.userInfo)"
                 )
             }
-        }
-    }
-
-    func uploadPodAge() async {
-        let uploadedPodAge = storage.retrieve(OpenAPS.Nightscout.uploadedPodAge, as: [NightscoutTreatment].self) ?? []
-        if let podAge = storage.retrieve(OpenAPS.Monitor.podAge, as: Date.self),
-           uploadedPodAge.last?.createdAt == nil || podAge != uploadedPodAge.last!.createdAt!
-        {
-            let siteTreatment = NightscoutTreatment(
-                duration: nil,
-                rawDuration: nil,
-                rawRate: nil,
-                absolute: nil,
-                rate: nil,
-                eventType: .nsSiteChange,
-                createdAt: podAge,
-                enteredBy: NightscoutTreatment.local,
-                bolus: nil,
-                insulin: nil,
-                notes: nil,
-                carbs: nil,
-                fat: nil,
-                protein: nil,
-                targetTop: nil,
-                targetBottom: nil
-            )
-            await uploadNonCoreDataTreatments([siteTreatment])
         }
     }
 


### PR DESCRIPTION
This addresses #677 by changing the trigger to upload a .nsSiteChange event to Nightscout from .prime to .replaceComponent(.infusionSet or .pump)

Before this PR, rewinding a Medtronic pump and doing a non-fixed prime to fill the tubing would upload a .nsSiteChange event to Nightscout even if the cannula was not primed with a fixed prime.

After this PR, only a fixed prime will trigger uploading a .nsSiteChange event to Nightscout, as a fixed prime is required for a cannula change with Medtronic but a non-fixed prime is not required.

Omnipod DASH and Eros will also trigger uploading a .nsSiteChange event to Nightscout when a new pod is started and primed in Trio.

~~This PR is marked as draft because DanaKit does not yet create .replaceComponent(.infusionSet) events, though https://github.com/bastiaanv/DanaKit/pull/11 should address that.~~