### PR TITLE
feat: update MedtrumKit

### DIFF
--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -18,6 +18,7 @@ protocol APSManager {
     var lastLoopDateSubject: PassthroughSubject<Date, Never> { get }
     var bolusProgress: CurrentValueSubject<Decimal?, Never> { get }
     var pumpExpiresAtDate: CurrentValueSubject<Date?, Never> { get }
+    var pumpActivatedAtDate: CurrentValueSubject<Date?, Never> { get }
     var isManualTempBasal: Bool { get }
     func enactTempBasal(rate: Double, duration: TimeInterval) async
     func determineBasal() async throws
@@ -122,6 +123,10 @@ final class BaseAPSManager: APSManager, Injectable {
 
     var pumpExpiresAtDate: CurrentValueSubject<Date?, Never> {
         deviceDataManager.pumpExpiresAtDate
+    }
+
+    var pumpActivatedAtDate: CurrentValueSubject<Date?, Never> {
+        deviceDataManager.pumpActivatedAtDate
     }
 
     var settings: TrioSettings {

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -48,6 +48,7 @@ extension Home {
         var reservoir: Decimal?
         var pumpName = ""
         var pumpExpiresAtDate: Date?
+        var pumpActivatedAtDate: Date?
         var highTTraisesSens: Bool = false
         var lowTTlowersSens: Bool = false
         var isExerciseModeActive: Bool = false
@@ -341,6 +342,11 @@ extension Home {
             apsManager.pumpExpiresAtDate
                 .receive(on: DispatchQueue.main)
                 .weakAssign(to: \.pumpExpiresAtDate, on: self)
+                .store(in: &lifetime)
+
+            apsManager.pumpActivatedAtDate
+                .receive(on: DispatchQueue.main)
+                .weakAssign(to: \.pumpActivatedAtDate, on: self)
                 .store(in: &lifetime)
 
             apsManager.lastError

--- a/Trio/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/PumpView.swift
@@ -18,7 +18,7 @@ struct PumpView: View {
     }
 
     private var hourglassIcon: String {
-        if activatedAtDate != nil { return "hourglass" }
+        if activatedAtDate != nil { return "hourglass.badge.plus" }
         guard let expiration = expiresAtDate else { return "hourglass" }
 
         let hoursRemaining = expiration.timeIntervalSince(timerDate) / 3600

--- a/Trio/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/PumpView.swift
@@ -11,6 +11,8 @@ struct PumpView: View {
     let battery: [OpenAPS_Battery]
     @Environment(\.colorScheme) var colorScheme
 
+    let NORMAL_PATCH_AGE = TimeInterval.hours(80)
+
     private var batteryFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .percent
@@ -208,8 +210,8 @@ struct PumpView: View {
     }
 
     private var timerColor: Color {
-        if activatedAtDate != nil {
-            return Color.loopGreen
+        if let activatedAt = activatedAtDate {
+            return abs(activatedAt.timeIntervalSinceNow) > NORMAL_PATCH_AGE ? Color.yellow : Color.loopGreen
         }
 
         guard let expiresAt = expiresAtDate else {

--- a/Trio/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/PumpView.swift
@@ -112,7 +112,7 @@ struct PumpView: View {
         HStack {
             Image(systemName: hourglassIcon)
                 .font(.callout)
-                .foregroundStyle(timerColor, Color.yellow)
+                .foregroundStyle(timerColor, timerColorSecondary)
                 .symbolRenderingMode(.palette)
 
             let remainingTimeString = isExpiration ?
@@ -226,6 +226,14 @@ struct PumpView: View {
         default:
             return Color.loopGreen
         }
+    }
+
+    private var timerColorSecondary: Color {
+        if activatedAtDate != nil {
+            return Color.gray
+        }
+
+        return Color.yellow
     }
 }
 

--- a/Trio/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/PumpView.swift
@@ -115,10 +115,9 @@ struct PumpView: View {
                 .foregroundStyle(timerColor, Color.yellow)
                 .symbolRenderingMode(.palette)
 
-            let remainingTimeString = remainingTimeString(
-                time: isExpiration ? date.timeIntervalSince(timerDate) : timerDate
-                    .timeIntervalSince(date)
-            )
+            let remainingTimeString = isExpiration ?
+                remainingTimeString(time: date.timeIntervalSince(timerDate)) :
+                activeTimeString(time: timerDate.timeIntervalSince(date))
 
             Text(remainingTimeString)
                 .font(date.timeIntervalSince(timerDate) > 0 ? .callout : .subheadline)
@@ -159,6 +158,23 @@ struct PumpView: View {
         }
 
         return "\(minutes)" + String(localized: "m", comment: "abbreviation for minutes")
+    }
+
+    private func activeTimeString(time: TimeInterval) -> String {
+        var time = time
+        let days = Int(time / 1.days.timeInterval)
+        time -= days.days.timeInterval
+        let hours = Int(time / 1.hours.timeInterval)
+        time -= hours.hours.timeInterval
+        let minutes = Int(time / 1.minutes.timeInterval)
+
+        if days >= 1 {
+            return "\(days)" + String(localized: "d", comment: "abbreviation for days") + " \(hours)" +
+                String(localized: "h", comment: "abbreviation for hours")
+        }
+
+        return "\(hours)" + String(localized: "h", comment: "abbreviation for hours") + "\(minutes)" +
+            String(localized: "m", comment: "abbreviation for minutes")
     }
 
     private var batteryColor: Color {

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -147,6 +147,7 @@ extension Home {
                 reservoir: state.reservoir,
                 name: state.pumpName,
                 expiresAtDate: state.pumpExpiresAtDate,
+                activatedAtDate: state.pumpActivatedAtDate,
                 timerDate: state.timerDate,
                 pumpStatusHighlightMessage: state.pumpStatusHighlightMessage,
                 battery: state.batteryFromPersistence


### PR DESCRIPTION
Change log:
- [MedtrumKit] Rename action buttons from next to save when outside onboarding flow
- [MedtrumKit] Update patch age header
  - When in normal mode, show Expires in
  - When in extended mode, show patch age without progress bar
- [MedtrumKit] Emit dose resume after patch activate & dose suspended after patch deactivated
  - Related issue: #767 
- [Trio] If MedtrumKit is in extended mode, show the patch age instead of patch expiration
- [MedtrumKit] emit uncertain bolus error if patch disconnects
  - related issue: https://github.com/jbr7rr/MedtrumKit/issues/28
- [MedtrumKit] add insulin usage to previousPatch storage
  - related issue: https://github.com/jbr7rr/MedtrumKit/issues/26 
- [MedtrumKit] Remove logic to auto update time/timezone
  - Just like with DanaKit, the user can choose to update the time in the pump menu
  - Warning about time drift is shown in Trio home screen, like the other pumpManagers
- [MedtrumKit] Update localizations

<details><summary><b>Video showing new HomeHeader & MedtrumKit header</b></summary>
<p>
<video src="https://github.com/user-attachments/assets/ca59a534-0d65-4321-be23-d8f007f25d44" controls></video>
</p>
</details> 

Resolves #791, #792, #767