### PR TITLE
Avoid starting an action at xx:00; when GitHub resources can be impacted

### DIFF
--- a/.github/workflows/build_trio.yml
+++ b/.github/workflows/build_trio.yml
@@ -7,8 +7,9 @@ on:
   #push:
 
   schedule:
-    - cron: "0 8 * * 3" # Checks for updates at 08:00 UTC every Wednesday
-    - cron: "0 6 1 * *" # Builds the app on the 1st of every month at 06:00 UTC
+    # avoid starting an action at xx:00 when GitHub resources are more likely to be impacted
+    - cron: "43 8 * * 3" # Checks for updates at 08:43 UTC every Wednesday
+    - cron: "43 6 1 * *" # Builds the app on the 1st of every month at 06:43 UTC
 
 env:
   UPSTREAM_REPO: nightscout/Trio
@@ -212,7 +213,7 @@ jobs:
       | # runs if started manually, or if sync schedule is set and enabled and scheduled on the first Saturday each month, or if sync schedule is set and enabled and new commits were found
       github.event_name == 'workflow_dispatch' ||
       (needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '0 6 1 * *') ||
+        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '43 6 1 * *') ||
         (vars.SCHEDULED_SYNC != 'false' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
       )
     steps:


### PR DESCRIPTION
## Problem being addressed

Recently, mentors are seeing reports of builds failing on the automatic build days because of no resources available at GitHub.

## Problem solution

Modify the minute at which the automatic builds happen
- avoid the top of the hour
- choose a different minute for build action for each app in the open-source AID community

###

For Trio, change from xx:00 to xx:43.