### PR TITLE
Allow 0.025 U bolus increments for MiniMed x23 and x54 pumps

### DIFF
--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -563,7 +563,8 @@ import WatchConnectivity
 
         if let bolusIncrement = message[WatchMessageKeys.bolusIncrement] {
             if let decimalValue = (bolusIncrement as? NSNumber)?.decimalValue {
-                self.bolusIncrement = decimalValue
+                // limit minimum to 0.05 to avoid dealing with 0.025 increments
+                self.bolusIncrement = max(decimalValue, 0.05)
             }
         }
 

--- a/Trio/Sources/APS/DeviceDataManager.swift
+++ b/Trio/Sources/APS/DeviceDataManager.swift
@@ -102,7 +102,7 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
                         )
                 )
                 modifiedPreferences
-                    .bolusIncrement = bolusIncrement
+                    .bolusIncrement = bolusIncrement > 0 ? bolusIncrement : 0.1
                 storage.save(modifiedPreferences, as: OpenAPS.Settings.preferences)
 
                 if let omnipod = pumpManager as? OmnipodPumpManager {

--- a/Trio/Sources/APS/DeviceDataManager.swift
+++ b/Trio/Sources/APS/DeviceDataManager.swift
@@ -102,7 +102,7 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
                         )
                 )
                 modifiedPreferences
-                    .bolusIncrement = bolusIncrement != 0.025 ? bolusIncrement : 0.1
+                    .bolusIncrement = bolusIncrement
                 storage.save(modifiedPreferences, as: OpenAPS.Settings.preferences)
 
                 if let omnipod = pumpManager as? OmnipodPumpManager {

--- a/Trio/Sources/Helpers/Formatters.swift
+++ b/Trio/Sources/Helpers/Formatters.swift
@@ -37,6 +37,14 @@ extension Formatter {
         return formatter
     }()
 
+    static let decimalFormatterWithThreeFractionDigits: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = .current
+        formatter.maximumFractionDigits = 3
+        return formatter
+    }()
+
     static let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.timeStyle = .short

