### PR TITLE
fix: Statistics summary timezone alignment for negative UTC users

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -449,6 +449,7 @@
 		C29E268A2DADFD2A00F87E75 /* GlucoseDailyPercentileChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29E26892DADFD2A00F87E75 /* GlucoseDailyPercentileChart.swift */; };
 		C2A0A42F2CE03131003B98E8 /* ConstantValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A0A42E2CE0312C003B98E8 /* ConstantValues.swift */; };
 		C2A6D1E42DB1581D0036DB66 /* GlucoseStatsSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A6D1E32DB1581D0036DB66 /* GlucoseStatsSetup.swift */; };
+		C2AA6D9C2E1AAC6300BF6C16 /* TDDStorageTimezoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AA6D9B2E1AAC6300BF6C16 /* TDDStorageTimezoneTests.swift */; };
 		C967DACD3B1E638F8B43BE06 /* ManualTempBasalStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCFE0781F9074C2917890E8 /* ManualTempBasalStateModel.swift */; };
 		CA370FC152BC98B3D1832968 /* BasalProfileEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF8BCB0C37DEB5EC377B9612 /* BasalProfileEditorRootView.swift */; };
 		CC6C406E2ACDD69E009B8058 /* RawFetchedProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6C406D2ACDD69E009B8058 /* RawFetchedProfile.swift */; };
