### PR TITLE
Fix typos in Onboarding

### DIFF
--- a/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/TherapySettings/CarbRatioStepView.swift
+++ b/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/TherapySettings/CarbRatioStepView.swift
@@ -69,7 +69,7 @@ struct CarbRatioStepView: View {
                             .padding(.horizontal)
 
                         VStack(alignment: .leading, spacing: 8) {
-                            Text("For 45g of carbs, you would need:")
+                            Text("For 45 g of carbs, you would need:")
                                 .font(.subheadline)
                                 .padding(.horizontal)
 
@@ -79,7 +79,7 @@ struct CarbRatioStepView: View {
                                         .carbRatioRateValues[state.carbRatioItems.first!.rateIndex] as NSNumber
                                 )
                             Text(
-                                "45 \(String(localized: "g", comment: "Gram abbreviation")) / \(formatter.string(from: state.carbRatioRateValues[state.carbRatioItems.first!.rateIndex] as NSNumber) ?? "--")  = \(String(format: "%.1f", insulinNeeded))" +
+                                "45 \(String(localized: "g", comment: "Gram abbreviation")) / \(formatter.string(from: state.carbRatioRateValues[state.carbRatioItems.first!.rateIndex] as NSNumber) ?? "--") \(String(localized: "g/U")) = \(String(format: "%.1f", insulinNeeded))" +
                                     " " + String(localized: "U", comment: "Insulin unit abbreviation")
                             )
                             .font(.system(.body, design: .monospaced))
@@ -100,7 +100,7 @@ struct CarbRatioStepView: View {
                             .padding(.horizontal)
 
                         VStack(alignment: .leading, spacing: 4) {
-                            Text("• A ratio of 10 g/U means 1 unit of insulin covers 10g of carbs")
+                            Text("• A ratio of 10 g/U means 1 unit of insulin covers 10 g of carbs")
                             Text("• A lower number means you need more insulin for the same amount of carbs")
                             Text("• A higher number means you need less insulin for the same amount of carbs")
                             Text("• Different times of day may require different ratios")

--- a/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/TherapySettings/InsulinSensitivityStepView.swift
+++ b/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/TherapySettings/InsulinSensitivityStepView.swift
@@ -106,13 +106,12 @@ struct InsulinSensitivityStepView: View {
                             .padding(.horizontal)
 
                         VStack(alignment: .leading, spacing: 4) {
-                            let isfValue = "\(state.units == .mgdL ? Decimal(50) : 50.asMmolL)" +
-                                "\(state.units.rawValue)"
+                            let isfValue = "\(state.units == .mgdL ? Decimal(50) : 50.asMmolL)"
                             Text(
-                                "• An ISF of \(isfValue) means 1 U lowers your glucose by \(isfValue)"
+                                "• An ISF of \(isfValue) \(state.units.rawValue)/U means 1 U lowers your glucose by \(isfValue) \(state.units.rawValue)"
                             )
-                            Text("• A lower number means you're more sensitive to insulin")
-                            Text("• A higher number means you're less sensitive to insulin")
+                            Text("• A lower number means you're less sensitive (more resistant) to insulin")
+                            Text("• A higher number means you're more sensitive (less resistant) to insulin")
                         }
                         .font(.caption)
                         .foregroundColor(.secondary)

--- a/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/WelcomeStepView.swift
+++ b/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/WelcomeStepView.swift
@@ -15,7 +15,7 @@ struct WelcomeStepView: View {
                     .multilineTextAlignment(.center)
 
                 Text(
-                    "Welcome to Trio - an automated insulin delivery system for iOS based on the OpenAPS algorithm with adaptations."
+                    "Welcome to Trio — an automated insulin delivery system for iOS based on the OpenAPS algorithm with adaptations."
                 )
                 .multilineTextAlignment(.leading)
                 .foregroundColor(.secondary)


### PR DESCRIPTION
This fixes the mixup between `less` and `more` sensitive in the Onboarding's description for ISF, as well as some formatting errors. I copy/pasted the localizations for the formatting errors, but let the ones reset where the original string changed meanings.

| 0.6.0.2 | This PR | localization reset |
|---|---|---|
| "• A higher number means you're less sensitive to insulin" | "• A higher number means you're more sensitive (less resistant) to insulin" | yes |
| "• A lower number means you're more sensitive to insulin" | "• A lower number means you're less sensitive (more resistant) to insulin" | yes |
| "• A ratio of 10 g/U means 1 unit of insulin covers 10g of carbs" | "• A ratio of 10 g/U means 1 unit of insulin covers 10 g of carbs" | no |
| "• An ISF of %@ means 1 U lowers your glucose by %@" (50 mg/dL, 50 mg/dL) | "• An ISF of %@ %@/U means 1 U lowers your glucose by %@ %@" (50, mg/dL, 50, mg/dL) | no |
| "For 45g of carbs, you would need:" | "For 45 g of carbs, you would need:" | no |
| "Welcome to Trio - an automated insulin delivery system for iOS based on the OpenAPS algorithm with adaptations." | "Welcome to Trio — an automated insulin delivery system for iOS based on the OpenAPS algorithm with adaptations." | no |