### PR TITLE
Update feat/dev-medtrum branch to bring in updates from MedtrumKit

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -19,7 +19,7 @@ TRIO_APP_GROUP_ID = group.org.nightscout.$(DEVELOPMENT_TEAM).trio.trio-app-group
 
 // The developers set the version numbers, please leave them alone
 APP_VERSION = 0.5.1
-APP_DEV_VERSION = 0.5.1.24
+APP_DEV_VERSION = 0.5.1.25
 APP_BUILD_NUMBER = 1
 COPYRIGHT_NOTICE =
 

--- a/Trio/Resources/Info.plist
+++ b/Trio/Resources/Info.plist
@@ -107,6 +107,8 @@
 		<string>remote-notification</string>
 		<string>audio</string>
 	</array>
+    <key>UIDesignRequiresCompatibility</key>
+    <true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/Trio/Resources/InfoPlist.xcstrings
+++ b/Trio/Resources/InfoPlist.xcstrings
@@ -8,7 +8,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Trio Medtrum"
+            "value" : "Trio"
           }
         }
       }
@@ -20,7 +20,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Trio Medtrum"
+            "value" : "Trio"
           }
         }
       }

--- a/scripts/swiftformat.sh
+++ b/scripts/swiftformat.sh
@@ -97,4 +97,19 @@ trailingClosures \
 --typeattributes same-line \
 --varattributes same-line \
 --wrapcollections before-first \
---exclude Pods,Generated,R.generated.swift,fastlane/swift,Dependencies, LoopKit, LibreTransmitter,G7SensorKit,OmniKit, dexcom-share-client-swift,CGMBLEKit,RileyLinkKit,OmniBLE,MinimedKit,TidepoolService
+--exclude Pods, Generated, \
+  R.generated.swift, \
+  fastlane/swift, \
+  Dependencies,  \
+  LoopKit,  \
+  LibreTransmitter, \
+  G7SensorKit, \
+  OmniKit,  \
+  dexcom-share-client-swift, \
+  CGMBLEKit, \
+  RileyLinkKit, \
+  OmniBLE, \
+  MinimedKit, \
+  TidepoolService \
+  DanaKit \
+  MedtrumKit


### PR DESCRIPTION
## Purpose

Update MedtrumKit.

Tagging @bastiaanv 

## Method

The last version of MedtrumKit included in Trio branch feat/dev-medtrum is from 09-Aug-2025.

This PR brings the most recent commit from MedtrumKit into Trio
* Caveat - I am preparing the PR for the MedtrumKit experts to approve
* I tested it using a Medtrum pump on a test phone

This update advances commits from MedtrumKit: 5bfb806...e695e62, which comprises 30 commits.

## Test


Test phone is SE 2nd gen running iOS 18.6.2.
* CGM is from Nightscout
* Pump is Medtrum
   * Built on phone: feat/dev-medtrum commit aa34d2976
   * Pump start was nominal
   * Note - I did this test prior to pushing this commit to Trio
* Built `updates_to_medtrumkit`, commit bef8d7f3a on same phone
   * Closed loop continued and manual boluses were accepted
   * Temp Basal shows on Trio main screen and Medtrum screen
   * Several SMB were reported and I could hear them on the pump