@@ -1269,6 +1270,7 @@
 		C29E26892DADFD2A00F87E75 /* GlucoseDailyPercentileChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseDailyPercentileChart.swift; sourceTree = "<group>"; };
 		C2A0A42E2CE0312C003B98E8 /* ConstantValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantValues.swift; sourceTree = "<group>"; };
 		C2A6D1E32DB1581D0036DB66 /* GlucoseStatsSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseStatsSetup.swift; sourceTree = "<group>"; };
+		C2AA6D9B2E1AAC6300BF6C16 /* TDDStorageTimezoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TDDStorageTimezoneTests.swift; sourceTree = "<group>"; };
 		C377490C77661D75E8C50649 /* ManualTempBasalRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalRootView.swift; sourceTree = "<group>"; };
 		C8D1A7CA8C10C4403D4BBFA7 /* TreatmentsDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TreatmentsDataFlow.swift; sourceTree = "<group>"; };
 		CC6C406D2ACDD69E009B8058 /* RawFetchedProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawFetchedProfile.swift; sourceTree = "<group>"; };
@@ -2578,6 +2580,7 @@
 		38FCF3EE25E9028E0078B0D1 /* TrioTests */ = {
 			isa = PBXGroup;
 			children = (
+				C2AA6D9B2E1AAC6300BF6C16 /* TDDStorageTimezoneTests.swift */,
 				DDC6CA6C2DD90A2A0060EE25 /* LocalizationTests.swift */,
 				3B997DD22DC02AEF006B6BB2 /* JSONImporterData */,
 				BD8FC05C2D6618BE00B95AED /* BolusCalculatorTests */,
@@ -4667,6 +4670,7 @@
 				BD8FC0622D6619E600B95AED /* OverrideStorageTests.swift in Sources */,
 				BD8FC0592D66189700B95AED /* TestAssembly.swift in Sources */,
 				DDC6CA6D2DD90A2A0060EE25 /* LocalizationTests.swift in Sources */,
+				C2AA6D9C2E1AAC6300BF6C16 /* TDDStorageTimezoneTests.swift in Sources */,
 				3B997DCF2DC00A3A006B6BB2 /* JSONImporterTests.swift in Sources */,
 				BD8FC0662D661A0000B95AED /* GlucoseStorageTests.swift in Sources */,
 				BD8FC05B2D6618AF00B95AED /* DeterminationStorageTests.swift in Sources */,

--- a/Trio/Sources/APS/Storage/TDDStorage.swift
+++ b/Trio/Sources/APS/Storage/TDDStorage.swift
@@ -361,11 +361,14 @@ final class BaseTDDStorage: TDDStorage, Injectable {
         gaps.reserveCapacity(sortedEvents.count + 1)
 
         // Use first event's date for calendar operations
-        let startOfDay = Calendar.current.startOfDay(for: sortedEvents.first!.timestamp)
-        let endOfDay = startOfDay.addingTimeInterval(24 * 60 * 60 - 1)
+        guard let firstEvent = sortedEvents.first else {
+            return []
+        }
+        let startOfDay = Calendar.current.startOfDay(for: firstEvent.timestamp)
+        let endOfDay = startOfDay.addingTimeInterval(TimeInterval.hours(24)) - 1
 
         // Process events in a single pass
-        var lastEndTime = sortedEvents.first!.timestamp
+        var lastEndTime = firstEvent.timestamp
 
         for i in 0 ..< sortedEvents.count {
             let event = sortedEvents[i]

--- a/Trio/Sources/Modules/Stat/StatStateModel+Setup/BolusStatsSetup.swift
+++ b/Trio/Sources/Modules/Stat/StatStateModel+Setup/BolusStatsSetup.swift
@@ -224,8 +224,13 @@ extension Stat.StateModel {
         to endDate: Date
     ) -> (manual: Double, smb: Double, external: Double) {
         // Filter cached values to only include those within the date range
+        // Use the same day boundary logic as the chart
+        let calendar = Calendar.current
+        let alignedStartDate = calendar.startOfDay(for: startDate)
+        let alignedEndDate = calendar.startOfDay(for: endDate)
+        
         let relevantStats = bolusAveragesCache.filter { date, _ in
-            date >= startDate && date <= endDate
+            date >= alignedStartDate && date <= alignedEndDate
         }
 
         // Return zeros if no data exists for the range
@@ -252,8 +257,13 @@ extension Stat.StateModel {
         to endDate: Date
     ) -> Double {
         // Filter cached values to only include those within the date range
+        // Use the same day boundary logic as the chart
+        let calendar = Calendar.current
+        let alignedStartDate = calendar.startOfDay(for: startDate)
+        let alignedEndDate = calendar.startOfDay(for: endDate)
+        
         let relevantStats = bolusAveragesCache.filter { date, _ in
-            date >= startDate && date <= endDate
+            date >= alignedStartDate && date <= alignedEndDate
         }
 
         // Return zeros if no data exists for the range

--- a/Trio/Sources/Modules/Stat/StatStateModel+Setup/MealStatsSetup.swift
+++ b/Trio/Sources/Modules/Stat/StatStateModel+Setup/MealStatsSetup.swift
@@ -147,7 +147,8 @@ extension Stat.StateModel {
     /// - Parameter range: A tuple containing the start and end dates to get averages for
     /// - Returns: A tuple containing the average carbs, fat and protein values for the date range
     func getCachedMealAverages(for range: (start: Date, end: Date)) -> (carbs: Double, fat: Double, protein: Double) {
-        return calculateAveragesForDateRange(from: range.start, to: range.end)
+        let result = calculateAveragesForDateRange(from: range.start, to: range.end)
+        return result
     }
 
     /// Calculates the average macronutrient values for a given date range
@@ -157,12 +158,19 @@ extension Stat.StateModel {
     /// - Returns: A tuple containing the average carbs, fat and protein values for the date range
     func calculateAveragesForDateRange(from startDate: Date, to endDate: Date) -> (carbs: Double, fat: Double, protein: Double) {
         // Filter cached values to only include those within the date range
+        // Use the same day boundary logic as the chart
+        let calendar = Calendar.current
+        let alignedStartDate = calendar.startOfDay(for: startDate)
+        let alignedEndDate = calendar.startOfDay(for: endDate)
+        
         let relevantStats = dailyAveragesCache.filter { date, _ in
-            date >= startDate && date <= endDate
+            date >= alignedStartDate && date <= alignedEndDate
         }
 
         // Return zeros if no data exists for the range
-        guard !relevantStats.isEmpty else { return (0, 0, 0) }
+        guard !relevantStats.isEmpty else { 
+            return (0, 0, 0) 
+        }
 
         // Calculate total macronutrients across all days
         let total = relevantStats.values.reduce((0.0, 0.0, 0.0)) { acc, avg in

--- a/Trio/Sources/Modules/Stat/StatStateModel+Setup/TDDSetup.swift
+++ b/Trio/Sources/Modules/Stat/StatStateModel+Setup/TDDSetup.swift
@@ -541,8 +541,13 @@ extension Stat.StateModel {
     /// - Returns: The average TDD in units for the specified date range. Returns 0.0 if no data exists.
     private func calculateTDDAveragesForDateRange(from startDate: Date, to endDate: Date) -> Double {
         // Filter cached TDD values to only include those within the date range
+        // Use the same day boundary logic as the chart
+        let calendar = Calendar.current
+        let alignedStartDate = calendar.startOfDay(for: startDate)
+        let alignedEndDate = calendar.startOfDay(for: endDate)
+        
         let relevantStats = tddAveragesCache.filter { date, _ in
-            date >= startDate && date <= endDate
+            date >= alignedStartDate && date <= alignedEndDate
         }
 
         // Return 0 if no data exists for the specified range

--- a/Trio/Sources/Modules/Stat/View/StatChartUtils.swift
+++ b/Trio/Sources/Modules/Stat/View/StatChartUtils.swift
@@ -31,21 +31,19 @@ struct StatChartUtils {
             let end = scrollPosition.addingTimeInterval(visibleDomainLength(for: selectedInterval) - 1)
             return (scrollPosition, end)
         } else {
-            // For week and longer intervals, we need smart alignment
-            // Find the nearest day boundary
+            // For week and longer intervals, align to day boundaries consistently with meal data grouping
+            // Use the same logic as meal data grouping: calendar.startOfDay()
             let startOfDay = calendar.startOfDay(for: scrollPosition)
-            let components = calendar.dateComponents([.hour, .minute, .second], from: scrollPosition)
-            let totalSeconds = Double(components.hour ?? 0) * 3600 + Double(components.minute ?? 0) * 60 +
-                Double(components.second ?? 0)
-
-            // Align start end to midnight
-            let alignedStart = totalSeconds > 12 * 3600 ?
-                calendar.date(byAdding: .day, value: 1, to: startOfDay)! : startOfDay
             let intervalLength = visibleDomainLength(for: selectedInterval)
-            let end = alignedStart.addingTimeInterval(intervalLength + (2 * 3600))
-            let alignedEnd = calendar.startOfDay(for: end).addingTimeInterval(-1)
+            
+            // Calculate end date by adding the interval length and aligning to day boundary
+            let endDate = startOfDay.addingTimeInterval(intervalLength)
+            let endOfDay = calendar.startOfDay(for: endDate)
+            
+            // Ensure we include the full end day by going to the end of that day
+            let alignedEnd = calendar.date(byAdding: .day, value: 1, to: endOfDay)!.addingTimeInterval(-1)
 
-            return (alignedStart, alignedEnd)
+            return (startOfDay, alignedEnd)
         }
     }
 

--- a/Trio/Sources/Modules/Stat/View/StatChartUtils.swift
+++ b/Trio/Sources/Modules/Stat/View/StatChartUtils.swift
@@ -35,13 +35,13 @@ struct StatChartUtils {
             // Use the same logic as meal data grouping: calendar.startOfDay()
             let startOfDay = calendar.startOfDay(for: scrollPosition)
             let intervalLength = visibleDomainLength(for: selectedInterval)
-            
+
             // Calculate end date by adding the interval length and aligning to day boundary
             let endDate = startOfDay.addingTimeInterval(intervalLength)
             let endOfDay = calendar.startOfDay(for: endDate)
-            
+
             // Ensure we include the full end day by going to the end of that day
-            let alignedEnd = calendar.date(byAdding: .day, value: 1, to: endOfDay)!.addingTimeInterval(-1)
+            let alignedEnd = (calendar.date(byAdding: .day, value: 1, to: endOfDay) ?? endOfDay).addingTimeInterval(-1)
 
             return (startOfDay, alignedEnd)
         }

--- a/TrioTests/TDDStorageTimezoneTests.swift
+++ b/TrioTests/TDDStorageTimezoneTests.swift
@@ -1,0 +1,193 @@
+import CoreData
+import Foundation
+import Swinject
+import Testing
+
+@testable import Trio
+
+@Suite("TDD Storage Timezone Tests", .serialized) struct TDDStorageTimezoneTests {
+    var coreDataStack: CoreDataStack!
+    var context: NSManagedObjectContext!
+
+    init() async throws {
+        // In-memory Core Data for tests
+        coreDataStack = try await CoreDataStack.createForTests()
+        context = coreDataStack.newTaskContext()
+    }
+
+    @Test("Kingst's concern: -1 logic doesn't drop days across all UTC offsets") func testMinusOneLogicAcrossAllTimezones() {
+        // Test the full spectrum of UTC offsets from -12 to +14
+        let testTimezones = [
+            // Negative offsets (west of UTC)
+            "Pacific/Midway", // UTC-11
+            "Pacific/Honolulu", // UTC-10
+            "America/Anchorage", // UTC-9/-8
+            "America/Los_Angeles", // UTC-8/-7
+            "America/Denver", // UTC-7/-6
+            "America/Chicago", // UTC-6/-5
+            "America/New_York", // UTC-5/-4
+            "America/Halifax", // UTC-4/-3
+            "America/Sao_Paulo", // UTC-3
+
+            // Near UTC
+            "Atlantic/Azores", // UTC-1/0
+            "UTC", // UTC+0
+            "Europe/London", // UTC+0/+1
+
+            // Positive offsets (east of UTC)
+            "Europe/Paris", // UTC+1/+2
+            "Europe/Athens", // UTC+2/+3
+            "Europe/Moscow", // UTC+3
+            "Asia/Dubai", // UTC+4
+            "Asia/Karachi", // UTC+5
+            "Asia/Kolkata", // UTC+5:30 (half-hour offset!)
+            "Asia/Dhaka", // UTC+6
+            "Asia/Bangkok", // UTC+7
+            "Asia/Shanghai", // UTC+8
+            "Asia/Tokyo", // UTC+9
+            "Australia/Sydney", // UTC+10/+11
+            "Pacific/Noumea", // UTC+11
+            "Pacific/Auckland", // UTC+12/+13
+            "Pacific/Kiritimati" // UTC+14
+        ]
+
+        for timezoneName in testTimezones {
+            guard let timezone = TimeZone(identifier: timezoneName) else {
+                Issue.record("Could not create timezone: \(timezoneName)")
+                continue
+            }
+
+            let calendar = Calendar.current
+
+            // Test edge case: late evening that crosses midnight in UTC
+            var components = DateComponents()
+            components.year = 2024
+            components.month = 1
+            components.day = 15
+            components.hour = 23 // 11 PM local time
+            components.minute = 30
+            components.timeZone = timezone
+
+            guard let testDate = calendar.date(from: components) else { continue }
+
+            // Apply our TDDStorage logic: startOfDay + 24 hours - 1
+            let startOfDay = calendar.startOfDay(for: testDate)
+            let endOfDay = startOfDay.addingTimeInterval(TimeInterval.hours(24)) - 1
+
+            // Extract day components to verify no day is dropped
+            let startDayComponents = calendar.dateComponents([.day], from: startOfDay)
+            let endDayComponents = calendar.dateComponents([.day], from: endOfDay)
+
+            // Kingst's main concern: verify the -1 doesn't cause day to be dropped
+            #expect(
+                startDayComponents.day == endDayComponents.day,
+                "The -1 second adjustment should NOT drop a day in \(timezoneName) (UTC\(timezone.secondsFromGMT() >= 0 ? "+" : "")\(timezone.secondsFromGMT() / 3600))"
+            )
+
+            // Verify we get exactly 23:59:59
+            let timeComponents = calendar.dateComponents([.hour, .minute, .second], from: endOfDay)
+            #expect(
+                timeComponents.hour == 23 && timeComponents.minute == 59 && timeComponents.second == 59,
+                "End of day should be 23:59:59 in \(timezoneName)"
+            )
+        }
+    }
+
+    @Test("Forced unwrap safety: empty events don't crash") func testEmptyEventsHandling() {
+        let emptyEvents: [PumpHistoryEvent] = []
+        let sortedEvents = emptyEvents.sorted { $0.timestamp < $1.timestamp }
+
+        // Our guard statement should handle this gracefully
+        guard let firstEvent = sortedEvents.first else {
+            // This is the expected path - no crash!
+            #expect(true, "Empty events handled without forced unwrap crash")
+            return
+        }
+
+        Issue.record("Should not reach here with empty events")
+    }
+
+    @Test("DST transitions maintain 24-hour calculations") func testDSTTransitions() {
+        // Test the specific edge case of DST transitions
+        let timezone = TimeZone(identifier: "America/New_York")!
+        let calendar = Calendar.current
+
+        // Spring forward: March 10, 2024 (lose an hour)
+        var springComponents = DateComponents()
+        springComponents.year = 2024
+        springComponents.month = 3
+        springComponents.day = 10
+        springComponents.hour = 12
+        springComponents.timeZone = timezone
+
+        if let springDate = calendar.date(from: springComponents) {
+            let startOfDay = calendar.startOfDay(for: springDate)
+            let endOfDay = startOfDay.addingTimeInterval(TimeInterval.hours(24)) - 1
+
+            let startDay = calendar.component(.day, from: startOfDay)
+            let endDay = calendar.component(.day, from: endOfDay)
+
+            #expect(
+                startDay == endDay,
+                "DST spring forward should not affect day boundaries"
+            )
+        }
+
+        // Fall back: November 3, 2024 (gain an hour)
+        var fallComponents = DateComponents()
+        fallComponents.year = 2024
+        fallComponents.month = 11
+        fallComponents.day = 3
+        fallComponents.hour = 12
+        fallComponents.timeZone = timezone
+
+        if let fallDate = calendar.date(from: fallComponents) {
+            let startOfDay = calendar.startOfDay(for: fallDate)
+            let endOfDay = startOfDay.addingTimeInterval(TimeInterval.hours(24)) - 1
+
+            let startDay = calendar.component(.day, from: startOfDay)
+            let endDay = calendar.component(.day, from: endOfDay)
+
+            #expect(
+                startDay == endDay,
+                "DST fall back should not affect day boundaries"
+            )
+        }
+    }
+
+    @Test("Multiple consecutive days maintain correct boundaries") func testConsecutiveDayBoundaries() {
+        // Verify the algorithm works correctly over multiple days
+        let timezone = TimeZone(identifier: "Pacific/Honolulu")! // UTC-10, no DST
+        let calendar = Calendar.current
+
+        for dayOffset in 0 ..< 3 {
+            var components = DateComponents()
+            components.year = 2024
+            components.month = 1
+            components.day = 15 + dayOffset
+            components.hour = 14
+            components.timeZone = timezone
+
+            guard let testDate = calendar.date(from: components) else { continue }
+
+            let startOfDay = calendar.startOfDay(for: testDate)
+            let endOfDay = startOfDay.addingTimeInterval(TimeInterval.hours(24)) - 1
+
+            let startDayComponents = calendar.dateComponents([.year, .month, .day], from: startOfDay)
+            let endDayComponents = calendar.dateComponents([.year, .month, .day], from: endOfDay)
+            let expectedDayComponents = calendar.dateComponents([.year, .month, .day], from: testDate)
+
+            #expect(
+                startDayComponents.day == endDayComponents.day,
+                "Start and end should be on the same day for offset \(dayOffset)"
+            )
+            
+            #expect(
+                startDayComponents.day == expectedDayComponents.day && 
+                startDayComponents.month == expectedDayComponents.month &&
+                startDayComponents.year == expectedDayComponents.year,
+                "Day boundaries should match the test date (offset \(dayOffset))"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixed timezone boundary alignment causing 0g carbs in summary while chart showed 75g
- Extended fix to all statistics types (Meal, TDD, Bolus) with same issue
- Ensures consistent day boundary calculations between chart display and summary data

## Description
This PR resolves issue #687 where users (particularly in negative UTC timezones like UTC-7) experienced discrepancies between statistics chart data and summary calculations. The main symptom was charts correctly showing 75g of carbs while the summary displayed 0g.

### Root Cause
The issue stemmed from inconsistent date boundary calculations:
- **Chart data**: Used complex timezone alignment logic in `StatChartUtils.visibleDateRange()`
- **Summary data**: Used simple `calendar.startOfDay()` grouping during data collection
- **Filter logic**: Used direct date comparison without day boundary alignment

This created misaligned date ranges that failed to match cached data, especially problematic for users in negative UTC offsets.

### Solution
Standardized all date boundary logic to use consistent `calendar.startOfDay()` approach:

1. **Simplified chart date range calculation** - Removed complex time-based alignment
2. **Fixed summary filtering** - Added day boundary alignment before filtering cached data  
3. **Applied to all statistics** - Extended fix to Meal, TDD, and Bolus statistics

## Test plan
- [x] Verify meal summary matches chart data for carbs
- [x] Test with negative UTC timezone scenarios (UTC-7)
- [x] Confirm TDD and Bolus summaries also display correctly
- [x] Check regional formatting changes don't affect results
- [x] Validate fix works across different time intervals (day/week/month)

Fixes #687