### PR TITLE
fix: Remove redundant backgroundContext.perform calls in ContactImageManager

### DIFF
--- a/Trio/Sources/Services/ContactImage/ContactImageManager.swift
+++ b/Trio/Sources/Services/ContactImage/ContactImageManager.swift
@@ -98,13 +98,12 @@ final class BaseContactImageManager: NSObject, ContactImageManager, Injectable {
             fetchLimit: 1
         )
 
-        return try await backgroundContext.perform {
-            guard let fetchedResults = results as? [OrefDetermination] else {
-                throw CoreDataError.fetchError(function: #function, file: #file)
-            }
-
-            return fetchedResults.map(\.objectID)
+        // The results are already processed on the background context, no need for another perform block
+        guard let fetchedResults = results as? [OrefDetermination] else {
+            throw CoreDataError.fetchError(function: #function, file: #file)
         }
+
+        return fetchedResults.map(\.objectID)
     }
 
     private func fetchGlucose() async throws -> [NSManagedObjectID] {
@@ -117,13 +116,12 @@ final class BaseContactImageManager: NSObject, ContactImageManager, Injectable {
             fetchLimit: 3 /// We only need 1-3 values, depending on whether the user wants to show delta or not
         )
 
-        return try await backgroundContext.perform {
-            guard let glucoseResults = results as? [GlucoseStored] else {
-                throw CoreDataError.fetchError(function: #function, file: #file)
-            }
-
-            return glucoseResults.map(\.objectID)
+        // The results are already processed on the background context, no need for another perform block
+        guard let glucoseResults = results as? [GlucoseStored] else {
+            throw CoreDataError.fetchError(function: #function, file: #file)
         }
+
+        return glucoseResults.map(\.objectID)
     }
 
     private func getCurrentGlucoseTarget() async -> Decimal? {


### PR DESCRIPTION
## Summary
- Fixes ContactImageManager crash in issue #655 by removing redundant Core Data context operations
- Eliminates memory access violations in BaseContactImageManager.fetchlastDetermination() at line 101

## Problem
The crash was caused by redundant context operations where `fetchEntitiesAsync()` already processes results on the background context, but the code was calling `backgroundContext.perform` again, leading to potential context invalidation issues.

## Solution
- Removed unnecessary `backgroundContext.perform` blocks in `fetchlastDetermination()`
- Removed unnecessary `backgroundContext.perform` blocks in `fetchGlucose()`
- Simplified the code while maintaining proper error handling

## Test plan
- [x] Build successfully without compilation errors
- [ ] Verify ContactImageManager functions work without crashes
- [ ] Test contact image updates don't cause memory access violations

## Note
This PR addresses the ContactImageManager crash from issue #655. The Charts rendering crash mentioned in the same issue will be addressed in a separate PR.