### PR TITLE
Decoupling IoB from determine basal

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -252,6 +252,8 @@
 		3BAAE60C2DE7766C0049589B /* DynamicISFEnableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAAE60B2DE776630049589B /* DynamicISFEnableTests.swift */; };
 		3BAD36B22D7CDC1A00CC298D /* MainLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD36B12D7CDC1400CC298D /* MainLoadingView.swift */; };
 		3BAD36CC2D7D420E00CC298D /* CoreDataInitializationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAD36CB2D7D420500CC298D /* CoreDataInitializationCoordinator.swift */; };
+		3BC4927F2E258B510051EE87 /* IobResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC4927D2E258B510051EE87 /* IobResult.swift */; };
+		3BC492812E258B860051EE87 /* IobSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC492802E258B860051EE87 /* IobSetup.swift */; };
 		3BCA5F7C2DC7B16400A7EAC7 /* pumphistory-with-external.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BCA5F7B2DC7B15400A7EAC7 /* pumphistory-with-external.json */; };
 		3BD6CE262DC24CFD00FA0472 /* pumphistory-24h-zoned.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BD6CE252DC24CFD00FA0472 /* pumphistory-24h-zoned.json */; };
 		3BD9687C2D8DDD4600899469 /* SlideButton in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD9687B2D8DDD4600899469 /* SlideButton */; };
@@ -1070,6 +1072,8 @@
 		3BAAE60B2DE776630049589B /* DynamicISFEnableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicISFEnableTests.swift; sourceTree = "<group>"; };
 		3BAD36B12D7CDC1400CC298D /* MainLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainLoadingView.swift; sourceTree = "<group>"; };
 		3BAD36CB2D7D420500CC298D /* CoreDataInitializationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataInitializationCoordinator.swift; sourceTree = "<group>"; };
+		3BC4927D2E258B510051EE87 /* IobResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IobResult.swift; sourceTree = "<group>"; };
+		3BC492802E258B860051EE87 /* IobSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IobSetup.swift; sourceTree = "<group>"; };
 		3BCA5F7B2DC7B15400A7EAC7 /* pumphistory-with-external.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pumphistory-with-external.json"; sourceTree = "<group>"; };
 		3BD6CE252DC24CFD00FA0472 /* pumphistory-24h-zoned.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "pumphistory-24h-zoned.json"; sourceTree = "<group>"; };
 		3BDEA2DC60EDE0A3CA54DC73 /* TargetsEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorProvider.swift; sourceTree = "<group>"; };
@@ -2144,6 +2148,7 @@
 				38192E06261BA9960094D973 /* FetchTreatmentsManager.swift */,
 				3856933F270B57A00002C50D /* CGM */,
 				38A504F625DDA0E200C5B9E8 /* Extensions */,
+				3BC4927E2E258B510051EE87 /* Models */,
 				388E5A5825B6F0070019842D /* OpenAPS */,
 				38A0362725ECF05300FCBB52 /* Storage */,
 			);
@@ -2607,6 +2612,14 @@
 			path = JSONImporterData;
 			sourceTree = "<group>";
 		};