--- a/Trio/Sources/Models/Preferences.swift
+++ b/Trio/Sources/Models/Preferences.swift
@@ -253,7 +253,7 @@ extension Preferences: Decodable {
         }
 
         if let bolusIncrement = try? container.decode(Decimal.self, forKey: .bolusIncrement) {
-            preferences.bolusIncrement = bolusIncrement
+            preferences.bolusIncrement = bolusIncrement > 0 ? bolusIncrement : 0.1
         }
 
         if let curve = try? container.decode(InsulinCurve.self, forKey: .curve) {

--- a/Trio/Sources/Modules/DataTable/View/DataTableRootView.swift
+++ b/Trio/Sources/Modules/DataTable/View/DataTableRootView.swift
@@ -621,7 +621,7 @@ extension DataTable {
                     Image(systemName: "circle.fill").foregroundColor(Color.insulin)
                     Text(bolus.isSMB ? "SMB" : item.type ?? "Bolus")
                     Text(
-                        (Formatter.decimalFormatterWithTwoFractionDigits.string(from: amount) ?? "0") +
+                        (Formatter.decimalFormatterWithThreeFractionDigits.string(from: amount) ?? "0") +
                             String(localized: " U", comment: "Insulin unit")
                     )
                     .foregroundColor(.secondary)
@@ -632,7 +632,7 @@ extension DataTable {
                     Image(systemName: "circle.fill").foregroundColor(Color.insulin.opacity(0.4))
                     Text("Temp Basal")
                     Text(
-                        (Formatter.decimalFormatterWithTwoFractionDigits.string(from: rate) ?? "0") +
+                        (Formatter.decimalFormatterWithThreeFractionDigits.string(from: rate) ?? "0") +
                             String(localized: " U/hr", comment: "Unit insulin per hour")
                     )
                     .foregroundColor(.secondary)
@@ -657,7 +657,7 @@ extension DataTable {
                             alertTitle = String(localized: "Delete Insulin?", comment: "Alert title for deleting insulin")
                             alertMessage = Formatter.dateFormatter
                                 .string(from: item.timestamp ?? Date()) + ", " +
-                                (Formatter.decimalFormatterWithTwoFractionDigits.string(from: item.bolus?.amount ?? 0) ?? "0") +
+                                (Formatter.decimalFormatterWithThreeFractionDigits.string(from: item.bolus?.amount ?? 0) ?? "0") +
                                 String(localized: " U", comment: "Insulin unit")
 
                             if let bolus = item.bolus {

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -54,11 +54,17 @@ extension Home {
         )) var latestTempTarget: FetchedResults<TempTargetStored>
 
         var bolusProgressFormatter: NumberFormatter {
+            let fractionDigits: Int = switch state.settingsManager.preferences.bolusIncrement {
+            case 0.1: 1
+            case 0.025: 3
+            default: 2
+            }
+
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
             formatter.minimum = 0
-            formatter.maximumFractionDigits = state.settingsManager.preferences.bolusIncrement > 0.05 ? 1 : 2
-            formatter.minimumFractionDigits = state.settingsManager.preferences.bolusIncrement > 0.05 ? 1 : 2
+            formatter.maximumFractionDigits = fractionDigits
+            formatter.minimumFractionDigits = fractionDigits
             formatter.allowsFloats = true
             formatter.roundingIncrement = Double(state.settingsManager.preferences.bolusIncrement) as NSNumber
             return formatter
@@ -188,7 +194,7 @@ extension Home {
                 rate = tempRate
             }
 
-            let rateString = Formatter.decimalFormatterWithTwoFractionDigits.string(from: rate) ?? "0"
+            let rateString = Formatter.decimalFormatterWithThreeFractionDigits.string(from: rate) ?? "0"
             return rateString + String(localized: " U/hr", comment: "Unit per hour with space") +
                 manualBasalString
         }
@@ -768,7 +774,7 @@ extension Home {
                 let bolusString =
                     (bolusProgressFormatter.string(from: bolusFraction as NSNumber) ?? "0")
                         + String(localized: " of ", comment: "Bolus string partial message: 'x U of y U' in home view") +
-                        (Formatter.decimalFormatterWithTwoFractionDigits.string(from: bolusTotal as NSNumber) ?? "0")
+                        (Formatter.decimalFormatterWithThreeFractionDigits.string(from: bolusTotal as NSNumber) ?? "0")
                         + String(localized: " U", comment: "Insulin unit")
 
                 ZStack {

--- a/Trio/Sources/Modules/Onboarding/OnboardingStateModel.swift
+++ b/Trio/Sources/Modules/Onboarding/OnboardingStateModel.swift
@@ -781,7 +781,7 @@ extension Onboarding {
                                 .bolusIncrement
                         )
                 )
-                preferences.bolusIncrement = bolusIncrement != 0.025 ? bolusIncrement : 0.1
+                preferences.bolusIncrement = bolusIncrement
             }
 
             settingsManager.preferences = preferences

--- a/Trio/Sources/Modules/Onboarding/OnboardingStateModel.swift
+++ b/Trio/Sources/Modules/Onboarding/OnboardingStateModel.swift
@@ -781,7 +781,7 @@ extension Onboarding {
                                 .bolusIncrement
                         )
                 )
-                preferences.bolusIncrement = bolusIncrement
+                preferences.bolusIncrement = bolusIncrement > 0 ? bolusIncrement : 0.1
             }
 
             settingsManager.preferences = preferences

--- a/Trio/Sources/Modules/Treatments/View/PopupView.swift
+++ b/Trio/Sources/Modules/Treatments/View/PopupView.swift
@@ -915,7 +915,7 @@ struct PopupView: View {
 
                     // Final insulin recommendation
                     HStack(alignment: .firstTextBaseline, spacing: 4) {
-                        Text(insulinFormatter(state.insulinCalculated))
+                        Text(insulinFormatter(state.insulinCalculated, .down, true))
                             .largeSolutionStyle()
                             .foregroundStyle(state.insulinCalculated > 0 ? Color.accentColor : .primary)
 
@@ -939,19 +939,24 @@ struct PopupView: View {
     /// - Parameters:
     ///   - value: The insulin value to format
     ///   - roundingMode: The rounding mode to apply (default: .down for conservative dosing)
+    ///   - roundedForPump: Use a max of 3 fraction digits when rounding for pump to accomidate for 0.025 U increments if applicable
     /// - Returns: A formatted string with 2 decimal places
-    private func insulinFormatter(_ value: Decimal, _ roundingMode: NSDecimalNumber.RoundingMode = .down) -> String {
+    private func insulinFormatter(
+        _ value: Decimal,
+        _ roundingMode: NSDecimalNumber.RoundingMode = .down,
+        _ roundedForPump: Bool = false
+    ) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.minimumFractionDigits = 2
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = roundedForPump ? 3 : 2
         formatter.locale = Locale.current
 
         // Create a decimal handler with the specified rounding behavior.
-        // Always rounds to 2 decimal places (0.01 U precision).
+        // Rounds to 2 decimal places (0.01 U precision), except when rounding for pump
         let handler = NSDecimalNumberHandler(
             roundingMode: roundingMode,
-            scale: 2,
+            scale: roundedForPump ? 3 : 2,
             raiseOnExactness: false,
             raiseOnOverflow: false,
             raiseOnUnderflow: false,

--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -37,7 +37,7 @@ extension Treatments {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
             formatter.maximumIntegerDigits = 2
-            formatter.maximumFractionDigits = 2
+            formatter.maximumFractionDigits = 3
             return formatter
         }
 


### PR DESCRIPTION
The basal and bolus increments for compatible MiniMed (Medtronic) pumps vary by model.

|Pump Model  |Basal increments  |Bolus increments  |Range  |
|---------|---------|---------|---------|
|515/715</br>and</br>522/722     |  0.05</br>0.1       |    0.1</br>0.1     | deliveries of less than 10 units</br>greater than 10 units        |
|523/723</br>and</br>554/754     |  0.025</br>0.05</br>0.1       |   0.025 </br>0.05 </br>0.1      | between 0.025 to 0.975 units</br>between 1 to 9.95 units</br>greater than 10 units        |

Prior to this PR, Trio used a bolus increment of 0.1 U for all MiniMed pumps, but this PR sets bolus increment to 0.025 U for x23 and x54 pumps.

Also included in this PR is expanding the fraction digits displayed to 3 digits for:
* Bolus progress and current basal rate in Main
* SMB, Bolus, and Temp Basal in History
* Recommendation and Bolus in Add Treatments
* Final recommended bolus in Bolus Calculator Details

Increments of Watch bolus view are capped at 0.05 U to improve user experience.

Bolus value labels on the main chart are also kept at a maximum of two fraction digits, to avoid clutter.

<img width="333" src="https://github.com/user-attachments/assets/9fada121-8452-4eaf-888d-0bf13f03c159" />
<img width="333" src="https://github.com/user-attachments/assets/b3b65393-8f7c-4205-8088-df3a45e072a0" />
<img width="333" src="https://github.com/user-attachments/assets/1e9cf83b-b75e-4e9d-9986-8dde104eca66" />
<img width="333" src="https://github.com/user-attachments/assets/31ab9af4-c675-44a8-8f5d-86cb8d73b4f8" />

The bolus calculator rounds down to the nearest valid bolus volume, but Oref just rounds SMBs based on the smallest possible bolus increment, so for SMBs > 1 U, it might still try to issue an invalid SMB amount. This does not seem to be an issue, as Trio just rounds it to a valid amount.

<img width="600" src="https://github.com/user-attachments/assets/5674653d-de6d-49ad-8b4a-e79771794587" />
