### PR TITLE
Narrow y-scale for AGP chart

### DIFF
--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucosePercentileChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucosePercentileChart.swift
@@ -36,6 +36,20 @@ struct GlucosePercentileChart: View {
         return hourlyStats.first { Int($0.hour) == hour }
     }
 
+    /// The minimum Y-axis value based on the lowest possible cgm reading
+    private var minYValue: Double {
+        40.0.asUnit(units)
+    }
+
+    /// The maximum Y-axis value based on the highest 90th percentile
+    private var maxYValue: Double {
+        let topLimit = 400.0.asUnit(units)
+        let validStats = hourlyStats.filter { $0.median > 0 }
+        guard !validStats.isEmpty else { return topLimit }
+        let maxPercentile90 = validStats.map(\.percentile90).max() ?? topLimit
+        return maxPercentile90.asUnit(units)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Ambulatory Glucose Profile (AGP)")
@@ -131,6 +145,7 @@ struct GlucosePercentileChart: View {
                     }
                 }
             }
+            .chartYScale(domain: minYValue ... maxYValue)
             .chartYAxis {
                 AxisMarks(position: .trailing) { value in
                     if let glucose = value.as(Double.self) {


### PR DESCRIPTION
This PR reduces the empty whitespace above and below the AGP charts in many circumstances making it easier to see details.

Here are screenshots comparing my AGP graphs from this PR to the current dev on an iPhone 14 Pro Max running iOS 26 beta 9:

## mg/dL

| This PR | dev |
|---|---|
| ![IMG_8174](https://github.com/user-attachments/assets/a0795e99-f945-4dbf-812b-4f69f97cb82d) | ![IMG_8190](https://github.com/user-attachments/assets/628d8b8d-2bb2-47e7-8561-4ae46f622dd1) |
| ![IMG_8175](https://github.com/user-attachments/assets/38359081-9f56-434d-a4eb-f71987cde8de) | ![IMG_8191](https://github.com/user-attachments/assets/16cc0cf5-d10a-42fd-a6a9-e9d745eb95d7) |
| ![IMG_8176](https://github.com/user-attachments/assets/50bff25e-d49e-4c44-804f-c1a6de5f2a2a) | ![IMG_8192](https://github.com/user-attachments/assets/67d81e84-5d77-4268-aab0-5b2ed92d7980) |
| ![IMG_8177](https://github.com/user-attachments/assets/ab4b9324-3918-4eef-ae7a-6f1e482bd74e) | ![IMG_8193](https://github.com/user-attachments/assets/421f312e-cd4f-4e9f-9dcb-d5281a8fb20e) |
| ![IMG_8178](https://github.com/user-attachments/assets/5f289e17-ec18-4c67-abfd-153fd7a5449a) | ![IMG_8194](https://github.com/user-attachments/assets/7ab5a65a-9e5b-4f86-b0d6-9407bfab261e) |

## mmol/L

| This PR | dev |
|---|---|
| ![IMG_8179](https://github.com/user-attachments/assets/5f3287b4-f546-471e-b0ce-c2f10f619f80) | ![IMG_8184](https://github.com/user-attachments/assets/553b8e89-08e5-4448-add1-0735e35a6bb9) |
| ![IMG_8180](https://github.com/user-attachments/assets/60dc8b93-93af-4781-9841-ac2501213f34) | ![IMG_8185](https://github.com/user-attachments/assets/282bc363-e4f9-463e-a936-617c0463339a) |
| ![IMG_8181](https://github.com/user-attachments/assets/486eb99a-8680-4aa1-b925-a1b39798a985) | ![IMG_8186](https://github.com/user-attachments/assets/09a4e18d-a562-4d50-8e09-c2f1608a4cdd) |
| ![IMG_8182](https://github.com/user-attachments/assets/785d6096-38a4-4ddd-836d-6c3534c1aa4f) | ![IMG_8187](https://github.com/user-attachments/assets/0b082c0e-ca2f-4e18-b1ed-a77f1d897102) |
| ![IMG_8183](https://github.com/user-attachments/assets/4e65eec7-9a13-470e-aa09-a48a18fb58af) | ![IMG_8189](https://github.com/user-attachments/assets/f7ab9900-e886-4acf-91af-3fe429390d95) |