### PR TITLE
fix: rework default pump settings to actual pump settings

### DIFF
--- a/Trio/Sources/Modules/BasalProfileEditor/BasalProfileEditorStateModel.swift
+++ b/Trio/Sources/Modules/BasalProfileEditor/BasalProfileEditorStateModel.swift
@@ -113,6 +113,12 @@ extension BasalProfileEditor {
                         // Successfully saved and synced
                         self.initialItems = self.items.map { Item(rateIndex: $0.rateIndex, timeIndex: $0.timeIndex) }
 
+                        DispatchQueue.main.async {
+                            self.broadcaster.notify(BasalProfileObserver.self, on: .main) {
+                                $0.basalProfileDidChange(profile)
+                            }
+                        }
+
                         Task.detached(priority: .low) {
                             do {
                                 debug(.nightscout, "Attempting to upload basal rates to Nightscout")
@@ -130,12 +136,6 @@ extension BasalProfileEditor {
                     print("We were successful")
                 }
                 .store(in: &lifetime)
-
-            DispatchQueue.main.async {
-                self.broadcaster.notify(BasalProfileObserver.self, on: .main) {
-                    $0.basalProfileDidChange(profile)
-                }
-            }
         }
 
         @MainActor func validate() {

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -567,7 +567,7 @@ extension Home {
 
                 if let schedule = BasalRateSchedule(
                     dailyItems: basalProfile
-                        .map { RepeatingScheduleValue(startTime: TimeInterval($0.minutes), value: Double($0.rate)) }
+                        .map { RepeatingScheduleValue(startTime: TimeInterval($0.minutes * 60), value: Double($0.rate)) }
                 ) {
                     self.pumpInitialSettings.basalSchedule = schedule
                 }

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -964,7 +964,7 @@ extension Home {
                 } else {
                     PumpConfig.PumpSetupView(
                         pumpType: state.setupPumpType,
-                        pumpInitialSettings: PumpConfig.PumpInitialSettings.default,
+                        pumpInitialSettings: state.pumpInitialSettings,
                         bluetoothManager: state.provider.apsManager.bluetoothManager!,
                         completionDelegate: state,
                         setupDelegate: state

--- a/Trio/Sources/Modules/PumpConfig/PumpConfigDataFlow.swift
+++ b/Trio/Sources/Modules/PumpConfig/PumpConfigDataFlow.swift
@@ -14,9 +14,9 @@ enum PumpConfig {
     }
 
     struct PumpInitialSettings {
-        let maxBolusUnits: Double
-        let maxBasalRateUnitsPerHour: Double
-        let basalSchedule: BasalRateSchedule
+        var maxBolusUnits: Double
+        var maxBasalRateUnitsPerHour: Double
+        var basalSchedule: BasalRateSchedule
 
         static let `default` = PumpInitialSettings(
             maxBolusUnits: 10,


### PR DESCRIPTION
closes #845 

Current dev branch, always uses the `default` pumpInitialSettings. In this PR, this is reworked to the actual pump settings. This struct will stay up-to-date by piggybacking on the subscribers already in place