### PR TITLE
Improve tabBar functionality for treatment sheet selection

### DIFF
--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -1063,9 +1063,12 @@ extension Home {
                 .tint(Color.tabBar)
                 .onChange(of: selectedTab) { oldValue, newValue in
                     if newValue == 2 {
-                        // Middle tab was selected – revert to previous tab and open sheet
-                        selectedTab = oldValue
+                        // Middle tab was selected - open treatment sheet and after delay revert to previous tab
                         state.showModal(for: .treatmentView)
+                        Task {
+                            try await Task.sleep(for: .seconds(1))
+                            selectedTab = oldValue
+                        }
                     }
                 }
 

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -513,7 +513,7 @@ extension Home {
                 }
             }
             .onTapGesture {
-                selectedTab = 2
+                selectedTab = 3
             }
         }
 
@@ -530,7 +530,7 @@ extension Home {
                 }
             }
             .onTapGesture {
-                selectedTab = 2
+                selectedTab = 3
             }
         }
 
@@ -609,7 +609,7 @@ extension Home {
                     // clear color for the icon
                     .foregroundStyle(Color.clear)
             }.onTapGesture {
-                selectedTab = 2
+                selectedTab = 3
             }
         }
 
@@ -1033,31 +1033,43 @@ extension Home {
                         return nil
                     }()
 
+                    // Tab 0: Main
                     NavigationStack { mainView() }
                         .tabItem { Label("Main", systemImage: "chart.xyaxis.line") }
-                        .badge(carbsRequiredBadge).tag(0)
+                        .badge(carbsRequiredBadge)
+                        .tag(0)
 
+                    // Tab 1: History
                     NavigationStack { DataTable.RootView(resolver: resolver) }
-                        .tabItem { Label("History", systemImage: historySFSymbol) }.tag(1)
+                        .tabItem { Label("History", systemImage: historySFSymbol) }
+                        .tag(1)
 
-                    Spacer()
+                    // Tab 2: Empty middle tab (intercepted by onChange and image overlaid)
+                    Color.clear
+                        .tabItem {}
+                        .tag(2)
 
+                    // Tab 3: Adjustments
                     NavigationStack { Adjustments.RootView(resolver: resolver) }
-                        .tabItem {
-                            Label(
-                                "Adjustments",
-                                systemImage: "slider.horizontal.2.gobackward"
-                            ) }.tag(2)
+                        .tabItem { Label("Adjustments", systemImage: "slider.horizontal.2.gobackward") }
+                        .tag(3)
 
+                    // Tab 4: Settings
                     NavigationStack(path: self.$settingsPath) {
                         Settings.RootView(resolver: resolver) }
-                        .tabItem { Label(
-                            "Settings",
-                            systemImage: "gear"
-                        ) }.tag(3)
+                        .tabItem { Label("Settings", systemImage: "gear") }
+                        .tag(4)
                 }
                 .tint(Color.tabBar)
+                .onChange(of: selectedTab) { oldValue, newValue in
+                    if newValue == 2 {
+                        // Middle tab was selected – revert to previous tab and open sheet
+                        selectedTab = oldValue
+                        state.showModal(for: .treatmentView)
+                    }
+                }
 
+                // Overlay the plus button on top of the middle tab
                 Button(
                     action: {
                         state.showModal(for: .treatmentView) },
@@ -1069,12 +1081,14 @@ extension Home {
                             .padding(.horizontal, 24)
                     }
                 )
-            }.ignoresSafeArea(.keyboard, edges: .bottom).blur(radius: state.waitForSuggestion ? 8 : 0)
-                .onChange(of: selectedTab) {
-                    if !settingsPath.isEmpty {
-                        settingsPath = NavigationPath()
-                    }
+            }
+            .ignoresSafeArea(.keyboard, edges: .bottom)
+            .blur(radius: state.waitForSuggestion ? 8 : 0)
+            .onChange(of: selectedTab) {
+                if !settingsPath.isEmpty {
+                    settingsPath = NavigationPath()
                 }
+            }
         }
 
         var body: some View {


### PR DESCRIPTION
When Trio is built to iOS 26 Beta with Xcode 26 Beta, it uses the new liquid glass for the tabBar. This creates an issue where the spacer in the middle of the tabBar can be accidentally selected instead when trying to open the Treatment sheet, which brings up a completely empty view instead of the Treatment sheet.

This PR makes it so if the middle tabBar slot is accidentally selected instead of the Treatment sheet button, it will revert back to the currently selected tab and open the Treatment sheet.

Tested using Xcode 26 Beta 7 with iOS 18.5 and iOS 26.0 simulators.