### PR TITLE
Disable flaky tests

### DIFF
--- a/TrioTests/BolusCalculatorTests/BolusCalculatorTests.swift
+++ b/TrioTests/BolusCalculatorTests/BolusCalculatorTests.swift
@@ -662,7 +662,10 @@ import Testing
         }
     }
 
-    @Test("Calculate insulin with backdated carbs") func testHandleBolusCalculationFunction() async throws {
+    @Test(
+        "Calculate insulin with backdated carbs",
+        .enabled(if: false, "Flaky test, disabled while investigating")
+    ) func testHandleBolusCalculationFunction() async throws {
         // STEP 1: Setup test scenario
         let currentDate = Date()
         let backdatedCarbsDate = currentDate.addingTimeInterval(-120 * 60) // 2 hours ago

--- a/TrioTests/CoreDataTests/GlucoseStorageTests.swift
+++ b/TrioTests/CoreDataTests/GlucoseStorageTests.swift
@@ -131,7 +131,10 @@ import Testing
         #expect(entry.eventType == .capillaryGlucose, "Type should be capillaryGlucose")
     }
 
-    @Test("Test glucose alarms") func testGlucoseAlarms() async throws {
+    @Test(
+        "Test glucose alarms",
+        .enabled(if: false, "Flaky test, disabled while investigating")
+    ) func testGlucoseAlarms() async throws {
         // Given
         let lowGlucose = [
             BloodGlucose(direction: BloodGlucose.Direction.flat, date: 123, dateString: Date(), glucose: 55)


### PR DESCRIPTION
This PR simply disables two of the unit tests that fail intermittently. I disabled them so that people can investigate and fix these and then re-enable them when they can run reliably. These failures disrupt both development flows and our automation via GitHub actions.

Our unit testing setup might benefit from some maintenance, but this PR is to ensure that we can run the tests we know work consistently.