### PR TITLE
fix: Handle nil IDs in CarbsEntry.convertSyncCarb to prevent Tidepool upload crashes

### DIFF
--- a/Trio/Sources/Models/CarbsEntry.swift
+++ b/Trio/Sources/Models/CarbsEntry.swift
@@ -42,13 +42,22 @@ extension CarbsEntry {
 
 extension CarbsEntry {
     func convertSyncCarb(operation: LoopKit.Operation = .create) -> SyncCarbObject {
+        // Generate a new UUID if id is nil to prevent crash
+        let safeUUID: UUID
+        if let id = id, let uuid = UUID(uuidString: id) {
+            safeUUID = uuid
+        } else {
+            safeUUID = UUID()
+            debug(.service, "Warning: CarbsEntry has nil or invalid ID, generating new UUID for Tidepool sync")
+        }
+
         SyncCarbObject(
             absorptionTime: nil,
             createdByCurrentApp: true,
             foodType: nil,
             grams: Double(carbs),
             startDate: createdAt,
-            uuid: UUID(uuidString: id!),
+            uuid: safeUUID,
             provenanceIdentifier: enteredBy ?? "Trio",
             syncIdentifier: id,
             syncVersion: nil,


### PR DESCRIPTION
## Summary
- Fix crash in Tidepool carb upload when CarbsEntry has nil ID
- Replace force unwrapping with safe UUID generation
- Add debug logging for tracking when fallback UUIDs are used
- Resolves #656

## Problem
The app crashes during background carbohydrate data uploads to Tidepool when `CarbsEntry.convertSyncCarb()` force-unwraps a nil `id` value:
- `CarbsStorage.getCarbsNotYetUploadedToTidepool()` can return entries with `id: nil`
- `convertSyncCarb()` calls `UUID(uuidString: id\!)` which crashes on nil
- Occurs specifically in `BaseTidepoolManager.uploadCarbs()` during background sync

## Solution
- Replace `UUID(uuidString: id\!)` with safe UUID handling
- Generate new UUID when original ID is nil or invalid
- Add debug logging to track fallback UUID generation
- Maintain backward compatibility while preventing crashes

## Test plan
- [x] Build compiles without errors
- [x] No compilation warnings or diagnostics
- [ ] Test with actual carb entries that have nil IDs
- [ ] Verify Tidepool sync continues working after fix
- [ ] Test background sync operations don't crash