### PR TITLE
Fix Trio Watch identifiers in fastlane documentation

### DIFF
--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -180,8 +180,8 @@ _Referring to the table below, tap on each **IDENTIFIER** that has a different *
 1. Go to [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) on the Apple developer site.
 1. Repeat this step for these three Identifier **NAMES** - refer to the [Table](#table-of-identifiers) above if your Names look different; if they do, see [Optional: Identifier Description Modification](#optional-identifier-description-modification)
     * Trio
-    * Trio Watch
-    * Trio WatchKit Extension
+    * Trio Watch App
+    * Trio Watch Complication
 1. Click on the **IDENTIFIER** row.
 1. Scroll down to the "App Groups" capabilies row, click on the "Configure" (or "Edit") button.
 1. Select the "Trio App Group" _(yes, "Trio App Group" is correct)_


### PR DESCRIPTION
Updated Identifier names for the Trio Watch section.