### PR TITLE
fix: statistics summaries not calculating on initial view load

### DIFF
--- a/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/BolusStatsView.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/BolusStatsView.swift
@@ -121,7 +121,10 @@ struct BolusStatsView: View {
         }
         .onAppear {
             scrollPosition = StatChartUtils.getInitialScrollPosition(for: selectedInterval)
-            updateCalculatedValues()
+            // Delay the initial update to ensure scroll position has been processed
+            DispatchQueue.main.async {
+                updateCalculatedValues()
+            }
         }
         .onChange(of: scrollPosition) {
             updateTimer.scheduleUpdate {
@@ -131,7 +134,10 @@ struct BolusStatsView: View {
         .onChange(of: selectedInterval) {
             Task {
                 scrollPosition = StatChartUtils.getInitialScrollPosition(for: selectedInterval)
-                updateCalculatedValues()
+                // Use async dispatch to ensure scroll position is updated before calculating values
+                await MainActor.run {
+                    updateCalculatedValues()
+                }
             }
         }
     }

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/TotalDailyDoseChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/TotalDailyDoseChart.swift
@@ -75,8 +75,11 @@ struct TotalDailyDoseChart: View {
         }
         .onAppear {
             scrollPosition = StatChartUtils.getInitialScrollPosition(for: selectedInterval)
-            updateAverages()
-            updateTotalDoses()
+            // Delay the initial update to ensure scroll position has been processed
+            DispatchQueue.main.async {
+                updateAverages()
+                updateTotalDoses()
+            }
         }
         .onChange(of: scrollPosition) {
             updateTimer.scheduleUpdate {
@@ -89,9 +92,12 @@ struct TotalDailyDoseChart: View {
         .onChange(of: selectedInterval) {
             Task {
                 scrollPosition = StatChartUtils.getInitialScrollPosition(for: selectedInterval)
-                updateAverages()
-                if selectedInterval == .day {
-                    updateTotalDoses()
+                // Use async dispatch to ensure scroll position is updated before calculating averages
+                await MainActor.run {
+                    updateAverages()
+                    if selectedInterval == .day {
+                        updateTotalDoses()
+                    }
                 }
             }
         }

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Meal/MealStatsView.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Meal/MealStatsView.swift
@@ -100,7 +100,10 @@ struct MealStatsView: View {
         }
         .onAppear {
             scrollPosition = StatChartUtils.getInitialScrollPosition(for: selectedInterval)
-            updateAverages()
+            // Delay the initial update to ensure scroll position has been processed
+            DispatchQueue.main.async {
+                updateAverages()
+            }
         }
         .onChange(of: scrollPosition) {
             updateTimer.scheduleUpdate {
@@ -110,7 +113,10 @@ struct MealStatsView: View {
         .onChange(of: selectedInterval) {
             Task {
                 scrollPosition = StatChartUtils.getInitialScrollPosition(for: selectedInterval)
-                updateAverages()
+                // Use async dispatch to ensure scroll position is updated before calculating averages
+                await MainActor.run {
+                    updateAverages()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes timing issue where statistics summaries show 0 values on initial view load
- Defers summary calculations with DispatchQueue.main.async in onAppear
- Uses MainActor.run for onChange(selectedInterval) to ensure proper sequencing

## Test plan
- [x] Open Statistics tab
- [x] Verify summaries show correct values immediately (not 0)
- [x] Change time intervals and verify summaries update correctly
- [x] Test on Meal, TDD, and Bolus statistics views

Related to #687 - this addresses the secondary timing issue discovered during testing.