### PR TITLE
Comment out CGM backfill logic

### DIFF
--- a/Trio/Resources/InfoPlist.xcstrings
+++ b/Trio/Resources/InfoPlist.xcstrings
@@ -457,18 +457,6 @@
         }
       }
     },
-    "NSCalendarsFullAccessUsageDescription" : {
-      "comment" : "Privacy - Calendars Full Access Usage Description",
-      "extractionState" : "extracted_with_value",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay"
-          }
-        }
-      }
-    },
     "NSCalendarsUsageDescription" : {
       "comment" : "Privacy - Calendars Usage Description",
       "extractionState" : "extracted_with_value",

--- a/Trio/Sources/APS/FetchGlucoseManager.swift
+++ b/Trio/Sources/APS/FetchGlucoseManager.swift
@@ -284,15 +284,17 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
             return
         }
 
-        let backfillGlucose = newGlucose.filter { $0.dateString <= syncDate }
-        if backfillGlucose.isNotEmpty {
-            debug(.deviceManager, "Backfilling glucose...")
-            do {
-                try await glucoseStorage.storeGlucose(backfillGlucose)
-            } catch {
-                debug(.deviceManager, "Unable to backfill glucose: \(error)")
-            }
-        }
+        // TODO: Fix backfill logic https://github.com/nightscout/Trio/issues/737
+        /*
+         let backfillGlucose = newGlucose.filter { $0.dateString <= syncDate }
+         if backfillGlucose.isNotEmpty {
+             debug(.deviceManager, "Backfilling glucose...")
+             do {
+                 try await glucoseStorage.storeGlucose(backfillGlucose)
+             } catch {
+                 debug(.deviceManager, "Unable to backfill glucose: \(error)")
+             }
+         }*/
 
         filteredByDate = newGlucose.filter { $0.dateString > syncDate }
         filtered = glucoseStorage.filterTooFrequentGlucose(filteredByDate, at: syncDate)


### PR DESCRIPTION
This PR temporarily removes the backfill logic. Backfilling was causing issues with CGM managers that send historical values commonly, like G6 and potentially xdrip. In particular, it would add duplicate readings and would re-add deleted CGM values.

For now I'm going to disable this logic, but will fix it soon https://github.com/nightscout/Trio/issues/737