### PR TITLE
fix: Prevent stats chart labels from moving off-screen

### DIFF
--- a/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/BolusStatsView.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/BolusStatsView.swift
@@ -321,29 +321,32 @@ private struct BolusSelectionPopover: View {
     }
 
     private func xOffset() -> CGFloat {
+        // If the selected date is outside the visible domain, hide the popover
+        guard selectedDate >= domain.start && selectedDate <= domain.end else { return 0 }
+        
         let domainDuration = domain.end.timeIntervalSince(domain.start)
         guard domainDuration > 0, chartWidth > 0 else { return 0 }
 
         let popoverWidth = popoverSize.width
+        let padding: CGFloat = 10 // Padding from screen edges
 
-        // Convert dates to pixel'd x-condition
+        // Convert dates to pixel'd x-position
         let dateFraction = selectedDate.timeIntervalSince(domain.start) / domainDuration
         let x_selected = dateFraction * chartWidth
 
-        // TODO: this is semi hacky, can this be improved?
-        let x_left = x_selected - (popoverWidth / 2) // Left edge of popover
-        let x_right = x_selected + (popoverWidth / 2) // Right edge of popover
+        // Calculate popover edges
+        let x_left = x_selected - (popoverWidth / 2)
+        let x_right = x_selected + (popoverWidth / 2)
 
-        var offset: CGFloat = 0 // Default = no shift
+        var offset: CGFloat = 0
 
-        // Push popover to right if its left edge is (nearing) out-of-bounds
-        if x_left < 0 {
-            offset = abs(x_left) // push to right
-        }
-
-        // Push popover to left if its right edge is (nearing) out-of-bounds)
-        if x_right > chartWidth {
-            offset = -(x_right - chartWidth) // push to left
+        // Ensure the popover stays within screen bounds
+        if x_left < padding {
+            // Popover would extend past left edge, shift it right
+            offset = padding - x_left
+        } else if x_right > chartWidth - padding {
+            // Popover would extend past right edge, shift it left
+            offset = (chartWidth - padding) - x_right
         }
 
         return offset
@@ -407,5 +410,7 @@ private struct BolusSelectionPopover: View {
         )
         // Apply calculated xOffset to keep within bounds
         .offset(x: xOffset(), y: 0)
+        // Hide popover if selected date is outside visible domain
+        .opacity(selectedDate >= domain.start && selectedDate <= domain.end ? 1 : 0)
     }
 }

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/TotalDailyDoseChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/TotalDailyDoseChart.swift
@@ -276,29 +276,32 @@ private struct TDDSelectionPopover: View {
     }
 
     private func xOffset() -> CGFloat {
+        // If the selected date is outside the visible domain, hide the popover
+        guard selectedDate >= domain.start && selectedDate <= domain.end else { return 0 }
+
         let domainDuration = domain.end.timeIntervalSince(domain.start)
         guard domainDuration > 0, chartWidth > 0 else { return 0 }
 
         let popoverWidth = popoverSize.width
+        let padding: CGFloat = 10 // Padding from screen edges
 
-        // Convert dates to pixel'd x-condition
+        // Convert dates to pixel'd x-position
         let dateFraction = selectedDate.timeIntervalSince(domain.start) / domainDuration
         let x_selected = dateFraction * chartWidth
 
-        // TODO: this is semi hacky, can this be improved?
-        let x_left = x_selected - (popoverWidth / 2) // Left edge of popover
-        let x_right = x_selected + (popoverWidth / 2) // Right edge of popover
+        // Calculate popover edges
+        let x_left = x_selected - (popoverWidth / 2)
+        let x_right = x_selected + (popoverWidth / 2)
 
-        var offset: CGFloat = 0 // Default = no shift
+        var offset: CGFloat = 0
 
-        // Push popover to right if its left edge is (nearing) out-of-bounds
-        if x_left < 0 {
-            offset = abs(x_left) // push to right
-        }
-
-        // Push popover to left if its right edge is (nearing) out-of-bounds)
-        if x_right > chartWidth {
-            offset = -(x_right - chartWidth) // push to left
+        // Ensure the popover stays within screen bounds
+        if x_left < padding {
+            // Popover would extend past left edge, shift it right
+            offset = padding - x_left
+        } else if x_right > chartWidth - padding {
+            // Popover would extend past right edge, shift it left
+            offset = (chartWidth - padding) - x_right
         }
 
         return offset
@@ -339,5 +342,7 @@ private struct TDDSelectionPopover: View {
         )
         // Apply calculated xOffset to keep within bounds
         .offset(x: xOffset(), y: 0)
+        // Hide popover if selected date is outside visible domain
+        .opacity(selectedDate >= domain.start && selectedDate <= domain.end ? 1 : 0)
     }
 }

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Meal/MealStatsView.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Meal/MealStatsView.swift
@@ -312,29 +312,32 @@ private struct MealSelectionPopover: View {
     }
 
     private func xOffset() -> CGFloat {
+        // If the selected date is outside the visible domain, hide the popover
+        guard selectedDate >= domain.start && selectedDate <= domain.end else { return 0 }
+
         let domainDuration = domain.end.timeIntervalSince(domain.start)
         guard domainDuration > 0, chartWidth > 0 else { return 0 }
 
         let popoverWidth = popoverSize.width
+        let padding: CGFloat = 10 // Padding from screen edges
 
-        // Convert dates to pixel'd x-condition
+        // Convert dates to pixel'd x-position
         let dateFraction = selectedDate.timeIntervalSince(domain.start) / domainDuration
         let x_selected = dateFraction * chartWidth
 
-        // TODO: this is semi hacky, can this be improved?
-        let x_left = x_selected - (popoverWidth / 2) // Left edge of popover
-        let x_right = x_selected + (popoverWidth / 2) // Right edge of popover
+        // Calculate popover edges
+        let x_left = x_selected - (popoverWidth / 2)
+        let x_right = x_selected + (popoverWidth / 2)
 
-        var offset: CGFloat = 0 // Default = no shift
+        var offset: CGFloat = 0
 
-        // Push popover to right if its left edge is (nearing) out-of-bounds
-        if x_left < 0 {
-            offset = abs(x_left) // push to right
-        }
-
-        // Push popover to left if its right edge is (nearing) out-of-bounds)
-        if x_right > chartWidth {
-            offset = -(x_right - chartWidth) // push to left
+        // Ensure the popover stays within screen bounds
+        if x_left < padding {
+            // Popover would extend past left edge, shift it right
+            offset = padding - x_left
+        } else if x_right > chartWidth - padding {
+            // Popover would extend past right edge, shift it left
+            offset = (chartWidth - padding) - x_right
         }
 
         return offset
@@ -397,5 +400,7 @@ private struct MealSelectionPopover: View {
         )
         // Apply calculated xOffset to keep within bounds
         .offset(x: xOffset(), y: 0)
+        // Hide popover if selected date is outside visible domain
+        .opacity(selectedDate >= domain.start && selectedDate <= domain.end ? 1 : 0)
     }
 }


### PR DESCRIPTION
## Summary
- Fixes chart label positioning issue where popover would slide off-screen during scroll/pan interactions
- Adds boundary checking and visibility detection for chart annotations
- Resolves #538

## Problem
When users interact with stats charts (scrolling or panning), the value labels would:
- Slide beyond screen edges becoming partially or fully invisible
- Continue to render even when the selected data point was outside the visible chart domain
- Create a confusing user experience where labels appeared disconnected from the data

## Solution
Implemented comprehensive boundary checking:
- Added padding-aware position calculations to keep labels within screen bounds
- Implemented visibility detection to hide labels when data points are outside the visible domain
- Applied consistent positioning logic across all three affected chart types (Meal, TDD, Bolus)

## Test plan
- [ ] Open Stats view and navigate to meal/insulin tabs
- [ ] Interact with charts by scrolling/panning
- [ ] Verify labels stay within screen bounds at all zoom levels
- [ ] Verify labels disappear when their data points are scrolled out of view
- [ ] Test on different device sizes (iPhone SE, Pro Max)
- [ ] Verify no regression in label accuracy or chart functionality