### PR TITLE
Fixes a race condition between share client and BLE for G6 CGMs

### DIFF
--- a/Trio/Resources/InfoPlist.xcstrings
+++ b/Trio/Resources/InfoPlist.xcstrings
@@ -457,18 +457,6 @@
         }
       }
     },
-    "NSCalendarsFullAccessUsageDescription" : {
-      "comment" : "Privacy - Calendars Full Access Usage Description",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay"
-          }
-        }
-      }
-    },
     "NSCalendarsUsageDescription" : {
       "comment" : "Privacy - Calendars Usage Description",
       "extractionState" : "extracted_with_value",

--- a/Trio/Sources/APS/CGM/PluginSource.swift
+++ b/Trio/Sources/APS/CGM/PluginSource.swift
@@ -60,8 +60,14 @@ final class PluginSource: GlucoseSource {
             guard let self = self else { return }
             self.processQueue.async {
                 guard let cgmManager = self.cgmManager else { return }
-                cgmManager.fetchNewDataIfNeeded { result in
-                    promise(self.readCGMResult(readingResult: result))
+                cgmManager.fetchNewDataIfNeeded { _ in
+                    // Ignore values returned from fetchNewDataIfNeeded since
+                    // these come from share client and cause a race condition
+                    // that causes the promise to complete before a CGM value
+                    // has a chance to return. From looking at the code this should
+                    // only impact G6 since that is the only CGM manager that will
+                    // return data and only if share credentials are set
+                    promise(.success([]))
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a race condition in PluginSource when using a G6 CGM and share client credentials are set. For more details, please see this issue: https://github.com/nightscout/Trio/issues/608

This fix simply ignores share client values to avoid the race condition. I confirmed that none of the other plugin CGMs add CGM readings using the `fetchDataIfNeeded` code path, so this will only impact G6.

This is a simple one-line fix for the problem, but the downside is that we won't get backfilled CGM values from share client any longer. To retain this capability we will need to do a major refactor of this whole bit of functionality, which is beyond the scope of this simple fix.