### PR TITLE
Improve time remaining string for <12 hrs #865

### DIFF
--- a/Trio/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/PumpView.swift
@@ -142,7 +142,12 @@ struct PumpView: View {
         }
 
         if hours >= 1 {
-            return "\(hours)" + String(localized: "h", comment: "abbreviation for hours")
+            var remainingHoursString = "\(hours)" + String(localized: "h", comment: "abbreviation for hours")
+            if hours < 12 {
+                remainingHoursString += " " + "\(minutes)" +
+                String(localized: "m", comment: "abbreviation for minutes")
+            }
+            return remainingHoursString
         }
 
         return "\(minutes)" + String(localized: "m", comment: "abbreviation for minutes")

--- a/Trio/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/PumpView.swift
@@ -145,7 +145,7 @@ struct PumpView: View {
             var remainingHoursString = "\(hours)" + String(localized: "h", comment: "abbreviation for hours")
             if hours < 12 {
                 remainingHoursString += " " + "\(minutes)" +
-                String(localized: "m", comment: "abbreviation for minutes")
+                    String(localized: "m", comment: "abbreviation for minutes")
             }
             return remainingHoursString
         }


### PR DESCRIPTION
This PR refines the pod time-remaining display to be more accurate and less confusing, especially right after the 12-hour reminder.

### Changes

* For **1–11 hours remaining**, the UI now shows **hours + minutes** (e.g. `11h 58m`).
* For **>=12 hours**, behavior is unchanged, show **hours only** (e.g. `12h`).
* For **<1 hour**, still show **minutes only** (e.g. `47m`).

Addresses #865.
