### PR TITLE
Modify the GitHub build schedule to every Sunday

### DIFF
--- a/.github/workflows/build_trio.yml
+++ b/.github/workflows/build_trio.yml
@@ -234,7 +234,7 @@ jobs:
       )
     steps:
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_16.3.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer"
       
       - name: Checkout Repo for syncing
         if: |

--- a/.github/workflows/build_trio.yml
+++ b/.github/workflows/build_trio.yml
@@ -2,14 +2,10 @@ name: 4. Build Trio
 run-name: Build Trio (${{ github.ref_name }})
 on:
   workflow_dispatch:
-
-  ## Remove the "#" sign from the beginning of the line below to get automated builds on push (code changes in your repository)
-  #push:
-
   schedule:
-    # avoid starting an action at times when GitHub resources are more likely to be impacted
-    - cron: "43 8 * * 0" # Checks for updates at 08:43 UTC every Sunday
-    - cron: "43 6 8-14 * 6" # Builds the app on the second Saturday of each month at 06:43 UTC
+    # Check for updates every Sunday
+    #   Later logic builds if there are updates or if it is the 2nd Sunday of the month
+    - cron: "43 6 * * 0" # Sunday at UTC 06:43
 
 env:
   UPSTREAM_REPO: nightscout/Trio
@@ -19,6 +15,26 @@ env:
   ALIVE_BRANCH_DEV: alive-dev
 
 jobs:
+
+  # Set a logic flag if this is the second instance of this day-of-week in this month
+  day_in_month:
+    runs-on: ubuntu-latest
+    name: Check day in month
+    outputs:
+      IS_SECOND_IN_MONTH: ${{ steps.date-check.outputs.is_second_instance }}
+
+    steps:
+      - id: date-check
+        name: Check if this is the second time this day-of-week happens this month
+        run: |
+          DAY_OF_MONTH=$(date +%-d)
+          WEEK_OF_MONTH=$(( ($(date +%-d) - 1) / 7 + 1 ))
+          if [[ $WEEK_OF_MONTH -eq 2 ]]; then
+            echo "is_second_instance=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_second_instance=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # Checks if Distribution certificate is present and valid, optionally nukes and
   # creates new certs if the repository variable ENABLE_NUKE_CERTS == 'true'
   check_certs:
@@ -205,15 +221,15 @@ jobs:
   # Builds Trio
   build:
     name: Build
-    needs: [check_certs, check_alive_and_permissions, check_latest_from_upstream]
+    needs: [check_certs, check_alive_and_permissions, check_latest_from_upstream, day_in_month]
     runs-on: macos-15
     permissions:
       contents: write
     if:
-      | # runs if started manually, or if sync schedule is set and enabled and scheduled on the first Saturday each month, or if sync schedule is set and enabled and new commits were found
+      | # builds with manual start; if automatic: once a month or when new commits are found
       github.event_name == 'workflow_dispatch' ||
       (needs.check_alive_and_permissions.outputs.WORKFLOW_PERMISSION == 'true' &&
-        (vars.SCHEDULED_BUILD != 'false' && github.event.schedule == '43 6 8-14 * 6') ||
+        (vars.SCHEDULED_BUILD != 'false' && needs.day_in_month.outputs.IS_SECOND_IN_MONTH == 'true') ||
         (vars.SCHEDULED_SYNC != 'false' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
       )
     steps:


### PR DESCRIPTION
## Purpose

Our previous attempt to build on the second Saturday of the month was configured to build every Saturday and on the 8-14th day of the month.

I noticed that Trio still had Xcode 16.3 selected, so I also update that to Xcode 16.4.

### Update the build_xxx.yml logic. 

Change the schedule to run at a specific time every Sunday:
* modify the logic to build monthly (2nd Sunday) regardless of status
* keep the logic to build weekly if there are new commits to the code
 
This new method eliminates one build process per month. The monthly build starts at the same time as the weekly check for updates.

The once a month logic is much simpler
* add a new job `day_in_month` that determines if this is the second time this day of the week has happened in this month
* the output `IS_SECOND_IN_MONTH` is used to decide whether to skip or execute a build

## Test new logic

✅ Tests succeeded.

### Test that scheduled build is run when expected

Make a test branch, `trigger_test` in GitHub org docs-test/Trio copied from `bb_schedule` to enable tests. 

**Modify time for test**
* change cron time to near future
* demonstrate app builds
* modification: https://github.com/docs-test/Trio/commit/baa56b62e16c34ceb8ce7c0abe8c951fc2ac03ca
* ✅ successful build: [Build Trio (trigger_test)](https://github.com/docs-test/Trio/actions/runs/18419952488)

### Test that scheduled build is skipped when expected

**Modify logic for test**
* change cron time to near future and logic to check for 3rd week
* demonstrate that build is skipped
* modification: https://github.com/docs-test/Trio/commit/6a6c1f59f5d52f14a0e46c518ce13d75dcd8742f
* ✅ successful skip of the build: [Build Trio (trigger_test)](https://github.com/docs-test/Trio/actions/runs/18420753117)
