### PR TITLE
Shift GitHub to check for updates every Sunday and build 2nd Saturday of each month

### DIFF
--- a/.github/workflows/build_trio.yml
+++ b/.github/workflows/build_trio.yml
@@ -7,9 +7,9 @@ on:
   #push:
 
   schedule:
-    # avoid starting an action at xx:00 when GitHub resources are more likely to be impacted
-    - cron: "43 8 * * 3" # Checks for updates at 08:43 UTC every Wednesday
-    - cron: "43 6 1 * *" # Builds the app on the 1st of every month at 06:43 UTC
+    # avoid starting an action at times when GitHub resources are more likely to be impacted
+    - cron: "43 8 * * 0" # Checks for updates at 08:43 UTC every Sunday
+    - cron: "43 6 8-14 * 6" # Builds the app on the second Saturday of each month at 06:43 UTC
 
 env:
   UPSTREAM_REPO: nightscout/Trio
@@ -213,7 +213,7 @@ jobs:
       | # runs if started manually, or if sync schedule is set and enabled and scheduled on the first Saturday each month, or if sync schedule is set and enabled and new commits were found
       github.event_name == 'workflow_dispatch' ||
       (needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '43 6 1 * *') ||
+        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '43 6 8-14 * 6') ||
         (vars.SCHEDULED_SYNC != 'false' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
       )
     steps:


### PR DESCRIPTION
## Purpose

Try to avoid times when GitHub actions are historically busy.
Thanks Carol Vachon for this report:

> The most significant and consistent historic pattern impacting GitHub activity is the week-to-weekend cycle, as most development work happens during the standard workweek.

> * Lowest activity: Weekends, especially Sundays, see the least amount of activity, as most developers are off work.
> * Highest activity: Activity is typically at its peak from Tuesday to Thursday.
> * Moderate activity: Mondays and Fridays have moderate activity as developers ease into and out of the workweek.

On Wed, Oct 1, GitHub actions were impacted and all builds across the Open Source community all failed.

## Method

* Shift the weekly build in case of code updates from Wednesday to Sunday
* Shift the monthly builds, regardless of whether code was updated, from the 1st of the month to the second Saturday of each month