### PR TITLE
Don't wipe saved Pump Manager state if PM fails to initialize

### DIFF
--- a/Trio/Sources/APS/DeviceDataManager.swift
+++ b/Trio/Sources/APS/DeviceDataManager.swift
@@ -77,11 +77,15 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
 
     var pumpManager: PumpManagerUI? {
         didSet {
-            pumpManager?.pumpManagerDelegate = self
-            pumpManager?.delegateQueue = processQueue
-            rawPumpManager = pumpManager?.rawValue
-            UserDefaults.standard.clearLegacyPumpManagerRawValue()
             if let pumpManager = pumpManager {
+                pumpManager.pumpManagerDelegate = self
+                pumpManager.delegateQueue = processQueue
+
+                /// Since the pump manager has been successfully instantiated from its saved state,
+                /// copy its rawValue to rawPumpManager which will be saved to persistant storage.
+                rawPumpManager = pumpManager.rawValue
+                UserDefaults.standard.clearLegacyPumpManagerRawValue()
+
                 pumpDisplayState.value = PumpDisplayState(name: pumpManager.localizedTitle, image: pumpManager.smallImage)
                 pumpName.send(pumpManager.localizedTitle)
 


### PR DESCRIPTION
Only overwrite the saved Pump Manager state kept in persistent storage after successfully instantiating the PM to avoid permanently destroying the PM state in situations like booting an alternate Trio image without the needed PM support or with a buggy PM implementation.