### PR TITLE
Fix iOS 26.1 LoopStatusView Detent Issue

### DIFF
--- a/Trio/Sources/Modules/Home/View/Header/LoopStatusView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/LoopStatusView.swift
@@ -129,7 +129,11 @@ struct LoopStatusView: View {
         .onAppear {
             lastDetermination = state.determinationsFromPersistence.first
         }
-        .presentationDetents([.height(sheetContentHeight)])
+        .presentationDetents([
+            sheetContentHeight > 0
+                ? .height(sheetContentHeight)
+                : .fraction(0.9)
+        ])
         .presentationDragIndicator(.visible)
         .onPreferenceChange(ContentSizeKey.self) { newSize in
             sheetContentHeight = newSize.height

--- a/Trio/Sources/Modules/Home/View/Header/LoopStatusView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/LoopStatusView.swift
@@ -130,9 +130,8 @@ struct LoopStatusView: View {
             lastDetermination = state.determinationsFromPersistence.first
         }
         .presentationDetents([
-            sheetContentHeight > 0
-                ? .height(sheetContentHeight)
-                : .fraction(0.9)
+            sheetContentHeight > 0 ? .height(sheetContentHeight) : .fraction(0.9),
+            .large
         ])
         .presentationDragIndicator(.visible)
         .onPreferenceChange(ContentSizeKey.self) { newSize in


### PR DESCRIPTION
There was a change (or bug?) in the iOS 26.1 Beta which broke the LoopStatusView from expanding to be viewable. Xcode says "Invalid sheet detent height: 0.0". 

The hardcoded 90% does not look as good as when the View is working properly (like on the latest public release of iOS — 26.0.1) since it hides more of the screen and has an awkward gap below the Got It button, but since this PR just forces a 90% detent if the detent height is 0, users that aren't experience this problem won't be affected. 

Once iOS 26.1 is officially released, if it's still falling back to the 90% version we should look into a more elegant solution.

| dev 0.6.0.4 | This PR |
|---|---|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/76f07ad1-9ef6-401f-a695-42061323e0f8" /> | ![41C2C1F5-EBF2-4DE6-A7AD-C253ED7C7A75_1_101_o](https://github.com/user-attachments/assets/a0504862-cb7e-4e60-accb-8e57ff9071d9) |