+		3BC4927E2E258B510051EE87 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				3BC4927D2E258B510051EE87 /* IobResult.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		4E8C7B59F8065047ECE20965 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -2682,18 +2695,19 @@
 		58645B972CA2D16A008AFCE7 /* HomeStateModel+Setup */ = {
 			isa = PBXGroup;
 			children = (
-				3B2F77872D7E5387005ED9FA /* CurrentTDDSetup.swift */,
-				BD4E1A7B2D3686D400D21626 /* StartEndMarkerSetup.swift */,
-				BD4E1A792D3681AD00D21626 /* GlucoseTargetSetup.swift */,
-				BDA6CC872CAF219800F942F9 /* TempTargetSetup.swift */,
-				58645B982CA2D1A4008AFCE7 /* GlucoseSetup.swift */,
-				58645B9A2CA2D24F008AFCE7 /* CarbSetup.swift */,
-				58645B9C2CA2D275008AFCE7 /* DeterminationSetup.swift */,
-				58645B9E2CA2D2BE008AFCE7 /* PumpHistorySetup.swift */,
-				58645BA02CA2D2F8008AFCE7 /* OverrideSetup.swift */,
 				58645BA22CA2D325008AFCE7 /* BatterySetup.swift */,
-				58645BA42CA2D347008AFCE7 /* ForecastSetup.swift */,
+				58645B9A2CA2D24F008AFCE7 /* CarbSetup.swift */,
 				58645BA62CA2D390008AFCE7 /* ChartAxisSetup.swift */,
+				3B2F77872D7E5387005ED9FA /* CurrentTDDSetup.swift */,
+				58645B9C2CA2D275008AFCE7 /* DeterminationSetup.swift */,
+				58645BA42CA2D347008AFCE7 /* ForecastSetup.swift */,
+				58645B982CA2D1A4008AFCE7 /* GlucoseSetup.swift */,
+				BD4E1A792D3681AD00D21626 /* GlucoseTargetSetup.swift */,
+				3BC492802E258B860051EE87 /* IobSetup.swift */,
+				58645BA02CA2D2F8008AFCE7 /* OverrideSetup.swift */,
+				58645B9E2CA2D2BE008AFCE7 /* PumpHistorySetup.swift */,
+				BD4E1A7B2D3686D400D21626 /* StartEndMarkerSetup.swift */,
+				BDA6CC872CAF219800F942F9 /* TempTargetSetup.swift */,
 			);
 			path = "HomeStateModel+Setup";
 			sourceTree = "<group>";
@@ -4105,6 +4119,7 @@
 				BD47FDD92D8B657D0043966B /* InsulinSensitivityStepView.swift in Sources */,
 				3862CC2E2743F9F700BF832C /* CalendarManager.swift in Sources */,
 				CEA4F62329BE10F70011ADF7 /* SavitzkyGolayFilter.swift in Sources */,
+				3BC492812E258B860051EE87 /* IobSetup.swift in Sources */,
 				38B4F3C325E2A20B00E76A18 /* PumpSetupView.swift in Sources */,
 				38E4453C274E411700EC9A94 /* Disk+Codable.swift in Sources */,
 				58D08B322C8DF88900AA37D3 /* DummyCharts.swift in Sources */,
@@ -4554,6 +4569,7 @@
 				BF1667ADE69E4B5B111CECAE /* ManualTempBasalProvider.swift in Sources */,
 				583684062BD178DB00070A60 /* GlucoseStored+helper.swift in Sources */,
 				49B9B57F2D5768D2009C6B59 /* AdjustmentStored+Helper.swift in Sources */,
+				3BC4927F2E258B510051EE87 /* IobResult.swift in Sources */,
 				F90692D6274B9A450037068D /* HealthKitStateModel.swift in Sources */,
 				BD1661312B82ADAB00256551 /* CustomProgressView.swift in Sources */,
 				C967DACD3B1E638F8B43BE06 /* ManualTempBasalStateModel.swift in Sources */,

--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -30,6 +30,7 @@ protocol APSManager {
     func roundBolus(amount: Decimal) -> Decimal
     var lastError: CurrentValueSubject<Error?, Never> { get }
     func cancelBolus(_ callback: ((Bool, String) -> Void)?) async
+    func iobForDisplay(at: Date) async throws -> Decimal?
 }
 
 enum APSError: LocalizedError {
@@ -413,6 +414,11 @@ final class BaseAPSManager: APSManager, Injectable {
 
         // Store TDD in Core Data
         await tddStorage.storeTDD(tddResult)
+    }
+
+    /// Calculate the iob at a given time using oref
+    func iobForDisplay(at: Date) async throws -> Decimal? {
+        try await openAPS.iobForDisplay(clock: at)
     }
 
     func determineBasal() async throws {

--- a/Trio/Sources/APS/Models/IobResult.swift
+++ b/Trio/Sources/APS/Models/IobResult.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A model to represent IoB results returned from the oref `iob` call via JSON
+struct IobResult: Codable {
+    let iob: Decimal
+    let activity: Decimal
+    let basaliob: Decimal
+    let bolusiob: Decimal
+    let netbasalinsulin: Decimal
+    let bolusinsulin: Decimal
+    let time: Date
+    let iobWithZeroTemp: IobWithZeroTemp
+    var lastBolusTime: UInt64?
+    var lastTemp: LastTemp?
+
+    struct IobWithZeroTemp: Codable {
+        let iob: Decimal
+        let activity: Decimal
+        let basaliob: Decimal
+        let bolusiob: Decimal
+        let netbasalinsulin: Decimal
+        let bolusinsulin: Decimal
+        let time: Date
+    }
+
+    struct LastTemp: Codable {
+        let rate: Decimal?
+        let timestamp: Date?
+        let started_at: Date?
+        let date: UInt64
+        let duration: Decimal?
+    }
+}

--- a/Trio/Sources/Modules/Home/HomeStateModel+Setup/IobSetup.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel+Setup/IobSetup.swift
@@ -1,0 +1,62 @@
+import Foundation
+import UIKit
+
+extension Home.StateModel {
+    /// Fetch the most recent IoB value using the oref `iob` function. Call this function any time
+    /// you want to update the displayed IoB, like on the arrival of a new pump event or at initialization
+    func setupIobForDisplay() {
+        Task {
+            do {
+                let at = Date()
+                guard let iob = try await apsManager.iobForDisplay(at: at) else {
+                    debug(.default, "Could not get iob for display (oref returned nil)")
+                    // if more than 15 minutes have gone by since the last IoB update
+                    // set it to nil
+                    let lastRun = iobForDisplayUpdatedAt ?? .distantPast
+                    if at.timeIntervalSince(lastRun) > (15 * 60) {
+                        await updateIobForDisplay(iob: nil, at: at)
+                    }
+                    return
+                }
+                await updateIobForDisplay(iob: iob, at: at)
+            } catch {
+                debug(
+                    .default,
+                    "\(DebuggingIdentifiers.failed) Error setting up iob for display \(error)"
+                )
+            }
+        }
+    }
+
+    /// Update IoB periodically. This function will update the displayed IoB in response
+    /// to timer events. Internally, it has logic to reduce the frequency of updates as it is
+    /// designed to capture typical decay from elapsed time. If there is something that
+    /// changes IoB, like a new pump event, use `setupIobForDisplay` instead.
+    /// Also, only update IoB when the app is in the foreground.
+    func setupIobForDisplayOnTimer() {
+        guard UIApplication.shared.applicationState == .active else {
+            return
+        }
+        Task {
+            let lastRun = iobForDisplayUpdatedAt ?? .distantPast
+            // if we don't have an iob value re-run it more often
+            let period = iobForDisplay == nil ? TimeInterval(1 * 60) : TimeInterval(5 * 60)
+            if Date().timeIntervalSince(lastRun) > period {
+                setupIobForDisplay()
+            }
+        }
+    }
+
+    /// Update the IoB state values. There is a small amount of logic to try to deal with
+    /// updated values that happen concurrently by using the most recent results
+    @MainActor func updateIobForDisplay(iob: Decimal?, at: Date) {
+        // in case we get two calls at around the same time
+        // make sure to only use the most recent result
+        // unless the iobForDisplay isn't set and we have a result
+        let lastRun = iobForDisplayUpdatedAt ?? .distantPast
+        if at > lastRun || (iob != nil && iobForDisplay == nil) {
+            iobForDisplay = iob
+            iobForDisplayUpdatedAt = at
+        }
+    }
+}

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -106,6 +106,8 @@ extension Home {
         var listOfCGM: [CGMModel] = []
         var cgmCurrent = cgmDefaultModel
         var shouldRunDeleteOnSettingsChange = true
+        var iobForDisplay: Decimal?
+        var iobForDisplayUpdatedAt: Date?
 
         var showCarbsRequiredBadge: Bool = true
         private(set) var setupPumpType: PumpConfig.PumpType = .minimed
@@ -215,6 +217,9 @@ extension Home {
                     group.addTask {
                         self.setupTempTargetsRunStored()
                     }
+                    group.addTask {
+                        self.setupIobForDisplay()
+                    }
                 }
             }
         }
@@ -265,6 +270,7 @@ extension Home {
                 self.setupLastBolus()
                 self.displayPumpStatusHighlightMessage()
                 self.displayPumpStatusBadge()
+                self.setupIobForDisplay()
             }.store(in: &subscriptions)
 
             coreDataPublisher?.filteredByEntityName("OpenAPS_Battery").sink { [weak self] _ in
@@ -306,6 +312,7 @@ extension Home {
             timer.eventHandler = {
                 DispatchQueue.main.async { [weak self] in
                     self?.timerDate = Date()
+                    self?.setupIobForDisplayOnTimer()
                 }
             }
             timer.resume()

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -431,8 +431,8 @@ extension Home {
                         .foregroundColor(Color.insulin)
                     Text(
                         (
-                            Formatter.decimalFormatterWithTwoFractionDigits
-                                .string(from: (state.enactedAndNonEnactedDeterminations.first?.iob ?? 0) as NSNumber) ?? "0"
+                            state.iobForDisplay.flatMap({ Formatter.decimalFormatterWithTwoFractionDigits
+                                    .string(from: $0 as NSNumber) }) ?? "??"
                         ) +
                             String(localized: " U", comment: "Insulin unit")
                     )

--- a/Trio/Sources/Modules/Treatments/TreatmentsStateModel.swift
+++ b/Trio/Sources/Modules/Treatments/TreatmentsStateModel.swift
@@ -910,7 +910,9 @@ extension Treatments.StateModel {
             target = (mostRecentDetermination.currentTarget ?? currentBGTarget as NSDecimalNumber) as Decimal
             isf = (mostRecentDetermination.insulinSensitivity ?? currentISF as NSDecimalNumber) as Decimal
             cob = mostRecentDetermination.cob as Int16
-            iob = (mostRecentDetermination.iob ?? 0) as Decimal
+            // We use the IoB from determination as a backup in case the iob calc fails
+            let determinationIob = (mostRecentDetermination.iob ?? 0) as Decimal
+            iob = (try? await apsManager.iobForDisplay(at: Date())) ?? determinationIob
             basal = (mostRecentDetermination.tempBasal ?? 0) as Decimal
             carbRatio = (mostRecentDetermination.carbRatio ?? currentCarbRatio as NSDecimalNumber) as Decimal
             insulinCalculated = await calculateInsulin()


### PR DESCRIPTION
This PR fixes a regression that happened after this [PR](https://github.com/nightscout/Trio/pull/590) landed and it is the case again where people who are stuck at 400 mg/dl will not get updates to their IoB. This lack of updates can be problematic since people will dose while they are at 400 manually and they need to know their IoB to do this safely.

The approach is to decouple the display of IoB values from determine basil. IoB will update if (1) there is a new pump event (2) there is a new determination, or (3) 5 minutes has elapsed since the last IoB update and the app is in the foreground.

There are two optimizations to ensure the IoB calculation doesn't get called too often: limiting the update frequency from timer events and only honoring timer events when the app is in the foreground.