### PR TITLE
Convert IOB and COB from Hstack to Vstack on Watch

### DIFF
--- a/Trio Watch App Extension/Views/TrioMainWatchView.swift
+++ b/Trio Watch App Extension/Views/TrioMainWatchView.swift
@@ -111,22 +111,26 @@ struct TrioMainWatchView: View {
             }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    HStack {
+                    VStack {
                         Image(systemName: "syringe.fill")
                             .foregroundStyle(Color.insulin)
 
                         Text(isWatchStateDated || isSessionUnreachable ? "--" : state.iob ?? "--")
                             .foregroundStyle(isWatchStateDated ? Color.secondary : Color.white)
+                            .frame(alignment: .leading)
+                            .minimumScaleFactor(0.5)
                     }.font(.caption2)
                 }
 
                 ToolbarItem(placement: .topBarTrailing) {
-                    HStack {
-                        Text(isWatchStateDated || isSessionUnreachable ? "--" : state.cob ?? "--")
-                            .foregroundStyle(isWatchStateDated || isSessionUnreachable ? Color.secondary : Color.white)
-
+                    VStack {
                         Image(systemName: "fork.knife")
                             .foregroundStyle(Color.orange)
+
+                        Text(isWatchStateDated || isSessionUnreachable ? "--" : state.cob ?? "--")
+                            .foregroundStyle(isWatchStateDated || isSessionUnreachable ? Color.secondary : Color.white)
+                            .frame(alignment: .trailing)
+                            .minimumScaleFactor(0.5)
                     }.font(.caption2)
                 }
 


### PR DESCRIPTION
Convert IOB and COB from Hstack to Vstack on Watch and allow to dynamically scale font size down 50 %.

* Addresses Issue #868 

Tested in simulator with watchOS 26.1 on Series 11 (46mm) and Series 8 (41mm)

<img width="500" src="https://github.com/user-attachments/assets/a9d3eff7-18c4-42cb-b23d-db126a82b3d5" />
<br>
<img width="500"  src="https://github.com/user-attachments/assets/bcc3cba4-5ff1-430b-91ad-519b9c3e08e9" />
