### PR TITLE
fix(medtrumkit): keep reservoir level up-to-date on HomeScreen

### DIFF
--- a/Trio/Sources/APS/DeviceDataManager.swift
+++ b/Trio/Sources/APS/DeviceDataManager.swift
@@ -491,6 +491,11 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
         }
         
         if let medtrumPump = pumpManager as? MedtrumPumpManager {
+            storage.save(Decimal(medtrumPump.state.reservoir), as: OpenAPS.Monitor.reservoir)
+            broadcaster.notify(PumpReservoirObserver.self, on: processQueue) {
+                $0.pumpReservoirDidChange(Decimal(medtrumPump.state.reservoir))
+            }
+
             guard let endTime = medtrumPump.state.patchExpiresAt else {
                 pumpExpiresAtDate.send(nil)
                 return


### PR DESCRIPTION
Added missing logic to keep the reservoir level up-to-date.
Logic is similar to Omnipod.

closes #789 