### PR TITLE
Disable Liquid Glass

### DIFF
--- a/Trio/Resources/Info.plist
+++ b/Trio/Resources/Info.plist
@@ -107,6 +107,8 @@
 		<string>remote-notification</string>
 		<string>audio</string>
 	</array>
+    <key>UIDesignRequiresCompatibility</key>
+    <true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchScreen</key>


### PR DESCRIPTION
This just prevents Liquid Glass from being used when built to iOS 26 from Xcode 26, as Trio's UI will require some tweaking to accommodate the new Liquid Glass feature.

<img width="432" height="246" alt="Screenshot 2025-09-08 at 08 25 15" src="https://github.com/user-attachments/assets/c9657d1e-de91-42cd-99e7-f0e0cc2fbdef" />


More info on this Boolean: https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility