### PR TITLE
Therapy profiles

### DIFF
--- a/Documents/TherapyProfiles_Implementation.md
+++ b/Documents/TherapyProfiles_Implementation.md
@@ -1,0 +1,279 @@
+# Therapy Profiles Implementation Plan
+
+## Overview
+
+Implement weekday/weekend therapy profiles for Trio, allowing users to create multiple named therapy profiles with different settings that automatically switch based on the day of week.
+
+## Requirements
+
+1. **Multiple Profiles**: Up to 10 named therapy profiles
+2. **Complete Settings Per Profile**:
+   - Basal rates
+   - Insulin Sensitivity Factors (ISF)
+   - Carb Ratios
+   - Glucose Targets
+3. **Day Assignment**: User-selectable days of the week per profile
+4. **Automatic Switching**: Profile switches at midnight based on day of week
+5. **Manual Override**: Ability to manually activate a different profile for the current day
+6. **Notifications**: In-app banner when profile switches (not push notifications)
+7. **History Logging**: Log all profile switches with timestamps and reasons
+8. **Nightscout Sync**: Sync profile changes to Nightscout
+9. **No Watch App**: Watch integration not required at this time
+
+## Architecture
+
+### Directory Structure (Trio v0.6.0)
+
+```
+Trio/Sources/
+├── Models/
+│   ├── Weekday.swift                    # Days of week enum
+│   ├── TherapyProfile.swift             # Profile model with all settings
+│   └── ProfileSwitchEvent.swift         # Switch history event
+├── Services/
+│   └── ProfileManager/
+│       ├── ProfileManager.swift         # Protocol
+│       └── BaseProfileManager.swift     # Implementation
+├── Modules/
+│   ├── TherapyProfileList/
+│   │   ├── TherapyProfileListDataFlow.swift
+│   │   ├── TherapyProfileListProvider.swift
+│   │   ├── TherapyProfileListStateModel.swift
+│   │   └── View/
+│   │       └── TherapyProfileListRootView.swift
+│   └── TherapyProfileEditor/
+│       ├── TherapyProfileEditorDataFlow.swift
+│       ├── TherapyProfileEditorProvider.swift
+│       ├── TherapyProfileEditorStateModel.swift
+│       └── View/
+│           └── TherapyProfileEditorRootView.swift
+└── Views/
+    ├── WeekdayPickerView.swift          # Multi-select day picker
+    └── ProfileSwitchBannerView.swift    # Switch notification banner
+```
+
+### Storage Files
+
+```
+settings/
+├── therapy_profiles.json       # Array of TherapyProfile
+├── active_profile_id.json      # UUID string of active profile
+└── profile_switch_history.json # Array of ProfileSwitchEvent
+```
+
+## Data Models
+
+### Weekday
+```swift
+enum Weekday: Int, CaseIterable, Codable, Comparable, Identifiable {
+    case sunday = 1
+    case monday = 2
+    case tuesday = 3
+    case wednesday = 4
+    case thursday = 5
+    case friday = 6
+    case saturday = 7
+
+    static var today: Weekday
+    static var weekdays: Set<Weekday>  // Mon-Fri
+    static var weekend: Set<Weekday>   // Sat-Sun
+
+    var localizedName: String
+    var shortName: String
+}
+```
+
+### TherapyProfile
+```swift
+struct TherapyProfile: JSON, Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var activeDays: Set<Weekday>
+    var basalProfile: [BasalProfileEntry]
+    var insulinSensitivities: InsulinSensitivities
+    var carbRatios: CarbRatios
+    var bgTargets: BGTargets
+    var isDefault: Bool
+    var createdAt: Date
+    var lastModified: Date
+
+    static let maxProfiles = 10
+}
+```
+
+### ProfileSwitchEvent
+```swift
+struct ProfileSwitchEvent: JSON, Identifiable, Equatable {
+    let id: UUID
+    let fromProfileId: UUID?
+    let fromProfileName: String?
+    let toProfileId: UUID
+    let toProfileName: String
+    let switchedAt: Date
+    let weekday: Weekday
+    let reason: SwitchReason
+    var acknowledged: Bool
+
+    enum SwitchReason: String, Codable {
+        case scheduled      // Automatic midnight switch
+        case manual         // User activated profile
+        case manualOverride // User overrode scheduled profile for today
+    }
+}
+```
+
+## ProfileManager Protocol
+
+```swift
+protocol ProfileManager: AnyObject {
+    // Properties
+    var profiles: [TherapyProfile] { get }
+    var activeProfile: TherapyProfile { get }
+    var activeProfilePublisher: AnyPublisher<TherapyProfile, Never> { get }
+    var pendingSwitchNotification: ProfileSwitchEvent? { get set }
+    var pendingSwitchNotificationPublisher: AnyPublisher<ProfileSwitchEvent?, Never> { get }
+    var switchHistory: [ProfileSwitchEvent] { get }
+    var isManualOverrideActive: Bool { get }
+
+    // Profile Management
+    func createProfile(name: String, copyFrom: TherapyProfile?) -> TherapyProfile
+    func updateProfile(_ profile: TherapyProfile)
+    func deleteProfile(id: UUID) throws
+
+    // Activation
+    func activateProfile(id: UUID, reason: ProfileSwitchEvent.SwitchReason)
+    func activateProfileAsOverride(id: UUID)
+    func clearManualOverride()
+
+    // Scheduling
+    func checkForScheduledSwitch()
+    func profileForDay(_ weekday: Weekday) -> TherapyProfile?
+
+    // Notifications
+    func acknowledgeSwitchNotification()
+}
+```
+
+## Key Implementation Details
+
+### Migration from Single Profile
+
+When user first opens app after update:
+1. Check if `therapy_profiles.json` exists
+2. If not, create default profile from existing settings files:
+   - `basal_profile.json`
+   - `insulin_sensitivities.json`
+   - `carb_ratios.json`
+   - `bg_targets.json`
+3. Mark as default profile, assign all days
+
+### Day Uniqueness
+
+- Each day can only be assigned to ONE profile
+- When assigning a day to profile A, automatically remove it from profile B
+- UI shows conflicts/warnings before saving
+
+### Midnight Switching Logic
+
+Called from the main loop (`APSManager`):
+1. Check if manual override is active and still valid (same day)
+2. If override expired, clear it
+3. Check if already switched today
+4. Find profile assigned to current weekday
+5. If different from active, switch and log event
+
+### Profile Activation Flow
+
+1. Save active profile ID
+2. Write settings to individual files (for OpenAPS compatibility):
+   - `basal_profile.json`
+   - `insulin_sensitivities.json`
+   - `carb_ratios.json`
+   - `bg_targets.json`
+3. Create switch event
+4. Notify observers
+5. Set pending notification for banner
+
+### In-App Banner
+
+- Shown when app enters foreground after a switch
+- Auto-dismisses after 8 seconds
+- Shows "Profile switched to [name]" with reason
+- Dismiss button for immediate dismissal
+
+## UI Flow
+
+### Settings Menu
+```
+Settings
+└── Configuration
+    └── Therapy Profiles  →  TherapyProfileListRootView
+```
+
+### Profile List View
+- List of all profiles with active indicator
+- Tap to edit
+- Swipe to delete (except default/active)
+- "Add Profile" button (if < 10)
+- "Activate" button per profile
+- "Override for Today" option
+
+### Profile Editor View
+- Name field
+- Day picker (multi-select with conflict warnings)
+- Sections for each setting type:
+  - Basal Rates → existing editor
+  - ISF → existing editor
+  - Carb Ratios → existing editor
+  - Glucose Targets → existing editor
+- "Set as Default" toggle
+- Save/Cancel buttons
+
+## Validation Rules
+
+1. Profile name must be unique and non-empty
+2. Default profile cannot be deleted
+3. Active profile cannot be deleted
+4. At least one profile must exist
+5. Maximum 10 profiles
+6. Days are automatically deduplicated across profiles
+
+## Files to Modify
+
+1. **Trio/Sources/APS/OpenAPS/Constants.swift** - Add file paths
+2. **Trio/Sources/Assemblies/StorageAssembly.swift** - Register ProfileManager
+3. **Trio/Sources/APS/APSManager.swift** - Add profile switch check in loop
+4. **Trio/Sources/Router/Screen.swift** - Add new screen cases
+5. **Trio/Sources/Modules/Settings/View/SettingsRootView.swift** - Add menu entry
+6. **Trio/Sources/Modules/Home/HomeStateModel.swift** - Subscribe to profile notifications
+7. **Trio/Sources/Modules/Home/View/HomeRootView.swift** - Add banner overlay
+8. **Trio.xcodeproj/project.pbxproj** - Add all new files
+
+## Testing Checklist
+
+- [ ] Create profile with all settings
+- [ ] Edit profile name and days
+- [ ] Delete non-active profile
+- [ ] Verify cannot delete active/default profile
+- [ ] Automatic midnight switch (simulate by changing date)
+- [ ] Manual profile activation
+- [ ] Manual override for today
+- [ ] Banner appears on foreground after switch
+- [ ] Banner auto-dismisses
+- [ ] History logging accurate
+- [ ] Migration from single profile system
+- [ ] Day uniqueness enforced
+- [ ] Profile limit enforced (max 10)
+
+## Nightscout Integration
+
+Profile switches will be synced to Nightscout as:
+- Profile switch treatment entries
+- Updated profile store with all therapy profiles
+
+## Future Considerations
+
+- Watch app support
+- Time-based switching (not just day-based)
+- Profile scheduling calendar view
+- Profile import/export

--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		118DF76D2C5ECBC60067FEB7 /* OverridePresetEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118DF7672C5ECBC60067FEB7 /* OverridePresetEntity.swift */; };
 		118DF76E2C5ECBC60067FEB7 /* OverridePresetsIntentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118DF7682C5ECBC60067FEB7 /* OverridePresetsIntentRequest.swift */; };
 		17A9D0899046B45E87834820 /* CarbRatioEditorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8D5F457B5AFF763F8CF3DF /* CarbRatioEditorProvider.swift */; };
+		18DDA1C6A9A1D7F2FBB0F8A3 /* ProfileSwitchEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2593404672BB08B4E9D1B22D /* ProfileSwitchEvent.swift */; };
 		19012CDC291D2CB900FB8210 /* LoopStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19012CDB291D2CB900FB8210 /* LoopStats.swift */; };
 		190EBCC429FF136900BA767D /* UserInterfaceSettingsDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190EBCC329FF136900BA767D /* UserInterfaceSettingsDataFlow.swift */; };
 		190EBCC629FF138000BA767D /* UserInterfaceSettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190EBCC529FF138000BA767D /* UserInterfaceSettingsProvider.swift */; };
@@ -57,7 +58,10 @@
 		1D845DF2E3324130E1D95E67 /* DataTableProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60744C3E9BB3652895C908CC /* DataTableProvider.swift */; };
 		23888883D4EA091C88480FF2 /* TreatmentsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19984D62EFC0035A9E9644D /* TreatmentsProvider.swift */; };
 		3171D2818C7C72CD1584BB5E /* GlucoseNotificationSettingsStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC2C6489D29ECCCAD78E0721 /* GlucoseNotificationSettingsStateModel.swift */; };
-		320D030F724170A637F06D50 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		320D030F724170A637F06D50 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
+		32A17501E640D0B396A04D1E /* TherapyProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18ED8EA2AF12F8301B9CC005 /* TherapyProfile.swift */; };
+		36E674C7925039164DE63BF7 /* BaseProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30B146108512F66E88E846CC /* BaseProfileManager.swift */; };
+		376C7FC61DD607DDF1D4CDFF /* WeekdayPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E41F65D7FA7986001C975515 /* WeekdayPickerView.swift */; };
 		3811DE0B25C9D32F00A708ED /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE0725C9D32E00A708ED /* BaseView.swift */; };
 		3811DE0C25C9D32F00A708ED /* BaseProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE0825C9D32F00A708ED /* BaseProvider.swift */; };
 		3811DE1025C9D37700A708ED /* Swinject in Frameworks */ = {isa = PBXBuildFile; productRef = 3811DE0F25C9D37700A708ED /* Swinject */; };
@@ -262,6 +266,7 @@
 		3E28F2AB2EB5337F00FB9EEB /* ConnectIQ in Frameworks */ = {isa = PBXBuildFile; productRef = 3E28F2AA2EB5337F00FB9EEB /* ConnectIQ */; };
 		45252C95D220E796FDB3B022 /* ConfigEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8A87AA037BD079BA3528BA /* ConfigEditorDataFlow.swift */; };
 		45717281F743594AA9D87191 /* ConfigEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920DDB21E5D0EB813197500D /* ConfigEditorRootView.swift */; };
+		4751132C9ED4D97A28EC29CC /* TherapyProfileListRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7254020C7405D49944F2A362 /* TherapyProfileListRootView.swift */; };
 		491D6FBD2D56741C00C49F67 /* TempTargetStored+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D6FBC2D56741C00C49F67 /* TempTargetStored+CoreDataProperties.swift */; };
 		491D6FBE2D56741C00C49F67 /* TempTargetRunStored+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D6FB92D56741C00C49F67 /* TempTargetRunStored+CoreDataClass.swift */; };
 		491D6FBF2D56741C00C49F67 /* TempTargetRunStored+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D6FBA2D56741C00C49F67 /* TempTargetRunStored+CoreDataProperties.swift */; };
@@ -302,6 +307,7 @@
 		58D08B382C8DFB6000AA37D3 /* BasalChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D08B372C8DFB6000AA37D3 /* BasalChart.swift */; };
 		58D08B3A2C8DFECD00AA37D3 /* TempTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D08B392C8DFECD00AA37D3 /* TempTargets.swift */; };
 		58F107742BD1A4D000B1A680 /* Determination+helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F107732BD1A4D000B1A680 /* Determination+helper.swift */; };
+		599C7B08152DD755FEAFE2CD /* TherapyProfileEditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50F1AF1D917100604E5DD84 /* TherapyProfileEditorStateModel.swift */; };
 		5A2325522BFCBF55003518CA /* NightscoutUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2325512BFCBF55003518CA /* NightscoutUploadView.swift */; };
 		5A2325542BFCBF66003518CA /* NightscoutFetchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2325532BFCBF65003518CA /* NightscoutFetchView.swift */; };
 		5A2325582BFCC168003518CA /* NightscoutConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2325572BFCC168003518CA /* NightscoutConnectView.swift */; };
@@ -322,7 +328,7 @@
 		6B1F539F9FF75646D1606066 /* SnoozeDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A708CDB546692C2230B385 /* SnoozeDataFlow.swift */; };
 		6BCF84DD2B16843A003AD46E /* LiveActitiyAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCF84DC2B16843A003AD46E /* LiveActitiyAttributes.swift */; };
 		6BCF84DE2B16843A003AD46E /* LiveActitiyAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCF84DC2B16843A003AD46E /* LiveActitiyAttributes.swift */; };
-		6EADD581738D64431902AC0A /* (null) in Sources */ = {isa = PBXBuildFile; };
+		6EADD581738D64431902AC0A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		6FFAE524D1D9C262F2407CAE /* SnoozeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAE81192B118804DCD23034 /* SnoozeProvider.swift */; };
 		711C0CB42CAABE788916BC9D /* ManualTempBasalDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96653287EDB276A111288305 /* ManualTempBasalDataFlow.swift */; };
 		715120D22D3C2BB4005D9FB6 /* GlucoseNotificationsOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715120D12D3C2B84005D9FB6 /* GlucoseNotificationsOption.swift */; };
@@ -331,6 +337,8 @@
 		7BCFACB97C821041BA43A114 /* ManualTempBasalRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C377490C77661D75E8C50649 /* ManualTempBasalRootView.swift */; };
 		7F7B756BE8543965D9FDF1A2 /* DataTableDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A401509D21F7F35D4E109EDA /* DataTableDataFlow.swift */; };
 		8194B80890CDD6A3C13B0FEE /* SnoozeStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26904AACA8D9C15D229D675 /* SnoozeStateModel.swift */; };
+		86F8F6CB10ECDFD2134A69F6 /* ProfileSwitchBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26FF508B6A5D8FB0D60275A /* ProfileSwitchBannerView.swift */; };
+		8765F676F6F301C841FECF52 /* TherapyProfileEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4901ED795DB4552A4329842A /* TherapyProfileEditorRootView.swift */; };
 		88AB39B23C9552BD6E0C9461 /* ISFEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBB3BAE7494CB771ABAC7B8B /* ISFEditorRootView.swift */; };
 		8A91342A2D63D9A1007F8874 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8A9134292D63D9A1007F8874 /* Localizable.xcstrings */; };
 		8A91342C2D63D9A2007F8874 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 8A91342B2D63D9A2007F8874 /* InfoPlist.xcstrings */; };
@@ -338,9 +346,26 @@
 		9702FF92A09C53942F20D7EA /* TargetsEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD795BA46B193644D48138C /* TargetsEditorRootView.swift */; };
 		9825E5E923F0B8FA80C8C7C7 /* NightscoutConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A48AE3AC813A49A517846A /* NightscoutConfigStateModel.swift */; };
 		98641AF4F92123DA668AB931 /* CarbRatioEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BDC6993C1087310EDFC428 /* CarbRatioEditorRootView.swift */; };
+		993FC470FFDA65FC95D65B3B /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FEFD9852C2751F2B74D71B3 /* Weekday.swift */; };
+		A1B1C1D1E1F101010101A1B1 /* AIInsightsConfigDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1A1 /* AIInsightsConfigDataFlow.swift */; };
+		A1B1C1D1E1F101010101A1B2 /* AIInsightsConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1A2 /* AIInsightsConfigStateModel.swift */; };
+		A1B1C1D1E1F101010101A1B3 /* AIInsightsConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1A3 /* AIInsightsConfigProvider.swift */; };
+		A1B1C1D1E1F101010101A1B4 /* AIInsightsConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1A4 /* AIInsightsConfigRootView.swift */; };
+		A1B1C1D1E1F101010101A1B5 /* ClaudeAPIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1A5 /* ClaudeAPIService.swift */; };
+		A1B1C1D1E1F101010101A1B6 /* HealthDataExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1A6 /* HealthDataExporter.swift */; };
+		A1B1C1D1E1F101010101A1B7 /* NightscoutDataFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1A7 /* NightscoutDataFetcher.swift */; };
+		A1B1C1D1E1F101010101A1B8 /* MarkdownParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1A8 /* MarkdownParser.swift */; };
+		A1B1C1D1E1F101010101A1B9 /* SavedReportsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1A9 /* SavedReportsManager.swift */; };
+		A1B1C1D1E1F101010101A1BA /* ClaudeOTuneModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1AA /* ClaudeOTuneModels.swift */; };
+		A1B1C1D1E1F101010101A1BB /* ClaudeOTuneProfileService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B1C1D1E1F101010101A1AB /* ClaudeOTuneProfileService.swift */; };
+		A29C54E891CFC09F509F6DE5 /* TherapyProfileListStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C9F7352C6C00A9970A4790 /* TherapyProfileListStateModel.swift */; };
 		A33352ED40476125EBAC6EE0 /* CarbRatioEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E22146D3DF4853786C78132 /* CarbRatioEditorDataFlow.swift */; };
+		AA2579CD7BD92C2C2DE6F94F /* TherapyProfileListProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CF6A38074A1E05033BA704 /* TherapyProfileListProvider.swift */; };
 		AD3D2CD42CD01B9EB8F26522 /* PumpConfigDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF65DA88F972B56090AD6AC3 /* PumpConfigDataFlow.swift */; };
-		B7C465E9472624D8A2BE2A6A /* (null) in Sources */ = {isa = PBXBuildFile; };
+		B127455A880F4A29CE57DC8A /* TherapyProfileEditorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03CADE5D659AFE6D0385E900 /* TherapyProfileEditorProvider.swift */; };
+		B4D5BC54194298AE9564B450 /* TherapyProfileEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845BF021B868C40808247497 /* TherapyProfileEditorDataFlow.swift */; };
+		B6002AC43008CD3ACE01C3E9 /* ProfileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32D8A4C1E2034FA022A3361 /* ProfileManager.swift */; };
+		B7C465E9472624D8A2BE2A6A /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		B958F1B72BA0711600484851 /* MKRingProgressView in Frameworks */ = {isa = PBXBuildFile; productRef = B958F1B62BA0711600484851 /* MKRingProgressView */; };
 		BA00D96F7B2FF169A06FB530 /* CGMSettingsStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C018D1680307A31C9ED7120 /* CGMSettingsStateModel.swift */; };
 		BD04ECCE2D29952A008C5FEB /* BolusProgressOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD04ECCD2D299522008C5FEB /* BolusProgressOverlay.swift */; };
@@ -714,6 +739,7 @@
 		E592A3792CEEC038009A472C /* ContactImageRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A3712CEEC038009A472C /* ContactImageRootView.swift */; };
 		E592A37A2CEEC038009A472C /* ContactImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E592A3742CEEC038009A472C /* ContactImageProvider.swift */; };
 		E974172296125A5AE99E634C /* PumpConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD22C985B79A2F0D2EA3D9D /* PumpConfigRootView.swift */; };
+		EF05C59A5D494DCA552D485E /* TherapyProfileListDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385A9890F5418D3299CE7F41 /* TherapyProfileListDataFlow.swift */; };
 		F5CA3DB1F9DC8B05792BBFAA /* CGMSettingsDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B5C0607505A38F256BF99A /* CGMSettingsDataFlow.swift */; };
 		F5F7E6C1B7F098F59EB67EC5 /* TargetsEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA49538D56989D8DA6FCF538 /* TargetsEditorDataFlow.swift */; };
 		F816825E28DB441200054060 /* HeartBeatManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F816825D28DB441200054060 /* HeartBeatManager.swift */; };
@@ -727,6 +753,8 @@
 		FE41E4D629463EE20047FD55 /* NightscoutPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */; };
 		FE66D16B291F74F8005D6F77 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */; };
 		FEFFA7A22929FE49007B8193 /* UIDevice+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */; };
+		HME7A7FED7B34D0D8F5BC383 /* HealthMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = HMF49BBBF5CD4A9BBC14CC1F /* HealthMetrics.swift */; };
+		HS65A6D45B1A4FC1B3A02035 /* HealthMetricsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = HS70616C45944CE888DC2C8D /* HealthMetricsService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -839,6 +867,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		03CADE5D659AFE6D0385E900 /* TherapyProfileEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorProvider.swift; path = Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorProvider.swift; sourceTree = "<group>"; };
 		110AEDE02C5193D100615CC9 /* BolusIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BolusIntent.swift; sourceTree = "<group>"; };
 		110AEDE12C5193D100615CC9 /* BolusIntentRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BolusIntentRequest.swift; sourceTree = "<group>"; };
 		110AEDE52C51A0AE00615CC9 /* ShortcutsConfigView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcutsConfigView.swift; sourceTree = "<group>"; };
@@ -849,6 +878,7 @@
 		118DF7652C5ECBC60067FEB7 /* CancelOverrideIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CancelOverrideIntent.swift; sourceTree = "<group>"; };
 		118DF7672C5ECBC60067FEB7 /* OverridePresetEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridePresetEntity.swift; sourceTree = "<group>"; };
 		118DF7682C5ECBC60067FEB7 /* OverridePresetsIntentRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridePresetsIntentRequest.swift; sourceTree = "<group>"; };
+		18ED8EA2AF12F8301B9CC005 /* TherapyProfile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfile.swift; path = Trio/Sources/Models/TherapyProfile.swift; sourceTree = "<group>"; };
 		19012CDB291D2CB900FB8210 /* LoopStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopStats.swift; sourceTree = "<group>"; };
 		190EBCC329FF136900BA767D /* UserInterfaceSettingsDataFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInterfaceSettingsDataFlow.swift; sourceTree = "<group>"; };
 		190EBCC529FF138000BA767D /* UserInterfaceSettingsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInterfaceSettingsProvider.swift; sourceTree = "<group>"; };
@@ -884,8 +914,10 @@
 		1CAE81192B118804DCD23034 /* SnoozeProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnoozeProvider.swift; sourceTree = "<group>"; };
 		223EC0494F55A91E3EA69EF4 /* TreatmentsStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TreatmentsStateModel.swift; sourceTree = "<group>"; };
 		22963BD06A9C83959D4914E4 /* GlucoseNotificationSettingsRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlucoseNotificationSettingsRootView.swift; sourceTree = "<group>"; };
+		2593404672BB08B4E9D1B22D /* ProfileSwitchEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileSwitchEvent.swift; path = Trio/Sources/Models/ProfileSwitchEvent.swift; sourceTree = "<group>"; };
 		2AD22C985B79A2F0D2EA3D9D /* PumpConfigRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PumpConfigRootView.swift; sourceTree = "<group>"; };
 		2F2A13DF0EDEEEDC4106AA2A /* NightscoutConfigDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NightscoutConfigDataFlow.swift; sourceTree = "<group>"; };
+		30B146108512F66E88E846CC /* BaseProfileManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BaseProfileManager.swift; path = Trio/Sources/Services/ProfileManager/BaseProfileManager.swift; sourceTree = "<group>"; };
 		3260468377DA9DB4DEE9AF6D /* GlucoseNotificationSettingsDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlucoseNotificationSettingsDataFlow.swift; sourceTree = "<group>"; };
 		36A708CDB546692C2230B385 /* SnoozeDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnoozeDataFlow.swift; sourceTree = "<group>"; };
 		36F58DDD71F0E795464FA3F0 /* TargetsEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorStateModel.swift; sourceTree = "<group>"; };
@@ -954,6 +986,7 @@
 		38569345270B5DFA0002C50D /* GlucoseSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseSource.swift; sourceTree = "<group>"; };
 		38569346270B5DFB0002C50D /* AppGroupSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppGroupSource.swift; sourceTree = "<group>"; };
 		38569352270B5E350002C50D /* CGMRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGMRootView.swift; sourceTree = "<group>"; };
+		385A9890F5418D3299CE7F41 /* TherapyProfileListDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListDataFlow.swift; path = Trio/Sources/Modules/TherapyProfileList/TherapyProfileListDataFlow.swift; sourceTree = "<group>"; };
 		385CEA8125F23DFD002D6D5B /* NightscoutStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutStatus.swift; sourceTree = "<group>"; };
 		3862CC2D2743F9F700BF832C /* CalendarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarManager.swift; sourceTree = "<group>"; };
 		3870FF4225EC13F40088248F /* BloodGlucose.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BloodGlucose.swift; sourceTree = "<group>"; };
@@ -1088,6 +1121,7 @@
 		3F8A87AA037BD079BA3528BA /* ConfigEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorDataFlow.swift; sourceTree = "<group>"; };
 		42369F66CF91F30624C0B3A6 /* BasalProfileEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorProvider.swift; sourceTree = "<group>"; };
 		44080E4709E3AE4B73054563 /* ConfigEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorProvider.swift; sourceTree = "<group>"; };
+		4901ED795DB4552A4329842A /* TherapyProfileEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorRootView.swift; path = Trio/Sources/Modules/TherapyProfileEditor/View/TherapyProfileEditorRootView.swift; sourceTree = "<group>"; };
 		491D6FB92D56741C00C49F67 /* TempTargetRunStored+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TempTargetRunStored+CoreDataClass.swift"; sourceTree = "<group>"; };
 		491D6FBA2D56741C00C49F67 /* TempTargetRunStored+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TempTargetRunStored+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		491D6FBB2D56741C00C49F67 /* TempTargetStored+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TempTargetStored+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -1095,6 +1129,7 @@
 		49B9B57E2D5768D2009C6B59 /* AdjustmentStored+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdjustmentStored+Helper.swift"; sourceTree = "<group>"; };
 		4DD795BA46B193644D48138C /* TargetsEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorRootView.swift; sourceTree = "<group>"; };
 		505E09DC17A0C3D0AF4B66FE /* ISFEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorStateModel.swift; sourceTree = "<group>"; };
+		53CF6A38074A1E05033BA704 /* TherapyProfileListProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListProvider.swift; path = Trio/Sources/Modules/TherapyProfileList/TherapyProfileListProvider.swift; sourceTree = "<group>"; };
 		581516A32BCED84A00BF67D7 /* DebuggingIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebuggingIdentifiers.swift; sourceTree = "<group>"; };
 		581516A82BCEEDF800BF67D7 /* NSPredicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicates.swift; sourceTree = "<group>"; };
 		581AC4382BE22ED10038760C /* JSONConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONConverter.swift; sourceTree = "<group>"; };
@@ -1133,6 +1168,7 @@
 		5A2325572BFCC168003518CA /* NightscoutConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutConnectView.swift; sourceTree = "<group>"; };
 		5C018D1680307A31C9ED7120 /* CGMSettingsStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CGMSettingsStateModel.swift; sourceTree = "<group>"; };
 		5D5B4F8B4194BB7E260EF251 /* ConfigEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorStateModel.swift; sourceTree = "<group>"; };
+		5FEFD9852C2751F2B74D71B3 /* Weekday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Weekday.swift; path = Trio/Sources/Models/Weekday.swift; sourceTree = "<group>"; };
 		60744C3E9BB3652895C908CC /* DataTableProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableProvider.swift; sourceTree = "<group>"; };
 		64AA5E04A2761F6EEA6568E1 /* CarbRatioEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarbRatioEditorStateModel.swift; sourceTree = "<group>"; };
 		65070A322BFDCB83006F213F /* TidepoolStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolStartView.swift; sourceTree = "<group>"; };
@@ -1150,8 +1186,10 @@
 		6BCF84DC2B16843A003AD46E /* LiveActitiyAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActitiyAttributes.swift; sourceTree = "<group>"; };
 		715120D12D3C2B84005D9FB6 /* GlucoseNotificationsOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseNotificationsOption.swift; sourceTree = "<group>"; };
 		71D44AAA2CA5F5EA0036EE9E /* AlertPermissionsChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertPermissionsChecker.swift; sourceTree = "<group>"; };
+		7254020C7405D49944F2A362 /* TherapyProfileListRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListRootView.swift; path = Trio/Sources/Modules/TherapyProfileList/View/TherapyProfileListRootView.swift; sourceTree = "<group>"; };
 		79BDA519C9B890FD9A5DFCF3 /* ISFEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorDataFlow.swift; sourceTree = "<group>"; };
 		7E22146D3DF4853786C78132 /* CarbRatioEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarbRatioEditorDataFlow.swift; sourceTree = "<group>"; };
+		845BF021B868C40808247497 /* TherapyProfileEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorDataFlow.swift; path = Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorDataFlow.swift; sourceTree = "<group>"; };
 		8782B44544F38F2B2D82C38E /* NightscoutConfigRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NightscoutConfigRootView.swift; sourceTree = "<group>"; };
 		881E04BA5E0A003DE8E0A9C6 /* DataTableRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableRootView.swift; sourceTree = "<group>"; };
 		8A9134292D63D9A1007F8874 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -1162,10 +1200,22 @@
 		9C8D5F457B5AFF763F8CF3DF /* CarbRatioEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarbRatioEditorProvider.swift; sourceTree = "<group>"; };
 		9F9F137F126D9F8DEB799F26 /* ISFEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorProvider.swift; sourceTree = "<group>"; };
 		A0A48AE3AC813A49A517846A /* NightscoutConfigStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NightscoutConfigStateModel.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1A1 /* AIInsightsConfigDataFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIInsightsConfigDataFlow.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1A2 /* AIInsightsConfigStateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIInsightsConfigStateModel.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1A3 /* AIInsightsConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIInsightsConfigProvider.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1A4 /* AIInsightsConfigRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIInsightsConfigRootView.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1A5 /* ClaudeAPIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeAPIService.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1A6 /* HealthDataExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthDataExporter.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1A7 /* NightscoutDataFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutDataFetcher.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1A8 /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1A9 /* SavedReportsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedReportsManager.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1AA /* ClaudeOTuneModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeOTuneModels.swift; sourceTree = "<group>"; };
+		A1B1C1D1E1F101010101A1AB /* ClaudeOTuneProfileService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeOTuneProfileService.swift; sourceTree = "<group>"; };
 		A401509D21F7F35D4E109EDA /* DataTableDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableDataFlow.swift; sourceTree = "<group>"; };
 		A8630D58BDAD6D9C650B9B39 /* PumpConfigProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PumpConfigProvider.swift; sourceTree = "<group>"; };
 		AAFF91130F2FCCC7EBBA11AD /* BasalProfileEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorStateModel.swift; sourceTree = "<group>"; };
 		AF65DA88F972B56090AD6AC3 /* PumpConfigDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PumpConfigDataFlow.swift; sourceTree = "<group>"; };
+		B50F1AF1D917100604E5DD84 /* TherapyProfileEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorStateModel.swift; path = Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift; sourceTree = "<group>"; };
 		B5822B15939E719628E9FF7C /* SnoozeRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnoozeRootView.swift; sourceTree = "<group>"; };
 		B9B5C0607505A38F256BF99A /* CGMSettingsDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CGMSettingsDataFlow.swift; sourceTree = "<group>"; };
 		BA49538D56989D8DA6FCF538 /* TargetsEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorDataFlow.swift; sourceTree = "<group>"; };
@@ -1274,6 +1324,7 @@
 		BDFF7A922D25F97D0016C40C /* TrioWatchAppExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrioWatchAppExtension.swift; sourceTree = "<group>"; };
 		BF8BCB0C37DEB5EC377B9612 /* BasalProfileEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorRootView.swift; sourceTree = "<group>"; };
 		C19984D62EFC0035A9E9644D /* TreatmentsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TreatmentsProvider.swift; sourceTree = "<group>"; };
+		C1C9F7352C6C00A9970A4790 /* TherapyProfileListStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListStateModel.swift; path = Trio/Sources/Modules/TherapyProfileList/TherapyProfileListStateModel.swift; sourceTree = "<group>"; };
 		C21FE1E62DA59C6B007D550B /* GlucoseDailyDistributionChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseDailyDistributionChart.swift; sourceTree = "<group>"; };
 		C263D59E2E4267F400CBF08C /* NightscoutUploadGlucoseStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutUploadGlucoseStepView.swift; sourceTree = "<group>"; };
 		C28DD7252DBA9A9E00EC02DD /* GlucosePercentileDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucosePercentileDetailView.swift; sourceTree = "<group>"; };
@@ -1344,6 +1395,7 @@
 		CEF1ED6A2D58FB4600FAF41E /* CGMOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGMOptions.swift; sourceTree = "<group>"; };
 		CFCFE0781F9074C2917890E8 /* ManualTempBasalStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalStateModel.swift; sourceTree = "<group>"; };
 		D0BDC6993C1087310EDFC428 /* CarbRatioEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarbRatioEditorRootView.swift; sourceTree = "<group>"; };
+		D32D8A4C1E2034FA022A3361 /* ProfileManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileManager.swift; path = Trio/Sources/Services/ProfileManager/ProfileManager.swift; sourceTree = "<group>"; };
 		DC2C6489D29ECCCAD78E0721 /* GlucoseNotificationSettingsStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlucoseNotificationSettingsStateModel.swift; sourceTree = "<group>"; };
 		DD09D47A2C5986D1003FEA5D /* CalendarEventSettingsDataFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventSettingsDataFlow.swift; sourceTree = "<group>"; };
 		DD09D47C2C5986DA003FEA5D /* CalendarEventSettingsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventSettingsProvider.swift; sourceTree = "<group>"; };
@@ -1537,6 +1589,8 @@
 		E0CC2C5B275B9DAE00A7BC71 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		E0D4F80427513ECF00BDF1FE /* HealthKitSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitSample.swift; sourceTree = "<group>"; };
 		E26904AACA8D9C15D229D675 /* SnoozeStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnoozeStateModel.swift; sourceTree = "<group>"; };
+		E26FF508B6A5D8FB0D60275A /* ProfileSwitchBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileSwitchBannerView.swift; path = Trio/Sources/Views/ProfileSwitchBannerView.swift; sourceTree = "<group>"; };
+		E41F65D7FA7986001C975515 /* WeekdayPickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WeekdayPickerView.swift; path = Trio/Sources/Views/WeekdayPickerView.swift; sourceTree = "<group>"; };
 		E592A36F2CEEC01E009A472C /* ContactTrickEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTrickEntry.swift; sourceTree = "<group>"; };
 		E592A3712CEEC038009A472C /* ContactImageRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactImageRootView.swift; sourceTree = "<group>"; };
 		E592A3732CEEC038009A472C /* ContactImageDataFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactImageDataFlow.swift; sourceTree = "<group>"; };
@@ -1554,11 +1608,33 @@
 		FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutPreferences.swift; sourceTree = "<group>"; };
 		FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
 		FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extensions.swift"; sourceTree = "<group>"; };
+		HMF49BBBF5CD4A9BBC14CC1F /* HealthMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMetrics.swift; sourceTree = "<group>"; };
+		HS70616C45944CE888DC2C8D /* HealthMetricsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMetricsService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		BDFF7A9E2D25FA970016C40C /* Preview Content */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Preview Content"; sourceTree = "<group>"; };
-		DDCEBF412CC1B42500DF4C36 /* Views */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Views; sourceTree = "<group>"; };
+		BDFF7A9E2D25FA970016C40C /* Preview Content */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		DDCEBF412CC1B42500DF4C36 /* Views */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1857,6 +1933,17 @@
 				DD98ACBF2D71013200C0778F /* StatChartUtils.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		1E21A617A191D93F649BC2B7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				B14C55392B0FC21725BE31EB /* Models */,
+				9289E093E9746636A8B44B67 /* Services */,
+				A3560286C3C14EE8FBF6E9EF /* Views */,
+				55B8B15029594C4735BDD058 /* Modules */,
+			);
+			name = Sources;
 			sourceTree = "<group>";
 		};
 		29B478DF61BF8D270F7D8954 /* Snooze */ = {
@@ -2338,6 +2425,7 @@
 				3B3B57C82DA07B3400849D16 /* GoogleService-Info.plist */,
 				3811DED425C9E1E300A708ED /* Resources */,
 				3811DE1325C9D39E00A708ED /* Sources */,
+				1E21A617A191D93F649BC2B7 /* Sources */,
 			);
 			path = Trio;
 			sourceTree = "<group>";
@@ -2678,6 +2766,15 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		55B8B15029594C4735BDD058 /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				8DB05841EC75E741077749C5 /* TherapyProfileList */,
+				7CEB44C225E33EB7F1370454 /* TherapyProfileEditor */,
+			);
+			name = Modules;
+			sourceTree = "<group>";
+		};
 		5825D1622BD405AE00F36E9B /* Helper */ = {
 			isa = PBXGroup;
 			children = (
@@ -2770,12 +2867,51 @@
 			path = LiveActivity;
 			sourceTree = "<group>";
 		};
+		7CEB44C225E33EB7F1370454 /* TherapyProfileEditor */ = {
+			isa = PBXGroup;
+			children = (
+				845BF021B868C40808247497 /* TherapyProfileEditorDataFlow.swift */,
+				03CADE5D659AFE6D0385E900 /* TherapyProfileEditorProvider.swift */,
+				B50F1AF1D917100604E5DD84 /* TherapyProfileEditorStateModel.swift */,
+				A277BC90AAEB5DA3D7958028 /* View */,
+			);
+			name = TherapyProfileEditor;
+			sourceTree = "<group>";
+		};
 		84BDC840A57C65A1E6F9F780 /* View */ = {
 			isa = PBXGroup;
 			children = (
 				C377490C77661D75E8C50649 /* ManualTempBasalRootView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		8CAF093858A54BFEBA8C7930 /* ProfileManager */ = {
+			isa = PBXGroup;
+			children = (
+				D32D8A4C1E2034FA022A3361 /* ProfileManager.swift */,
+				30B146108512F66E88E846CC /* BaseProfileManager.swift */,
+			);
+			name = ProfileManager;
+			sourceTree = "<group>";
+		};
+		8DB05841EC75E741077749C5 /* TherapyProfileList */ = {
+			isa = PBXGroup;
+			children = (
+				385A9890F5418D3299CE7F41 /* TherapyProfileListDataFlow.swift */,
+				53CF6A38074A1E05033BA704 /* TherapyProfileListProvider.swift */,
+				C1C9F7352C6C00A9970A4790 /* TherapyProfileListStateModel.swift */,
+				EC4F00394DA94ACF17B4045A /* View */,
+			);
+			name = TherapyProfileList;
+			sourceTree = "<group>";
+		};
+		9289E093E9746636A8B44B67 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				8CAF093858A54BFEBA8C7930 /* ProfileManager */,
+			);
+			name = Services;
 			sourceTree = "<group>";
 		};
 		99C01B871ACAB3F32CE755C7 /* PumpConfig */ = {
@@ -2800,6 +2936,49 @@
 			path = DataTable;
 			sourceTree = "<group>";
 		};
+		A1B1C1D1E1F101010101C1C1 /* AIInsightsConfig */ = {
+			isa = PBXGroup;
+			children = (
+				A1B1C1D1E1F101010101A1A1 /* AIInsightsConfigDataFlow.swift */,
+				A1B1C1D1E1F101010101A1A3 /* AIInsightsConfigProvider.swift */,
+				A1B1C1D1E1F101010101A1A2 /* AIInsightsConfigStateModel.swift */,
+				A1B1C1D1E1F101010101A1A5 /* ClaudeAPIService.swift */,
+				A1B1C1D1E1F101010101A1A6 /* HealthDataExporter.swift */,
+				A1B1C1D1E1F101010101A1A8 /* MarkdownParser.swift */,
+				A1B1C1D1E1F101010101A1A7 /* NightscoutDataFetcher.swift */,
+				A1B1C1D1E1F101010101A1A9 /* SavedReportsManager.swift */,
+				A1B1C1D1E1F101010101A1AA /* ClaudeOTuneModels.swift */,
+				A1B1C1D1E1F101010101A1AB /* ClaudeOTuneProfileService.swift */,
+				A1B1C1D1E1F101010101C2C2 /* View */,
+			);
+			path = AIInsightsConfig;
+			sourceTree = "<group>";
+		};
+		A1B1C1D1E1F101010101C2C2 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				A1B1C1D1E1F101010101A1A4 /* AIInsightsConfigRootView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		A277BC90AAEB5DA3D7958028 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				4901ED795DB4552A4329842A /* TherapyProfileEditorRootView.swift */,
+			);
+			name = View;
+			sourceTree = "<group>";
+		};
+		A3560286C3C14EE8FBF6E9EF /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				E41F65D7FA7986001C975515 /* WeekdayPickerView.swift */,
+				E26FF508B6A5D8FB0D60275A /* ProfileSwitchBannerView.swift */,
+			);
+			name = Views;
+			sourceTree = "<group>";
+		};
 		A42F1FEDFFD0DDE00AAD54D3 /* BasalProfileEditor */ = {
 			isa = PBXGroup;
 			children = (
@@ -2809,6 +2988,16 @@
 				18B49BC9587A59E3A347C1CD /* View */,
 			);
 			path = BasalProfileEditor;
+			sourceTree = "<group>";
+		};
+		B14C55392B0FC21725BE31EB /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				5FEFD9852C2751F2B74D71B3 /* Weekday.swift */,
+				18ED8EA2AF12F8301B9CC005 /* TherapyProfile.swift */,
+				2593404672BB08B4E9D1B22D /* ProfileSwitchEvent.swift */,
+			);
+			name = Models;
 			sourceTree = "<group>";
 		};
 		B9488883C59C31550E0B4CEC /* View */ = {
@@ -3683,6 +3872,14 @@
 			path = ContactImage;
 			sourceTree = "<group>";
 		};
+		EC4F00394DA94ACF17B4045A /* View */ = {
+			isa = PBXGroup;
+			children = (
+				7254020C7405D49944F2A362 /* TherapyProfileListRootView.swift */,
+			);
+			name = View;
+			sourceTree = "<group>";
+		};
 		EEC747824D6593B5CD87E195 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -3840,8 +4037,6 @@
 			dependencies = (
 			);
 			name = "Trio Watch Complication Extension";
-			packageProductDependencies = (
-			);
 			productName = "Trio Watch WidgetExtension";
 			productReference = BD8207C32D2B42E50023339D /* Trio Watch Complication Extension.appex */;
 			productType = "com.apple.product-type.app-extension";
@@ -3864,8 +4059,6 @@
 				BDFF7A9E2D25FA970016C40C /* Preview Content */,
 			);
 			name = "Trio Watch App";
-			packageProductDependencies = (
-			);
 			productName = "TrioWatch Watch App";
 			productReference = BDFF797C2D25AA870016C40C /* Trio Watch App.app */;
 			productType = "com.apple.product-type.application";
@@ -3884,8 +4077,6 @@
 				BDFF798D2D25AA890016C40C /* PBXTargetDependency */,
 			);
 			name = "Trio Watch AppTests";
-			packageProductDependencies = (
-			);
 			productName = "TrioWatch Watch AppTests";
 			productReference = BDFF798B2D25AA890016C40C /* Trio Watch AppTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -4633,16 +4824,16 @@
 				BDF34F952C10D27300D51995 /* DeterminationData.swift in Sources */,
 				BA00D96F7B2FF169A06FB530 /* CGMSettingsStateModel.swift in Sources */,
 				BD7DA9A52AE06DFC00601B20 /* BolusCalculatorConfigDataFlow.swift in Sources */,
-				6EADD581738D64431902AC0A /* (null) in Sources */,
+				6EADD581738D64431902AC0A /* BuildFile in Sources */,
 				CE94598729E9E4110047C9C6 /* WatchConfigRootView.swift in Sources */,
 				DD5DC9FB2CF3E1B100AB8703 /* AdjustmentsStateModel+Helpers.swift in Sources */,
 				BD249D972D42FCBF00412DEB /* AreaChartSetup.swift in Sources */,
 				DDF847E42C5C288F0049BB3B /* LiveActivitySettingsRootView.swift in Sources */,
 				DD88C8E22C50420800F2D558 /* DefinitionRow.swift in Sources */,
-				B7C465E9472624D8A2BE2A6A /* (null) in Sources */,
+				B7C465E9472624D8A2BE2A6A /* BuildFile in Sources */,
 				71D44AAB2CA5F5EA0036EE9E /* AlertPermissionsChecker.swift in Sources */,
 				DDF691032DA2CA1E008BF16C /* AppDiagnosticsProvider.swift in Sources */,
-				320D030F724170A637F06D50 /* (null) in Sources */,
+				320D030F724170A637F06D50 /* BuildFile in Sources */,
 				19E1F7E829D082D0005C8D20 /* IconConfigDataFlow.swift in Sources */,
 				5A2325522BFCBF55003518CA /* NightscoutUploadView.swift in Sources */,
 				E3A08AAE59538BC8A8ABE477 /* GlucoseNotificationSettingsDataFlow.swift in Sources */,
@@ -4697,6 +4888,21 @@
 				8194B80890CDD6A3C13B0FEE /* SnoozeStateModel.swift in Sources */,
 				BDA25EE42D260CD500035F34 /* AppleWatchManager.swift in Sources */,
 				0437CE46C12535A56504EC19 /* SnoozeRootView.swift in Sources */,
+				993FC470FFDA65FC95D65B3B /* Weekday.swift in Sources */,
+				32A17501E640D0B396A04D1E /* TherapyProfile.swift in Sources */,
+				18DDA1C6A9A1D7F2FBB0F8A3 /* ProfileSwitchEvent.swift in Sources */,
+				B6002AC43008CD3ACE01C3E9 /* ProfileManager.swift in Sources */,
+				36E674C7925039164DE63BF7 /* BaseProfileManager.swift in Sources */,
+				376C7FC61DD607DDF1D4CDFF /* WeekdayPickerView.swift in Sources */,
+				86F8F6CB10ECDFD2134A69F6 /* ProfileSwitchBannerView.swift in Sources */,
+				EF05C59A5D494DCA552D485E /* TherapyProfileListDataFlow.swift in Sources */,
+				AA2579CD7BD92C2C2DE6F94F /* TherapyProfileListProvider.swift in Sources */,
+				A29C54E891CFC09F509F6DE5 /* TherapyProfileListStateModel.swift in Sources */,
+				4751132C9ED4D97A28EC29CC /* TherapyProfileListRootView.swift in Sources */,
+				B4D5BC54194298AE9564B450 /* TherapyProfileEditorDataFlow.swift in Sources */,
+				B127455A880F4A29CE57DC8A /* TherapyProfileEditorProvider.swift in Sources */,
+				599C7B08152DD755FEAFE2CD /* TherapyProfileEditorStateModel.swift in Sources */,
+				8765F676F6F301C841FECF52 /* TherapyProfileEditorRootView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -867,7 +867,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		03CADE5D659AFE6D0385E900 /* TherapyProfileEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorProvider.swift; path = Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorProvider.swift; sourceTree = "<group>"; };
+		03CADE5D659AFE6D0385E900 /* TherapyProfileEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorProvider.swift; path = TherapyProfileEditorProvider.swift; sourceTree = "<group>"; };
 		110AEDE02C5193D100615CC9 /* BolusIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BolusIntent.swift; sourceTree = "<group>"; };
 		110AEDE12C5193D100615CC9 /* BolusIntentRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BolusIntentRequest.swift; sourceTree = "<group>"; };
 		110AEDE52C51A0AE00615CC9 /* ShortcutsConfigView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShortcutsConfigView.swift; sourceTree = "<group>"; };
@@ -878,7 +878,7 @@
 		118DF7652C5ECBC60067FEB7 /* CancelOverrideIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CancelOverrideIntent.swift; sourceTree = "<group>"; };
 		118DF7672C5ECBC60067FEB7 /* OverridePresetEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridePresetEntity.swift; sourceTree = "<group>"; };
 		118DF7682C5ECBC60067FEB7 /* OverridePresetsIntentRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverridePresetsIntentRequest.swift; sourceTree = "<group>"; };
-		18ED8EA2AF12F8301B9CC005 /* TherapyProfile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfile.swift; path = Trio/Sources/Models/TherapyProfile.swift; sourceTree = "<group>"; };
+		18ED8EA2AF12F8301B9CC005 /* TherapyProfile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfile.swift; path = TherapyProfile.swift; sourceTree = "<group>"; };
 		19012CDB291D2CB900FB8210 /* LoopStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopStats.swift; sourceTree = "<group>"; };
 		190EBCC329FF136900BA767D /* UserInterfaceSettingsDataFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInterfaceSettingsDataFlow.swift; sourceTree = "<group>"; };
 		190EBCC529FF138000BA767D /* UserInterfaceSettingsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInterfaceSettingsProvider.swift; sourceTree = "<group>"; };
@@ -914,10 +914,10 @@
 		1CAE81192B118804DCD23034 /* SnoozeProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnoozeProvider.swift; sourceTree = "<group>"; };
 		223EC0494F55A91E3EA69EF4 /* TreatmentsStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TreatmentsStateModel.swift; sourceTree = "<group>"; };
 		22963BD06A9C83959D4914E4 /* GlucoseNotificationSettingsRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlucoseNotificationSettingsRootView.swift; sourceTree = "<group>"; };
-		2593404672BB08B4E9D1B22D /* ProfileSwitchEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileSwitchEvent.swift; path = Trio/Sources/Models/ProfileSwitchEvent.swift; sourceTree = "<group>"; };
+		2593404672BB08B4E9D1B22D /* ProfileSwitchEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileSwitchEvent.swift; path = ProfileSwitchEvent.swift; sourceTree = "<group>"; };
 		2AD22C985B79A2F0D2EA3D9D /* PumpConfigRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PumpConfigRootView.swift; sourceTree = "<group>"; };
 		2F2A13DF0EDEEEDC4106AA2A /* NightscoutConfigDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NightscoutConfigDataFlow.swift; sourceTree = "<group>"; };
-		30B146108512F66E88E846CC /* BaseProfileManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BaseProfileManager.swift; path = Trio/Sources/Services/ProfileManager/BaseProfileManager.swift; sourceTree = "<group>"; };
+		30B146108512F66E88E846CC /* BaseProfileManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BaseProfileManager.swift; path = BaseProfileManager.swift; sourceTree = "<group>"; };
 		3260468377DA9DB4DEE9AF6D /* GlucoseNotificationSettingsDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlucoseNotificationSettingsDataFlow.swift; sourceTree = "<group>"; };
 		36A708CDB546692C2230B385 /* SnoozeDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnoozeDataFlow.swift; sourceTree = "<group>"; };
 		36F58DDD71F0E795464FA3F0 /* TargetsEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorStateModel.swift; sourceTree = "<group>"; };
@@ -986,7 +986,7 @@
 		38569345270B5DFA0002C50D /* GlucoseSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GlucoseSource.swift; sourceTree = "<group>"; };
 		38569346270B5DFB0002C50D /* AppGroupSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppGroupSource.swift; sourceTree = "<group>"; };
 		38569352270B5E350002C50D /* CGMRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGMRootView.swift; sourceTree = "<group>"; };
-		385A9890F5418D3299CE7F41 /* TherapyProfileListDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListDataFlow.swift; path = Trio/Sources/Modules/TherapyProfileList/TherapyProfileListDataFlow.swift; sourceTree = "<group>"; };
+		385A9890F5418D3299CE7F41 /* TherapyProfileListDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListDataFlow.swift; path = TherapyProfileListDataFlow.swift; sourceTree = "<group>"; };
 		385CEA8125F23DFD002D6D5B /* NightscoutStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutStatus.swift; sourceTree = "<group>"; };
 		3862CC2D2743F9F700BF832C /* CalendarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarManager.swift; sourceTree = "<group>"; };
 		3870FF4225EC13F40088248F /* BloodGlucose.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BloodGlucose.swift; sourceTree = "<group>"; };
@@ -1121,7 +1121,7 @@
 		3F8A87AA037BD079BA3528BA /* ConfigEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorDataFlow.swift; sourceTree = "<group>"; };
 		42369F66CF91F30624C0B3A6 /* BasalProfileEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorProvider.swift; sourceTree = "<group>"; };
 		44080E4709E3AE4B73054563 /* ConfigEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorProvider.swift; sourceTree = "<group>"; };
-		4901ED795DB4552A4329842A /* TherapyProfileEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorRootView.swift; path = Trio/Sources/Modules/TherapyProfileEditor/View/TherapyProfileEditorRootView.swift; sourceTree = "<group>"; };
+		4901ED795DB4552A4329842A /* TherapyProfileEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorRootView.swift; path = TherapyProfileEditorRootView.swift; sourceTree = "<group>"; };
 		491D6FB92D56741C00C49F67 /* TempTargetRunStored+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TempTargetRunStored+CoreDataClass.swift"; sourceTree = "<group>"; };
 		491D6FBA2D56741C00C49F67 /* TempTargetRunStored+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TempTargetRunStored+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		491D6FBB2D56741C00C49F67 /* TempTargetStored+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TempTargetStored+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -1129,7 +1129,7 @@
 		49B9B57E2D5768D2009C6B59 /* AdjustmentStored+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdjustmentStored+Helper.swift"; sourceTree = "<group>"; };
 		4DD795BA46B193644D48138C /* TargetsEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorRootView.swift; sourceTree = "<group>"; };
 		505E09DC17A0C3D0AF4B66FE /* ISFEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorStateModel.swift; sourceTree = "<group>"; };
-		53CF6A38074A1E05033BA704 /* TherapyProfileListProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListProvider.swift; path = Trio/Sources/Modules/TherapyProfileList/TherapyProfileListProvider.swift; sourceTree = "<group>"; };
+		53CF6A38074A1E05033BA704 /* TherapyProfileListProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListProvider.swift; path = TherapyProfileListProvider.swift; sourceTree = "<group>"; };
 		581516A32BCED84A00BF67D7 /* DebuggingIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebuggingIdentifiers.swift; sourceTree = "<group>"; };
 		581516A82BCEEDF800BF67D7 /* NSPredicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicates.swift; sourceTree = "<group>"; };
 		581AC4382BE22ED10038760C /* JSONConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONConverter.swift; sourceTree = "<group>"; };
@@ -1168,7 +1168,7 @@
 		5A2325572BFCC168003518CA /* NightscoutConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutConnectView.swift; sourceTree = "<group>"; };
 		5C018D1680307A31C9ED7120 /* CGMSettingsStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CGMSettingsStateModel.swift; sourceTree = "<group>"; };
 		5D5B4F8B4194BB7E260EF251 /* ConfigEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorStateModel.swift; sourceTree = "<group>"; };
-		5FEFD9852C2751F2B74D71B3 /* Weekday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Weekday.swift; path = Trio/Sources/Models/Weekday.swift; sourceTree = "<group>"; };
+		5FEFD9852C2751F2B74D71B3 /* Weekday.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Weekday.swift; path = Weekday.swift; sourceTree = "<group>"; };
 		60744C3E9BB3652895C908CC /* DataTableProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableProvider.swift; sourceTree = "<group>"; };
 		64AA5E04A2761F6EEA6568E1 /* CarbRatioEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarbRatioEditorStateModel.swift; sourceTree = "<group>"; };
 		65070A322BFDCB83006F213F /* TidepoolStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TidepoolStartView.swift; sourceTree = "<group>"; };
@@ -1186,10 +1186,10 @@
 		6BCF84DC2B16843A003AD46E /* LiveActitiyAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActitiyAttributes.swift; sourceTree = "<group>"; };
 		715120D12D3C2B84005D9FB6 /* GlucoseNotificationsOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseNotificationsOption.swift; sourceTree = "<group>"; };
 		71D44AAA2CA5F5EA0036EE9E /* AlertPermissionsChecker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertPermissionsChecker.swift; sourceTree = "<group>"; };
-		7254020C7405D49944F2A362 /* TherapyProfileListRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListRootView.swift; path = Trio/Sources/Modules/TherapyProfileList/View/TherapyProfileListRootView.swift; sourceTree = "<group>"; };
+		7254020C7405D49944F2A362 /* TherapyProfileListRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListRootView.swift; path = TherapyProfileListRootView.swift; sourceTree = "<group>"; };
 		79BDA519C9B890FD9A5DFCF3 /* ISFEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorDataFlow.swift; sourceTree = "<group>"; };
 		7E22146D3DF4853786C78132 /* CarbRatioEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarbRatioEditorDataFlow.swift; sourceTree = "<group>"; };
-		845BF021B868C40808247497 /* TherapyProfileEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorDataFlow.swift; path = Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorDataFlow.swift; sourceTree = "<group>"; };
+		845BF021B868C40808247497 /* TherapyProfileEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorDataFlow.swift; path = TherapyProfileEditorDataFlow.swift; sourceTree = "<group>"; };
 		8782B44544F38F2B2D82C38E /* NightscoutConfigRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NightscoutConfigRootView.swift; sourceTree = "<group>"; };
 		881E04BA5E0A003DE8E0A9C6 /* DataTableRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableRootView.swift; sourceTree = "<group>"; };
 		8A9134292D63D9A1007F8874 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -1215,7 +1215,7 @@
 		A8630D58BDAD6D9C650B9B39 /* PumpConfigProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PumpConfigProvider.swift; sourceTree = "<group>"; };
 		AAFF91130F2FCCC7EBBA11AD /* BasalProfileEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorStateModel.swift; sourceTree = "<group>"; };
 		AF65DA88F972B56090AD6AC3 /* PumpConfigDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PumpConfigDataFlow.swift; sourceTree = "<group>"; };
-		B50F1AF1D917100604E5DD84 /* TherapyProfileEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorStateModel.swift; path = Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift; sourceTree = "<group>"; };
+		B50F1AF1D917100604E5DD84 /* TherapyProfileEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileEditorStateModel.swift; path = TherapyProfileEditorStateModel.swift; sourceTree = "<group>"; };
 		B5822B15939E719628E9FF7C /* SnoozeRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnoozeRootView.swift; sourceTree = "<group>"; };
 		B9B5C0607505A38F256BF99A /* CGMSettingsDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CGMSettingsDataFlow.swift; sourceTree = "<group>"; };
 		BA49538D56989D8DA6FCF538 /* TargetsEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorDataFlow.swift; sourceTree = "<group>"; };
@@ -1324,7 +1324,7 @@
 		BDFF7A922D25F97D0016C40C /* TrioWatchAppExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrioWatchAppExtension.swift; sourceTree = "<group>"; };
 		BF8BCB0C37DEB5EC377B9612 /* BasalProfileEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorRootView.swift; sourceTree = "<group>"; };
 		C19984D62EFC0035A9E9644D /* TreatmentsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TreatmentsProvider.swift; sourceTree = "<group>"; };
-		C1C9F7352C6C00A9970A4790 /* TherapyProfileListStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListStateModel.swift; path = Trio/Sources/Modules/TherapyProfileList/TherapyProfileListStateModel.swift; sourceTree = "<group>"; };
+		C1C9F7352C6C00A9970A4790 /* TherapyProfileListStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TherapyProfileListStateModel.swift; path = TherapyProfileListStateModel.swift; sourceTree = "<group>"; };
 		C21FE1E62DA59C6B007D550B /* GlucoseDailyDistributionChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseDailyDistributionChart.swift; sourceTree = "<group>"; };
 		C263D59E2E4267F400CBF08C /* NightscoutUploadGlucoseStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutUploadGlucoseStepView.swift; sourceTree = "<group>"; };
 		C28DD7252DBA9A9E00EC02DD /* GlucosePercentileDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucosePercentileDetailView.swift; sourceTree = "<group>"; };
@@ -1395,7 +1395,7 @@
 		CEF1ED6A2D58FB4600FAF41E /* CGMOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGMOptions.swift; sourceTree = "<group>"; };
 		CFCFE0781F9074C2917890E8 /* ManualTempBasalStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalStateModel.swift; sourceTree = "<group>"; };
 		D0BDC6993C1087310EDFC428 /* CarbRatioEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarbRatioEditorRootView.swift; sourceTree = "<group>"; };
-		D32D8A4C1E2034FA022A3361 /* ProfileManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileManager.swift; path = Trio/Sources/Services/ProfileManager/ProfileManager.swift; sourceTree = "<group>"; };
+		D32D8A4C1E2034FA022A3361 /* ProfileManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileManager.swift; path = ProfileManager.swift; sourceTree = "<group>"; };
 		DC2C6489D29ECCCAD78E0721 /* GlucoseNotificationSettingsStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GlucoseNotificationSettingsStateModel.swift; sourceTree = "<group>"; };
 		DD09D47A2C5986D1003FEA5D /* CalendarEventSettingsDataFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventSettingsDataFlow.swift; sourceTree = "<group>"; };
 		DD09D47C2C5986DA003FEA5D /* CalendarEventSettingsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventSettingsProvider.swift; sourceTree = "<group>"; };
@@ -1589,8 +1589,8 @@
 		E0CC2C5B275B9DAE00A7BC71 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
 		E0D4F80427513ECF00BDF1FE /* HealthKitSample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitSample.swift; sourceTree = "<group>"; };
 		E26904AACA8D9C15D229D675 /* SnoozeStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnoozeStateModel.swift; sourceTree = "<group>"; };
-		E26FF508B6A5D8FB0D60275A /* ProfileSwitchBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileSwitchBannerView.swift; path = Trio/Sources/Views/ProfileSwitchBannerView.swift; sourceTree = "<group>"; };
-		E41F65D7FA7986001C975515 /* WeekdayPickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WeekdayPickerView.swift; path = Trio/Sources/Views/WeekdayPickerView.swift; sourceTree = "<group>"; };
+		E26FF508B6A5D8FB0D60275A /* ProfileSwitchBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ProfileSwitchBannerView.swift; path = ProfileSwitchBannerView.swift; sourceTree = "<group>"; };
+		E41F65D7FA7986001C975515 /* WeekdayPickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WeekdayPickerView.swift; path = WeekdayPickerView.swift; sourceTree = "<group>"; };
 		E592A36F2CEEC01E009A472C /* ContactTrickEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTrickEntry.swift; sourceTree = "<group>"; };
 		E592A3712CEEC038009A472C /* ContactImageRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactImageRootView.swift; sourceTree = "<group>"; };
 		E592A3732CEEC038009A472C /* ContactImageDataFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactImageDataFlow.swift; sourceTree = "<group>"; };
@@ -1938,7 +1938,6 @@
 		1E21A617A191D93F649BC2B7 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				B14C55392B0FC21725BE31EB /* Models */,
 				9289E093E9746636A8B44B67 /* Services */,
 				A3560286C3C14EE8FBF6E9EF /* Views */,
 				55B8B15029594C4735BDD058 /* Modules */,
@@ -2444,6 +2443,9 @@
 		388E5A5925B6F0250019842D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				5FEFD9852C2751F2B74D71B3 /* Weekday.swift */,
+				18ED8EA2AF12F8301B9CC005 /* TherapyProfile.swift */,
+				2593404672BB08B4E9D1B22D /* ProfileSwitchEvent.swift */,
 				DDFF204F2DB2C11900AB8A96 /* WatchStateSnapshot.swift */,
 				DDEBB05B2D89E9050032305D /* TimeInRangeType.swift */,
 				3B2F77852D7E52ED005ED9FA /* TDD.swift */,
@@ -2875,8 +2877,8 @@
 				B50F1AF1D917100604E5DD84 /* TherapyProfileEditorStateModel.swift */,
 				A277BC90AAEB5DA3D7958028 /* View */,
 			);
-			name = TherapyProfileEditor;
-			sourceTree = "<group>";
+			path = Trio/Sources/Modules/TherapyProfileEditor;
+			sourceTree = SOURCE_ROOT;
 		};
 		84BDC840A57C65A1E6F9F780 /* View */ = {
 			isa = PBXGroup;
@@ -2892,8 +2894,8 @@
 				D32D8A4C1E2034FA022A3361 /* ProfileManager.swift */,
 				30B146108512F66E88E846CC /* BaseProfileManager.swift */,
 			);
-			name = ProfileManager;
-			sourceTree = "<group>";
+			path = Trio/Sources/Services/ProfileManager;
+			sourceTree = SOURCE_ROOT;
 		};
 		8DB05841EC75E741077749C5 /* TherapyProfileList */ = {
 			isa = PBXGroup;
@@ -2903,8 +2905,8 @@
 				C1C9F7352C6C00A9970A4790 /* TherapyProfileListStateModel.swift */,
 				EC4F00394DA94ACF17B4045A /* View */,
 			);
-			name = TherapyProfileList;
-			sourceTree = "<group>";
+			path = Trio/Sources/Modules/TherapyProfileList;
+			sourceTree = SOURCE_ROOT;
 		};
 		9289E093E9746636A8B44B67 /* Services */ = {
 			isa = PBXGroup;
@@ -2967,7 +2969,7 @@
 			children = (
 				4901ED795DB4552A4329842A /* TherapyProfileEditorRootView.swift */,
 			);
-			name = View;
+			path = View;
 			sourceTree = "<group>";
 		};
 		A3560286C3C14EE8FBF6E9EF /* Views */ = {
@@ -2976,8 +2978,8 @@
 				E41F65D7FA7986001C975515 /* WeekdayPickerView.swift */,
 				E26FF508B6A5D8FB0D60275A /* ProfileSwitchBannerView.swift */,
 			);
-			name = Views;
-			sourceTree = "<group>";
+			path = Trio/Sources/Views;
+			sourceTree = SOURCE_ROOT;
 		};
 		A42F1FEDFFD0DDE00AAD54D3 /* BasalProfileEditor */ = {
 			isa = PBXGroup;
@@ -2988,16 +2990,6 @@
 				18B49BC9587A59E3A347C1CD /* View */,
 			);
 			path = BasalProfileEditor;
-			sourceTree = "<group>";
-		};
-		B14C55392B0FC21725BE31EB /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				5FEFD9852C2751F2B74D71B3 /* Weekday.swift */,
-				18ED8EA2AF12F8301B9CC005 /* TherapyProfile.swift */,
-				2593404672BB08B4E9D1B22D /* ProfileSwitchEvent.swift */,
-			);
-			name = Models;
 			sourceTree = "<group>";
 		};
 		B9488883C59C31550E0B4CEC /* View */ = {
@@ -3877,7 +3869,7 @@
 			children = (
 				7254020C7405D49944F2A362 /* TherapyProfileListRootView.swift */,
 			);
-			name = View;
+			path = View;
 			sourceTree = "<group>";
 		};
 		EEC747824D6593B5CD87E195 /* View */ = {

--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -81,6 +81,7 @@ final class BaseAPSManager: APSManager, Injectable {
     @Injected() private var settingsManager: SettingsManager!
     @Injected() private var tddStorage: TDDStorage!
     @Injected() private var broadcaster: Broadcaster!
+    @Injected() private var profileManager: ProfileManager!
     @Persisted(key: "lastLoopStartDate") private var lastLoopStartDate: Date = .distantPast
     @Persisted(key: "lastLoopDate") var lastLoopDate: Date = .distantPast {
         didSet {
@@ -221,6 +222,8 @@ final class BaseAPSManager: APSManager, Injectable {
 
     func heartbeat(date: Date) {
         deviceDataManager.heartbeat(date: date)
+        // Check for scheduled therapy profile switch
+        profileManager.checkForScheduledSwitch()
     }
 
     // Loop entry point

--- a/Trio/Sources/APS/OpenAPS/Constants.swift
+++ b/Trio/Sources/APS/OpenAPS/Constants.swift
@@ -94,5 +94,8 @@ extension OpenAPS {
         static let settings = "freeaps/freeaps_settings.json"
         static let tempTargetsPresets = "freeaps/temptargets_presets.json"
         static let calibrations = "freeaps/calibrations.json"
+        static let therapyProfiles = "settings/therapy_profiles.json"
+        static let activeProfileId = "settings/active_profile_id.json"
+        static let profileSwitchHistory = "settings/profile_switch_history.json"
     }
 }

--- a/Trio/Sources/Assemblies/StorageAssembly.swift
+++ b/Trio/Sources/Assemblies/StorageAssembly.swift
@@ -16,6 +16,7 @@ final class StorageAssembly: Assembly {
         container.register(CarbsStorage.self) { r in BaseCarbsStorage(resolver: r) }
         container.register(ContactImageStorage.self) { r in BaseContactImageStorage(resolver: r) }
         container.register(SettingsManager.self) { r in BaseSettingsManager(resolver: r) }
+        container.register(ProfileManager.self) { r in BaseProfileManager(resolver: r) }
         container.register(Keychain.self) { _ in BaseKeychain() }
         container.register(AlertHistoryStorage.self) { r in BaseAlertHistoryStorage(resolver: r) }
     }

--- a/Trio/Sources/Models/ProfileSwitchEvent.swift
+++ b/Trio/Sources/Models/ProfileSwitchEvent.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Records a therapy profile switch event for history tracking.
+struct ProfileSwitchEvent: JSON, Identifiable, Equatable, Hashable {
+    let id: UUID
+    let fromProfileId: UUID?
+    let fromProfileName: String?
+    let toProfileId: UUID
+    let toProfileName: String
+    let switchedAt: Date
+    let weekday: Weekday
+    let reason: SwitchReason
+    var acknowledged: Bool
+
+    /// The reason for the profile switch
+    enum SwitchReason: String, Codable {
+        /// Automatic midnight switch based on day schedule
+        case scheduled
+        /// User manually activated a profile
+        case manual
+        /// User overrode the scheduled profile for the current day
+        case manualOverride
+    }
+
+    init(
+        id: UUID = UUID(),
+        fromProfileId: UUID? = nil,
+        fromProfileName: String? = nil,
+        toProfileId: UUID,
+        toProfileName: String,
+        switchedAt: Date = Date(),
+        weekday: Weekday = .today,
+        reason: SwitchReason,
+        acknowledged: Bool = false
+    ) {
+        self.id = id
+        self.fromProfileId = fromProfileId
+        self.fromProfileName = fromProfileName
+        self.toProfileId = toProfileId
+        self.toProfileName = toProfileName
+        self.switchedAt = switchedAt
+        self.weekday = weekday
+        self.reason = reason
+        self.acknowledged = acknowledged
+    }
+
+    /// Human-readable description of the switch reason
+    var reasonDescription: String {
+        switch reason {
+        case .scheduled:
+            return NSLocalizedString("Scheduled switch", comment: "Automatic scheduled profile switch")
+        case .manual:
+            return NSLocalizedString("Manual activation", comment: "User manually activated profile")
+        case .manualOverride:
+            return NSLocalizedString("Manual override", comment: "User overrode scheduled profile")
+        }
+    }
+
+    // MARK: - Hashable
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+// MARK: - Codable
+
+extension ProfileSwitchEvent {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case fromProfileId = "from_profile_id"
+        case fromProfileName = "from_profile_name"
+        case toProfileId = "to_profile_id"
+        case toProfileName = "to_profile_name"
+        case switchedAt = "switched_at"
+        case weekday
+        case reason
+        case acknowledged
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decode(UUID.self, forKey: .id)
+        fromProfileId = try container.decodeIfPresent(UUID.self, forKey: .fromProfileId)
+        fromProfileName = try container.decodeIfPresent(String.self, forKey: .fromProfileName)
+        toProfileId = try container.decode(UUID.self, forKey: .toProfileId)
+        toProfileName = try container.decode(String.self, forKey: .toProfileName)
+        switchedAt = try container.decode(Date.self, forKey: .switchedAt)
+
+        let weekdayRawValue = try container.decode(Int.self, forKey: .weekday)
+        weekday = Weekday(rawValue: weekdayRawValue) ?? .sunday
+
+        reason = try container.decode(SwitchReason.self, forKey: .reason)
+        acknowledged = try container.decode(Bool.self, forKey: .acknowledged)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(id, forKey: .id)
+        try container.encodeIfPresent(fromProfileId, forKey: .fromProfileId)
+        try container.encodeIfPresent(fromProfileName, forKey: .fromProfileName)
+        try container.encode(toProfileId, forKey: .toProfileId)
+        try container.encode(toProfileName, forKey: .toProfileName)
+        try container.encode(switchedAt, forKey: .switchedAt)
+        try container.encode(weekday.rawValue, forKey: .weekday)
+        try container.encode(reason, forKey: .reason)
+        try container.encode(acknowledged, forKey: .acknowledged)
+    }
+}

--- a/Trio/Sources/Models/TherapyProfile.swift
+++ b/Trio/Sources/Models/TherapyProfile.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// A complete therapy profile containing all settings for insulin delivery and glucose management.
+/// Users can create multiple profiles for different scenarios (e.g., weekday vs weekend).
+struct TherapyProfile: JSON, Identifiable, Equatable, Hashable {
+    let id: UUID
+    var name: String
+    var activeDays: Set<Weekday>
+    var basalProfile: [BasalProfileEntry]
+    var insulinSensitivities: InsulinSensitivities
+    var carbRatios: CarbRatios
+    var bgTargets: BGTargets
+    var isDefault: Bool
+    var createdAt: Date
+    var lastModified: Date
+
+    /// Maximum number of profiles allowed
+    static let maxProfiles = 10
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        activeDays: Set<Weekday> = [],
+        basalProfile: [BasalProfileEntry] = [],
+        insulinSensitivities: InsulinSensitivities,
+        carbRatios: CarbRatios,
+        bgTargets: BGTargets,
+        isDefault: Bool = false,
+        createdAt: Date = Date(),
+        lastModified: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.activeDays = activeDays
+        self.basalProfile = basalProfile
+        self.insulinSensitivities = insulinSensitivities
+        self.carbRatios = carbRatios
+        self.bgTargets = bgTargets
+        self.isDefault = isDefault
+        self.createdAt = createdAt
+        self.lastModified = lastModified
+    }
+
+    /// Creates a copy of this profile with a new ID and name
+    func copy(withName newName: String) -> TherapyProfile {
+        TherapyProfile(
+            id: UUID(),
+            name: newName,
+            activeDays: [],
+            basalProfile: basalProfile,
+            insulinSensitivities: insulinSensitivities,
+            carbRatios: carbRatios,
+            bgTargets: bgTargets,
+            isDefault: false,
+            createdAt: Date(),
+            lastModified: Date()
+        )
+    }
+
+    /// Updates the lastModified timestamp
+    mutating func touch() {
+        lastModified = Date()
+    }
+
+    // MARK: - Hashable
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    // MARK: - Equatable
+
+    static func == (lhs: TherapyProfile, rhs: TherapyProfile) -> Bool {
+        lhs.id == rhs.id &&
+            lhs.name == rhs.name &&
+            lhs.activeDays == rhs.activeDays &&
+            lhs.isDefault == rhs.isDefault &&
+            lhs.createdAt == rhs.createdAt &&
+            lhs.lastModified == rhs.lastModified
+    }
+}
+
+// MARK: - Codable
+
+extension TherapyProfile {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case activeDays = "active_days"
+        case basalProfile = "basal_profile"
+        case insulinSensitivities = "insulin_sensitivities"
+        case carbRatios = "carb_ratios"
+        case bgTargets = "bg_targets"
+        case isDefault = "is_default"
+        case createdAt = "created_at"
+        case lastModified = "last_modified"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+
+        // Decode activeDays as array of raw values, convert to Set<Weekday>
+        let dayValues = try container.decode([Int].self, forKey: .activeDays)
+        activeDays = Set(dayValues.compactMap { Weekday(rawValue: $0) })
+
+        basalProfile = try container.decode([BasalProfileEntry].self, forKey: .basalProfile)
+        insulinSensitivities = try container.decode(InsulinSensitivities.self, forKey: .insulinSensitivities)
+        carbRatios = try container.decode(CarbRatios.self, forKey: .carbRatios)
+        bgTargets = try container.decode(BGTargets.self, forKey: .bgTargets)
+        isDefault = try container.decode(Bool.self, forKey: .isDefault)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        lastModified = try container.decode(Date.self, forKey: .lastModified)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+
+        // Encode activeDays as array of raw values
+        let dayValues = activeDays.map(\.rawValue).sorted()
+        try container.encode(dayValues, forKey: .activeDays)
+
+        try container.encode(basalProfile, forKey: .basalProfile)
+        try container.encode(insulinSensitivities, forKey: .insulinSensitivities)
+        try container.encode(carbRatios, forKey: .carbRatios)
+        try container.encode(bgTargets, forKey: .bgTargets)
+        try container.encode(isDefault, forKey: .isDefault)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(lastModified, forKey: .lastModified)
+    }
+}
+
+// MARK: - Observer Protocol
+
+protocol TherapyProfileObserver {
+    func activeProfileDidChange(_ profile: TherapyProfile)
+}

--- a/Trio/Sources/Models/Weekday.swift
+++ b/Trio/Sources/Models/Weekday.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Represents days of the week for therapy profile scheduling.
+/// Uses Calendar.Component.weekday values (1 = Sunday, 7 = Saturday)
+enum Weekday: Int, CaseIterable, Codable, Comparable, Identifiable, Hashable {
+    case sunday = 1
+    case monday = 2
+    case tuesday = 3
+    case wednesday = 4
+    case thursday = 5
+    case friday = 6
+    case saturday = 7
+
+    var id: Int { rawValue }
+
+    /// Returns the weekday for today
+    static var today: Weekday {
+        let weekdayComponent = Calendar.current.component(.weekday, from: Date())
+        return Weekday(rawValue: weekdayComponent) ?? .sunday
+    }
+
+    /// Returns weekdays (Monday through Friday)
+    static var weekdays: Set<Weekday> {
+        [.monday, .tuesday, .wednesday, .thursday, .friday]
+    }
+
+    /// Returns weekend days (Saturday and Sunday)
+    static var weekend: Set<Weekday> {
+        [.saturday, .sunday]
+    }
+
+    /// Returns all days as a set
+    static var allDays: Set<Weekday> {
+        Set(Weekday.allCases)
+    }
+
+    /// Localized full name of the day (e.g., "Monday")
+    var localizedName: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        // weekdaySymbols is 0-indexed (Sunday = 0), rawValue is 1-indexed
+        return formatter.weekdaySymbols[rawValue - 1]
+    }
+
+    /// Localized short name of the day (e.g., "Mon")
+    var shortName: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        return formatter.shortWeekdaySymbols[rawValue - 1]
+    }
+
+    /// Very short name (e.g., "M" for Monday)
+    var veryShortName: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        return formatter.veryShortWeekdaySymbols[rawValue - 1]
+    }
+
+    /// Comparable conformance - allows sorting days in calendar order
+    static func < (lhs: Weekday, rhs: Weekday) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+extension Weekday: JSON {}
+
+extension Set where Element == Weekday {
+    /// Formats a set of weekdays into a human-readable string
+    /// Examples: "Weekdays", "Weekends", "Mon, Wed, Fri", "Every day"
+    var formattedString: String {
+        if self == Weekday.allDays {
+            return NSLocalizedString("Every day", comment: "All days selected")
+        }
+        if self == Weekday.weekdays {
+            return NSLocalizedString("Weekdays", comment: "Monday through Friday")
+        }
+        if self == Weekday.weekend {
+            return NSLocalizedString("Weekends", comment: "Saturday and Sunday")
+        }
+        if isEmpty {
+            return NSLocalizedString("No days", comment: "No days selected")
+        }
+
+        let sortedDays = sorted()
+        return sortedDays.map(\.shortName).joined(separator: ", ")
+    }
+}

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -22,6 +22,7 @@ extension Home {
         @ObservationIgnored @Injected() var overrideStorage: OverrideStorage!
         @ObservationIgnored @Injected() var bluetoothManager: BluetoothStateManager!
         @ObservationIgnored @Injected() var iobService: IOBService!
+        @ObservationIgnored @Injected() var profileManager: ProfileManager!
 
         var cgmStateModel: CGMSettings.StateModel {
             CGMSettings.StateModel.shared
@@ -109,6 +110,7 @@ extension Home {
         var cgmCurrent = cgmDefaultModel
         var pumpInitialSettings = PumpConfig.PumpInitialSettings.default
         var shouldRunDeleteOnSettingsChange = true
+        var pendingProfileSwitchNotification: ProfileSwitchEvent?
 
         var showCarbsRequiredBadge: Bool = true
         private(set) var setupPumpType: PumpConfig.PumpType = .minimed
@@ -380,6 +382,14 @@ extension Home {
                     }
                 }
                 .store(in: &lifetime)
+
+            // Subscribe to therapy profile switch notifications
+            profileManager.pendingSwitchNotificationPublisher
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] event in
+                    self?.pendingProfileSwitchNotification = event
+                }
+                .store(in: &lifetime)
         }
 
         private enum SettingType {
@@ -548,6 +558,11 @@ extension Home {
                 // perform determine basal sync, otherwise you have could end up with too much iob when opening the calculator again
                 try await apsManager.determineBasalSync()
             }
+        }
+
+        func acknowledgeProfileSwitch() {
+            profileManager.acknowledgeSwitchNotification()
+            pendingProfileSwitchNotification = nil
         }
 
         private func setupPumpSettings() async {

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -1123,6 +1123,15 @@ extension Home {
                     CustomProgressView(text: String(localized: "Updating IOB...", comment: "Progress text when updating IOB"))
                 }
             }
+            .profileSwitchBanner(
+                event: Binding(
+                    get: { state.pendingProfileSwitchNotification },
+                    set: { state.pendingProfileSwitchNotification = $0 }
+                ),
+                onDismiss: {
+                    state.acknowledgeProfileSwitch()
+                }
+            )
         }
     }
 }

--- a/Trio/Sources/Modules/Settings/SettingItems.swift
+++ b/Trio/Sources/Modules/Settings/SettingItems.swift
@@ -91,6 +91,17 @@ enum SettingItems {
             ],
             path: ["Therapy Settings", "Units and Limits"]
         ),
+        SettingItem(
+            title: "Therapy Profiles",
+            view: .therapyProfileList,
+            searchContents: [
+                "Weekday",
+                "Weekend",
+                "Profile Schedule",
+                "Automatic Profile Switch"
+            ],
+            path: ["Therapy Settings", "Therapy Profiles"]
+        ),
         SettingItem(title: "Basal Rates", view: .basalProfileEditor, path: ["Therapy Settings"]),
         SettingItem(title: "Insulin Sensitivities", view: .isfEditor, path: ["Therapy Settings"]),
         SettingItem(title: "ISF", view: .isfEditor, path: ["Therapy Settings"]),

--- a/Trio/Sources/Modules/Settings/View/Subviews/TherapySettingsView.swift
+++ b/Trio/Sources/Modules/Settings/View/Subviews/TherapySettingsView.swift
@@ -27,6 +27,14 @@ struct TherapySettingsView: BaseView {
             .listRowBackground(Color.chart)
 
             Section(
+                header: Text("Therapy Profiles"),
+                content: {
+                    Text("Therapy Profiles").navigationLink(to: .therapyProfileList, from: self)
+                }
+            )
+            .listRowBackground(Color.chart)
+
+            Section(
                 header: Text("Basic Insulin Rates & Targets"),
                 content: {
                     Text("Glucose Targets").navigationLink(to: .targetsEditor, from: self)

--- a/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorDataFlow.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorDataFlow.swift
@@ -14,4 +14,11 @@ protocol TherapyProfileEditorProvider: Provider {
     var isNew: Bool { get }
     var allProfiles: [TherapyProfile] { get }
     var units: GlucoseUnits { get }
+
+    // Current active settings for copy feature
+    var hasCurrentActiveSettings: Bool { get }
+    var currentBasalProfile: [BasalProfileEntry] { get }
+    var currentInsulinSensitivities: InsulinSensitivities? { get }
+    var currentCarbRatios: CarbRatios? { get }
+    var currentBGTargets: BGTargets? { get }
 }

--- a/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorDataFlow.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorDataFlow.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum TherapyProfileEditor {
+    enum Config {
+        /// The profile being edited
+        static var profile: TherapyProfile?
+        /// Whether this is a new profile
+        static var isNew: Bool = false
+    }
+}
+
+protocol TherapyProfileEditorProvider: Provider {
+    var profile: TherapyProfile? { get }
+    var isNew: Bool { get }
+    var allProfiles: [TherapyProfile] { get }
+    var units: GlucoseUnits { get }
+}

--- a/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorProvider.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorProvider.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Swinject
+
+extension TherapyProfileEditor {
+    final class Provider: BaseProvider, TherapyProfileEditorProvider {
+        @Injected() private var profileManager: ProfileManager!
+        @Injected() private var settingsManager: SettingsManager!
+
+        var profile: TherapyProfile? {
+            Config.profile
+        }
+
+        var isNew: Bool {
+            Config.isNew
+        }
+
+        var allProfiles: [TherapyProfile] {
+            profileManager.profiles
+        }
+
+        var units: GlucoseUnits {
+            settingsManager.settings.units
+        }
+    }
+}

--- a/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorProvider.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorProvider.swift
@@ -21,5 +21,27 @@ extension TherapyProfileEditor {
         var units: GlucoseUnits {
             settingsManager.settings.units
         }
+
+        // MARK: - Current Active Settings (for copy feature)
+
+        var hasCurrentActiveSettings: Bool {
+            !currentBasalProfile.isEmpty
+        }
+
+        var currentBasalProfile: [BasalProfileEntry] {
+            storage.retrieve(OpenAPS.Settings.basalProfile, as: [BasalProfileEntry].self) ?? []
+        }
+
+        var currentInsulinSensitivities: InsulinSensitivities? {
+            storage.retrieve(OpenAPS.Settings.insulinSensitivities, as: InsulinSensitivities.self)
+        }
+
+        var currentCarbRatios: CarbRatios? {
+            storage.retrieve(OpenAPS.Settings.carbRatios, as: CarbRatios.self)
+        }
+
+        var currentBGTargets: BGTargets? {
+            storage.retrieve(OpenAPS.Settings.bgTargets, as: BGTargets.self)
+        }
     }
 }

--- a/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift
@@ -234,13 +234,14 @@ extension TherapyProfileEditor {
 
         func updateBasalEntry(at index: Int, rate: Decimal) {
             guard index < basalProfile.count else { return }
-            basalProfile[index].rate = rate
+            let existing = basalProfile[index]
+            basalProfile[index] = BasalProfileEntry(start: existing.start, minutes: existing.minutes, rate: rate)
         }
 
         func updateBasalEntryTime(at index: Int, minutes: Int) {
             guard index < basalProfile.count else { return }
-            basalProfile[index].minutes = minutes
-            basalProfile[index].start = minutesToTimeString(minutes)
+            let existing = basalProfile[index]
+            basalProfile[index] = BasalProfileEntry(start: minutesToTimeString(minutes), minutes: minutes, rate: existing.rate)
             basalProfile.sort { $0.minutes < $1.minutes }
         }
 
@@ -296,7 +297,8 @@ extension TherapyProfileEditor {
 
         func updateISFEntry(at index: Int, sensitivity: Decimal) {
             guard var isf = insulinSensitivities, index < isf.sensitivities.count else { return }
-            isf.sensitivities[index].sensitivity = sensitivity
+            let existing = isf.sensitivities[index]
+            isf.sensitivities[index] = InsulinSensitivityEntry(sensitivity: sensitivity, offset: existing.offset, start: existing.start)
             insulinSensitivities = isf
         }
 
@@ -309,7 +311,7 @@ extension TherapyProfileEditor {
         // MARK: - Carb Ratio Editing
 
         func addCarbRatioEntry() {
-            guard var cr = carbRatios else {
+            guard let cr = carbRatios else {
                 carbRatios = CarbRatios(
                     units: .grams,
                     schedule: [CarbRatioEntry(start: "00:00", offset: 0, ratio: 0)]
@@ -322,21 +324,25 @@ extension TherapyProfileEditor {
                 offset: min(nextOffset, 23 * 60),
                 ratio: cr.schedule.last?.ratio ?? 0
             )
-            cr.schedule.append(newEntry)
-            cr.schedule.sort { $0.offset < $1.offset }
-            carbRatios = cr
+            var newSchedule = cr.schedule
+            newSchedule.append(newEntry)
+            newSchedule.sort { $0.offset < $1.offset }
+            carbRatios = CarbRatios(units: cr.units, schedule: newSchedule)
         }
 
         func updateCarbRatioEntry(at index: Int, ratio: Decimal) {
-            guard var cr = carbRatios, index < cr.schedule.count else { return }
-            cr.schedule[index].ratio = ratio
-            carbRatios = cr
+            guard let cr = carbRatios, index < cr.schedule.count else { return }
+            let existing = cr.schedule[index]
+            var newSchedule = cr.schedule
+            newSchedule[index] = CarbRatioEntry(start: existing.start, offset: existing.offset, ratio: ratio)
+            carbRatios = CarbRatios(units: cr.units, schedule: newSchedule)
         }
 
         func deleteCarbRatioEntry(at index: Int) {
-            guard var cr = carbRatios, index < cr.schedule.count else { return }
-            cr.schedule.remove(at: index)
-            carbRatios = cr
+            guard let cr = carbRatios, index < cr.schedule.count else { return }
+            var newSchedule = cr.schedule
+            newSchedule.remove(at: index)
+            carbRatios = CarbRatios(units: cr.units, schedule: newSchedule)
         }
 
         // MARK: - Glucose Targets Editing
@@ -364,8 +370,8 @@ extension TherapyProfileEditor {
 
         func updateTargetEntry(at index: Int, low: Decimal, high: Decimal) {
             guard var targets = bgTargets, index < targets.targets.count else { return }
-            targets.targets[index].low = low
-            targets.targets[index].high = high
+            let existing = targets.targets[index]
+            targets.targets[index] = BGTargetEntry(low: low, high: high, start: existing.start, offset: existing.offset)
             bgTargets = targets
         }
 

--- a/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift
@@ -84,6 +84,7 @@ extension TherapyProfileEditor {
         // MARK: - Computed Properties
 
         var conflictingDays: Set<Weekday> {
+            guard let provider = provider else { return [] }
             var conflicts = Set<Weekday>()
             for profile in provider.allProfiles where profile.id != profileId {
                 conflicts.formUnion(profile.activeDays)
@@ -92,6 +93,7 @@ extension TherapyProfileEditor {
         }
 
         var conflictingDayOwners: [Weekday: String] {
+            guard let provider = provider else { return [:] }
             var owners: [Weekday: String] = [:]
             for profile in provider.allProfiles where profile.id != profileId {
                 for day in profile.activeDays {
@@ -106,15 +108,16 @@ extension TherapyProfileEditor {
         }
 
         var units: GlucoseUnits {
-            provider.units
+            provider?.units ?? .mgdL
         }
 
         var availableProfilesForCopy: [TherapyProfile] {
-            provider.allProfiles.filter { $0.id != profileId }
+            guard let provider = provider else { return [] }
+            return provider.allProfiles.filter { $0.id != profileId }
         }
 
         var hasCurrentActiveSettings: Bool {
-            provider.hasCurrentActiveSettings
+            provider?.hasCurrentActiveSettings ?? false
         }
 
         // MARK: - Actions
@@ -124,6 +127,11 @@ extension TherapyProfileEditor {
 
             if trimmedName.isEmpty {
                 nameError = NSLocalizedString("Profile name is required", comment: "Validation error")
+                return
+            }
+
+            guard let provider = provider else {
+                nameError = nil
                 return
             }
 
@@ -192,6 +200,7 @@ extension TherapyProfileEditor {
         }
 
         func copyFromCurrentActiveSettings() {
+            guard let provider = provider else { return }
             let currentBasal = provider.currentBasalProfile
             let currentISF = provider.currentInsulinSensitivities
             let currentCR = provider.currentCarbRatios

--- a/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift
@@ -1,0 +1,164 @@
+import Combine
+import Foundation
+import Swinject
+
+extension TherapyProfileEditor {
+    final class StateModel: BaseStateModel<Provider> {
+        @Injected() private var profileManager: ProfileManager!
+
+        // MARK: - Published Properties
+
+        @Published var name: String = ""
+        @Published var activeDays: Set<Weekday> = []
+        @Published var isDefault: Bool = false
+        @Published var hasChanges: Bool = false
+        @Published var showDiscardAlert: Bool = false
+        @Published var nameError: String?
+
+        // MARK: - Therapy Settings (read from profile)
+
+        @Published var basalProfile: [BasalProfileEntry] = []
+        @Published var insulinSensitivities: InsulinSensitivities?
+        @Published var carbRatios: CarbRatios?
+        @Published var bgTargets: BGTargets?
+
+        // MARK: - Private Properties
+
+        private var originalProfile: TherapyProfile?
+        private var isNew: Bool = false
+        private var cancellables = Set<AnyCancellable>()
+
+        var profileId: UUID {
+            originalProfile?.id ?? UUID()
+        }
+
+        override func subscribe() {
+            guard let profile = provider.profile else {
+                return
+            }
+
+            originalProfile = profile
+            isNew = provider.isNew
+
+            // Load values from profile
+            name = profile.name
+            activeDays = profile.activeDays
+            isDefault = profile.isDefault
+            basalProfile = profile.basalProfile
+            insulinSensitivities = profile.insulinSensitivities
+            carbRatios = profile.carbRatios
+            bgTargets = profile.bgTargets
+
+            // Track changes
+            setupChangeTracking()
+        }
+
+        private func setupChangeTracking() {
+            Publishers.CombineLatest4($name, $activeDays, $isDefault, $basalProfile)
+                .dropFirst()
+                .sink { [weak self] _ in
+                    self?.hasChanges = true
+                }
+                .store(in: &cancellables)
+        }
+
+        // MARK: - Computed Properties
+
+        var conflictingDays: Set<Weekday> {
+            // Find days assigned to other profiles
+            var conflicts = Set<Weekday>()
+            for profile in provider.allProfiles where profile.id != profileId {
+                conflicts.formUnion(profile.activeDays)
+            }
+            return conflicts
+        }
+
+        var canSave: Bool {
+            !name.isEmpty && nameError == nil
+        }
+
+        var units: GlucoseUnits {
+            provider.units
+        }
+
+        // MARK: - Actions
+
+        func validateName() {
+            let trimmedName = name.trimmingCharacters(in: .whitespaces)
+
+            if trimmedName.isEmpty {
+                nameError = NSLocalizedString("Profile name is required", comment: "Validation error")
+                return
+            }
+
+            // Check for duplicate names (excluding current profile)
+            let isDuplicate = provider.allProfiles.contains { profile in
+                profile.id != profileId && profile.name.lowercased() == trimmedName.lowercased()
+            }
+
+            if isDuplicate {
+                nameError = NSLocalizedString("A profile with this name already exists", comment: "Validation error")
+                return
+            }
+
+            nameError = nil
+        }
+
+        func save() {
+            validateName()
+            guard canSave else { return }
+
+            guard var profile = originalProfile else { return }
+
+            profile.name = name.trimmingCharacters(in: .whitespaces)
+            profile.activeDays = activeDays
+            profile.isDefault = isDefault
+            profile.basalProfile = basalProfile
+            if let isf = insulinSensitivities {
+                profile.insulinSensitivities = isf
+            }
+            if let cr = carbRatios {
+                profile.carbRatios = cr
+            }
+            if let targets = bgTargets {
+                profile.bgTargets = targets
+            }
+
+            profileManager.updateProfile(profile)
+            hasChanges = false
+            hideModal()
+        }
+
+        func discardChanges() {
+            hasChanges = false
+            hideModal()
+        }
+
+        func confirmDiscard() {
+            if hasChanges {
+                showDiscardAlert = true
+            } else {
+                hideModal()
+            }
+        }
+
+        // MARK: - Navigation to Editors
+
+        func editBasalRates() {
+            // Navigate to basal editor with callback
+            showModal(for: .basalProfileEditor)
+        }
+
+        func editInsulinSensitivities() {
+            showModal(for: .isfEditor)
+        }
+
+        func editCarbRatios() {
+            showModal(for: .crEditor)
+        }
+
+        func editGlucoseTargets() {
+            showModal(for: .targetsEditor)
+        }
+    }
+}

--- a/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/TherapyProfileEditorStateModel.swift
@@ -15,12 +15,24 @@ extension TherapyProfileEditor {
         @Published var showDiscardAlert: Bool = false
         @Published var nameError: String?
 
-        // MARK: - Therapy Settings (read from profile)
+        // MARK: - Therapy Settings
 
         @Published var basalProfile: [BasalProfileEntry] = []
         @Published var insulinSensitivities: InsulinSensitivities?
         @Published var carbRatios: CarbRatios?
         @Published var bgTargets: BGTargets?
+
+        // MARK: - UI State
+
+        @Published var showCopySheet: Bool = false
+        @Published var expandedSection: SettingsSection?
+
+        enum SettingsSection: String, CaseIterable {
+            case basal
+            case isf
+            case carbRatio
+            case targets
+        }
 
         // MARK: - Private Properties
 
@@ -60,17 +72,33 @@ extension TherapyProfileEditor {
                     self?.hasChanges = true
                 }
                 .store(in: &cancellables)
+
+            Publishers.CombineLatest3($insulinSensitivities, $carbRatios, $bgTargets)
+                .dropFirst()
+                .sink { [weak self] _ in
+                    self?.hasChanges = true
+                }
+                .store(in: &cancellables)
         }
 
         // MARK: - Computed Properties
 
         var conflictingDays: Set<Weekday> {
-            // Find days assigned to other profiles
             var conflicts = Set<Weekday>()
             for profile in provider.allProfiles where profile.id != profileId {
                 conflicts.formUnion(profile.activeDays)
             }
             return conflicts
+        }
+
+        var conflictingDayOwners: [Weekday: String] {
+            var owners: [Weekday: String] = [:]
+            for profile in provider.allProfiles where profile.id != profileId {
+                for day in profile.activeDays {
+                    owners[day] = profile.name
+                }
+            }
+            return owners
         }
 
         var canSave: Bool {
@@ -79,6 +107,14 @@ extension TherapyProfileEditor {
 
         var units: GlucoseUnits {
             provider.units
+        }
+
+        var availableProfilesForCopy: [TherapyProfile] {
+            provider.allProfiles.filter { $0.id != profileId }
+        }
+
+        var hasCurrentActiveSettings: Bool {
+            provider.hasCurrentActiveSettings
         }
 
         // MARK: - Actions
@@ -91,7 +127,6 @@ extension TherapyProfileEditor {
                 return
             }
 
-            // Check for duplicate names (excluding current profile)
             let isDuplicate = provider.allProfiles.contains { profile in
                 profile.id != profileId && profile.name.lowercased() == trimmedName.lowercased()
             }
@@ -142,23 +177,202 @@ extension TherapyProfileEditor {
             }
         }
 
-        // MARK: - Navigation to Editors
+        // MARK: - Copy Settings
 
-        func editBasalRates() {
-            // Navigate to basal editor with callback
-            showModal(for: .basalProfileEditor)
+        func showCopyOptions() {
+            showCopySheet = true
         }
 
-        func editInsulinSensitivities() {
-            showModal(for: .isfEditor)
+        func copySettingsFrom(profile: TherapyProfile) {
+            basalProfile = profile.basalProfile
+            insulinSensitivities = profile.insulinSensitivities
+            carbRatios = profile.carbRatios
+            bgTargets = profile.bgTargets
+            hasChanges = true
         }
 
-        func editCarbRatios() {
-            showModal(for: .crEditor)
+        func copyFromCurrentActiveSettings() {
+            let currentBasal = provider.currentBasalProfile
+            let currentISF = provider.currentInsulinSensitivities
+            let currentCR = provider.currentCarbRatios
+            let currentTargets = provider.currentBGTargets
+
+            basalProfile = currentBasal
+            if let isf = currentISF {
+                insulinSensitivities = isf
+            }
+            if let cr = currentCR {
+                carbRatios = cr
+            }
+            if let targets = currentTargets {
+                bgTargets = targets
+            }
+            hasChanges = true
         }
 
-        func editGlucoseTargets() {
-            showModal(for: .targetsEditor)
+        // MARK: - Section Expansion
+
+        func toggleSection(_ section: SettingsSection) {
+            if expandedSection == section {
+                expandedSection = nil
+            } else {
+                expandedSection = section
+            }
+        }
+
+        // MARK: - Basal Rate Editing
+
+        func addBasalEntry() {
+            let newEntry = BasalProfileEntry(
+                start: nextAvailableBasalTime(),
+                minutes: nextAvailableBasalMinutes(),
+                rate: 0.0
+            )
+            basalProfile.append(newEntry)
+            basalProfile.sort { $0.minutes < $1.minutes }
+        }
+
+        func updateBasalEntry(at index: Int, rate: Decimal) {
+            guard index < basalProfile.count else { return }
+            basalProfile[index].rate = rate
+        }
+
+        func updateBasalEntryTime(at index: Int, minutes: Int) {
+            guard index < basalProfile.count else { return }
+            basalProfile[index].minutes = minutes
+            basalProfile[index].start = minutesToTimeString(minutes)
+            basalProfile.sort { $0.minutes < $1.minutes }
+        }
+
+        func deleteBasalEntry(at index: Int) {
+            guard index < basalProfile.count else { return }
+            basalProfile.remove(at: index)
+        }
+
+        private func nextAvailableBasalTime() -> String {
+            if basalProfile.isEmpty {
+                return "00:00"
+            }
+            let lastMinutes = basalProfile.last?.minutes ?? 0
+            let nextMinutes = min(lastMinutes + 60, 23 * 60)
+            return minutesToTimeString(nextMinutes)
+        }
+
+        private func nextAvailableBasalMinutes() -> Int {
+            if basalProfile.isEmpty {
+                return 0
+            }
+            let lastMinutes = basalProfile.last?.minutes ?? 0
+            return min(lastMinutes + 60, 23 * 60)
+        }
+
+        private func minutesToTimeString(_ minutes: Int) -> String {
+            let hours = minutes / 60
+            let mins = minutes % 60
+            return String(format: "%02d:%02d", hours, mins)
+        }
+
+        // MARK: - ISF Editing
+
+        func addISFEntry() {
+            guard var isf = insulinSensitivities else {
+                insulinSensitivities = InsulinSensitivities(
+                    units: units,
+                    userPreferredUnits: units,
+                    sensitivities: [InsulinSensitivityEntry(sensitivity: 0, offset: 0, start: "00:00")]
+                )
+                return
+            }
+            let nextOffset = (isf.sensitivities.last?.offset ?? 0) + 60
+            let newEntry = InsulinSensitivityEntry(
+                sensitivity: isf.sensitivities.last?.sensitivity ?? 0,
+                offset: min(nextOffset, 23 * 60),
+                start: minutesToTimeString(min(nextOffset, 23 * 60))
+            )
+            isf.sensitivities.append(newEntry)
+            isf.sensitivities.sort { $0.offset < $1.offset }
+            insulinSensitivities = isf
+        }
+
+        func updateISFEntry(at index: Int, sensitivity: Decimal) {
+            guard var isf = insulinSensitivities, index < isf.sensitivities.count else { return }
+            isf.sensitivities[index].sensitivity = sensitivity
+            insulinSensitivities = isf
+        }
+
+        func deleteISFEntry(at index: Int) {
+            guard var isf = insulinSensitivities, index < isf.sensitivities.count else { return }
+            isf.sensitivities.remove(at: index)
+            insulinSensitivities = isf
+        }
+
+        // MARK: - Carb Ratio Editing
+
+        func addCarbRatioEntry() {
+            guard var cr = carbRatios else {
+                carbRatios = CarbRatios(
+                    units: .grams,
+                    schedule: [CarbRatioEntry(start: "00:00", offset: 0, ratio: 0)]
+                )
+                return
+            }
+            let nextOffset = (cr.schedule.last?.offset ?? 0) + 60
+            let newEntry = CarbRatioEntry(
+                start: minutesToTimeString(min(nextOffset, 23 * 60)),
+                offset: min(nextOffset, 23 * 60),
+                ratio: cr.schedule.last?.ratio ?? 0
+            )
+            cr.schedule.append(newEntry)
+            cr.schedule.sort { $0.offset < $1.offset }
+            carbRatios = cr
+        }
+
+        func updateCarbRatioEntry(at index: Int, ratio: Decimal) {
+            guard var cr = carbRatios, index < cr.schedule.count else { return }
+            cr.schedule[index].ratio = ratio
+            carbRatios = cr
+        }
+
+        func deleteCarbRatioEntry(at index: Int) {
+            guard var cr = carbRatios, index < cr.schedule.count else { return }
+            cr.schedule.remove(at: index)
+            carbRatios = cr
+        }
+
+        // MARK: - Glucose Targets Editing
+
+        func addTargetEntry() {
+            guard var targets = bgTargets else {
+                bgTargets = BGTargets(
+                    units: units,
+                    userPreferredUnits: units,
+                    targets: [BGTargetEntry(low: 100, high: 120, start: "00:00", offset: 0)]
+                )
+                return
+            }
+            let nextOffset = (targets.targets.last?.offset ?? 0) + 60
+            let newEntry = BGTargetEntry(
+                low: targets.targets.last?.low ?? 100,
+                high: targets.targets.last?.high ?? 120,
+                start: minutesToTimeString(min(nextOffset, 23 * 60)),
+                offset: min(nextOffset, 23 * 60)
+            )
+            targets.targets.append(newEntry)
+            targets.targets.sort { $0.offset < $1.offset }
+            bgTargets = targets
+        }
+
+        func updateTargetEntry(at index: Int, low: Decimal, high: Decimal) {
+            guard var targets = bgTargets, index < targets.targets.count else { return }
+            targets.targets[index].low = low
+            targets.targets[index].high = high
+            bgTargets = targets
+        }
+
+        func deleteTargetEntry(at index: Int) {
+            guard var targets = bgTargets, index < targets.targets.count else { return }
+            targets.targets.remove(at: index)
+            bgTargets = targets
         }
     }
 }

--- a/Trio/Sources/Modules/TherapyProfileEditor/View/TherapyProfileEditorRootView.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/View/TherapyProfileEditorRootView.swift
@@ -11,6 +11,7 @@ extension TherapyProfileEditor {
             Form {
                 basicInfoSection
                 schedulingSection
+                copySettingsSection
                 therapySettingsSection
                 optionsSection
             }
@@ -41,6 +42,9 @@ extension TherapyProfileEditor {
                 }
             } message: {
                 Text("You have unsaved changes. Are you sure you want to discard them?")
+            }
+            .sheet(isPresented: $state.showCopySheet) {
+                CopySettingsSheet(state: state)
             }
             .onAppear {
                 configureView()
@@ -77,60 +81,93 @@ extension TherapyProfileEditor {
                     WeekdayPickerView(
                         selectedDays: $state.activeDays,
                         conflictingDays: state.conflictingDays,
+                        conflictingDayOwners: state.conflictingDayOwners,
                         showQuickSelect: true
-                    ) { day in
-                        // Handle conflict tap - could show info about which profile owns this day
-                    }
+                    )
                 }
                 .padding(.vertical, 8)
             } header: {
                 Text("Active Days")
             } footer: {
-                if !state.conflictingDays.isEmpty {
-                    Text("Days shown in gray are assigned to other profiles.")
-                } else {
-                    Text("Select which days of the week this profile should be active.")
+                Text("Select which days of the week this profile should be active.")
+            }
+        }
+
+        @ViewBuilder
+        private var copySettingsSection: some View {
+            Section {
+                Button(action: state.showCopyOptions) {
+                    HStack {
+                        Image(systemName: "doc.on.doc")
+                        Text("Copy Settings From...")
+                    }
                 }
+            } footer: {
+                Text("Copy therapy settings from another profile or from your current active settings.")
             }
         }
 
         @ViewBuilder
         private var therapySettingsSection: some View {
             Section {
-                NavigationLink {
-                    BasalProfileEditor.RootView(resolver: resolver)
+                // Basal Rates
+                DisclosureGroup(
+                    isExpanded: Binding(
+                        get: { state.expandedSection == .basal },
+                        set: { _ in state.toggleSection(.basal) }
+                    )
+                ) {
+                    InlineBasalRatesEditor(state: state)
                 } label: {
-                    settingsRow(
+                    settingsRowLabel(
                         title: "Basal Rates",
                         subtitle: basalSummary,
                         systemImage: "waveform.path"
                     )
                 }
 
-                NavigationLink {
-                    ISFEditor.RootView(resolver: resolver)
+                // Insulin Sensitivities
+                DisclosureGroup(
+                    isExpanded: Binding(
+                        get: { state.expandedSection == .isf },
+                        set: { _ in state.toggleSection(.isf) }
+                    )
+                ) {
+                    InlineISFEditor(state: state)
                 } label: {
-                    settingsRow(
+                    settingsRowLabel(
                         title: "Insulin Sensitivities",
                         subtitle: isfSummary,
                         systemImage: "arrow.down.right"
                     )
                 }
 
-                NavigationLink {
-                    CarbRatioEditor.RootView(resolver: resolver)
+                // Carb Ratios
+                DisclosureGroup(
+                    isExpanded: Binding(
+                        get: { state.expandedSection == .carbRatio },
+                        set: { _ in state.toggleSection(.carbRatio) }
+                    )
+                ) {
+                    InlineCarbRatioEditor(state: state)
                 } label: {
-                    settingsRow(
+                    settingsRowLabel(
                         title: "Carb Ratios",
                         subtitle: carbRatioSummary,
                         systemImage: "fork.knife"
                     )
                 }
 
-                NavigationLink {
-                    TargetsEditor.RootView(resolver: resolver)
+                // Glucose Targets
+                DisclosureGroup(
+                    isExpanded: Binding(
+                        get: { state.expandedSection == .targets },
+                        set: { _ in state.toggleSection(.targets) }
+                    )
+                ) {
+                    InlineTargetsEditor(state: state)
                 } label: {
-                    settingsRow(
+                    settingsRowLabel(
                         title: "Glucose Targets",
                         subtitle: targetsSummary,
                         systemImage: "target"
@@ -139,7 +176,7 @@ extension TherapyProfileEditor {
             } header: {
                 Text("Therapy Settings")
             } footer: {
-                Text("Configure the insulin delivery and glucose management settings for this profile.")
+                Text("Configure the insulin delivery and glucose management settings for this profile. These settings only apply when this profile is active.")
             }
         }
 
@@ -157,7 +194,7 @@ extension TherapyProfileEditor {
         // MARK: - Helper Views
 
         @ViewBuilder
-        private func settingsRow(title: String, subtitle: String, systemImage: String) -> some View {
+        private func settingsRowLabel(title: String, subtitle: String, systemImage: String) -> some View {
             HStack(spacing: 12) {
                 Image(systemName: systemImage)
                     .font(.title3)
@@ -167,13 +204,13 @@ extension TherapyProfileEditor {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
                         .font(.body)
+                        .foregroundColor(.primary)
 
                     Text(subtitle)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
             }
-            .padding(.vertical, 4)
         }
 
         // MARK: - Summaries
@@ -183,7 +220,6 @@ extension TherapyProfileEditor {
             if count == 0 {
                 return "Not configured"
             }
-            let total = state.basalProfile.reduce(Decimal.zero) { $0 + $1.rate }
             return "\(count) rate\(count == 1 ? "" : "s")"
         }
 
@@ -209,6 +245,415 @@ extension TherapyProfileEditor {
             }
             let count = targets.targets.count
             return "\(count) target\(count == 1 ? "" : "s")"
+        }
+    }
+}
+
+// MARK: - Copy Settings Sheet
+
+private struct CopySettingsSheet: View {
+    @ObservedObject var state: TherapyProfileEditor.StateModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            List {
+                if state.hasCurrentActiveSettings {
+                    Section {
+                        Button(action: {
+                            state.copyFromCurrentActiveSettings()
+                            dismiss()
+                        }) {
+                            HStack {
+                                Image(systemName: "bolt.fill")
+                                    .foregroundColor(.green)
+                                VStack(alignment: .leading) {
+                                    Text("Current Active Settings")
+                                        .foregroundColor(.primary)
+                                    Text("Copy from your pump's current settings")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    } header: {
+                        Text("Active Settings")
+                    }
+                }
+
+                if !state.availableProfilesForCopy.isEmpty {
+                    Section {
+                        ForEach(state.availableProfilesForCopy) { profile in
+                            Button(action: {
+                                state.copySettingsFrom(profile: profile)
+                                dismiss()
+                            }) {
+                                HStack {
+                                    Image(systemName: "person.crop.circle")
+                                        .foregroundColor(.accentColor)
+                                    VStack(alignment: .leading) {
+                                        Text(profile.name)
+                                            .foregroundColor(.primary)
+                                        Text(profile.activeDays.formattedString)
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                    } header: {
+                        Text("Existing Profiles")
+                    }
+                }
+            }
+            .navigationTitle("Copy Settings From")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Inline Basal Rates Editor
+
+private struct InlineBasalRatesEditor: View {
+    @ObservedObject var state: TherapyProfileEditor.StateModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(state.basalProfile.enumerated()), id: \.element.minutes) { index, entry in
+                BasalEntryRow(
+                    entry: entry,
+                    onRateChanged: { newRate in
+                        state.updateBasalEntry(at: index, rate: newRate)
+                    },
+                    onDelete: {
+                        state.deleteBasalEntry(at: index)
+                    }
+                )
+                if index < state.basalProfile.count - 1 {
+                    Divider()
+                }
+            }
+
+            Button(action: state.addBasalEntry) {
+                HStack {
+                    Image(systemName: "plus.circle.fill")
+                    Text("Add Time Slot")
+                }
+                .font(.subheadline)
+            }
+            .padding(.top, 8)
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+private struct BasalEntryRow: View {
+    let entry: BasalProfileEntry
+    let onRateChanged: (Decimal) -> Void
+    let onDelete: () -> Void
+
+    @State private var rateText: String = ""
+
+    var body: some View {
+        HStack {
+            Text(entry.start)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .frame(width: 60, alignment: .leading)
+
+            TextField("Rate", text: $rateText)
+                .keyboardType(.decimalPad)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .frame(width: 80)
+                .onChange(of: rateText) { _, newValue in
+                    if let rate = Decimal(string: newValue) {
+                        onRateChanged(rate)
+                    }
+                }
+
+            Text("U/hr")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Spacer()
+
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+                    .foregroundColor(.red)
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(.vertical, 4)
+        .onAppear {
+            rateText = "\(entry.rate)"
+        }
+    }
+}
+
+// MARK: - Inline ISF Editor
+
+private struct InlineISFEditor: View {
+    @ObservedObject var state: TherapyProfileEditor.StateModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let isf = state.insulinSensitivities {
+                ForEach(Array(isf.sensitivities.enumerated()), id: \.element.offset) { index, entry in
+                    ISFEntryRow(
+                        entry: entry,
+                        units: state.units,
+                        onSensitivityChanged: { newValue in
+                            state.updateISFEntry(at: index, sensitivity: newValue)
+                        },
+                        onDelete: {
+                            state.deleteISFEntry(at: index)
+                        }
+                    )
+                    if index < isf.sensitivities.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+
+            Button(action: state.addISFEntry) {
+                HStack {
+                    Image(systemName: "plus.circle.fill")
+                    Text("Add Time Slot")
+                }
+                .font(.subheadline)
+            }
+            .padding(.top, 8)
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+private struct ISFEntryRow: View {
+    let entry: InsulinSensitivityEntry
+    let units: GlucoseUnits
+    let onSensitivityChanged: (Decimal) -> Void
+    let onDelete: () -> Void
+
+    @State private var valueText: String = ""
+
+    var body: some View {
+        HStack {
+            Text(entry.start)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .frame(width: 60, alignment: .leading)
+
+            TextField("ISF", text: $valueText)
+                .keyboardType(.decimalPad)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .frame(width: 80)
+                .onChange(of: valueText) { _, newValue in
+                    if let value = Decimal(string: newValue) {
+                        onSensitivityChanged(value)
+                    }
+                }
+
+            Text(units == .mgdL ? "mg/dL" : "mmol/L")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Spacer()
+
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+                    .foregroundColor(.red)
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(.vertical, 4)
+        .onAppear {
+            valueText = "\(entry.sensitivity)"
+        }
+    }
+}
+
+// MARK: - Inline Carb Ratio Editor
+
+private struct InlineCarbRatioEditor: View {
+    @ObservedObject var state: TherapyProfileEditor.StateModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let cr = state.carbRatios {
+                ForEach(Array(cr.schedule.enumerated()), id: \.element.offset) { index, entry in
+                    CarbRatioEntryRow(
+                        entry: entry,
+                        onRatioChanged: { newValue in
+                            state.updateCarbRatioEntry(at: index, ratio: newValue)
+                        },
+                        onDelete: {
+                            state.deleteCarbRatioEntry(at: index)
+                        }
+                    )
+                    if index < cr.schedule.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+
+            Button(action: state.addCarbRatioEntry) {
+                HStack {
+                    Image(systemName: "plus.circle.fill")
+                    Text("Add Time Slot")
+                }
+                .font(.subheadline)
+            }
+            .padding(.top, 8)
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+private struct CarbRatioEntryRow: View {
+    let entry: CarbRatioEntry
+    let onRatioChanged: (Decimal) -> Void
+    let onDelete: () -> Void
+
+    @State private var valueText: String = ""
+
+    var body: some View {
+        HStack {
+            Text(entry.start)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .frame(width: 60, alignment: .leading)
+
+            TextField("Ratio", text: $valueText)
+                .keyboardType(.decimalPad)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .frame(width: 80)
+                .onChange(of: valueText) { _, newValue in
+                    if let value = Decimal(string: newValue) {
+                        onRatioChanged(value)
+                    }
+                }
+
+            Text("g/U")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Spacer()
+
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+                    .foregroundColor(.red)
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(.vertical, 4)
+        .onAppear {
+            valueText = "\(entry.ratio)"
+        }
+    }
+}
+
+// MARK: - Inline Targets Editor
+
+private struct InlineTargetsEditor: View {
+    @ObservedObject var state: TherapyProfileEditor.StateModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let targets = state.bgTargets {
+                ForEach(Array(targets.targets.enumerated()), id: \.element.offset) { index, entry in
+                    TargetEntryRow(
+                        entry: entry,
+                        units: state.units,
+                        onValuesChanged: { low, high in
+                            state.updateTargetEntry(at: index, low: low, high: high)
+                        },
+                        onDelete: {
+                            state.deleteTargetEntry(at: index)
+                        }
+                    )
+                    if index < targets.targets.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+
+            Button(action: state.addTargetEntry) {
+                HStack {
+                    Image(systemName: "plus.circle.fill")
+                    Text("Add Time Slot")
+                }
+                .font(.subheadline)
+            }
+            .padding(.top, 8)
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+private struct TargetEntryRow: View {
+    let entry: BGTargetEntry
+    let units: GlucoseUnits
+    let onValuesChanged: (Decimal, Decimal) -> Void
+    let onDelete: () -> Void
+
+    @State private var lowText: String = ""
+    @State private var highText: String = ""
+
+    var body: some View {
+        HStack {
+            Text(entry.start)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .frame(width: 50, alignment: .leading)
+
+            TextField("Low", text: $lowText)
+                .keyboardType(.decimalPad)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .frame(width: 60)
+                .onChange(of: lowText) { _, _ in
+                    updateValues()
+                }
+
+            Text("-")
+                .foregroundColor(.secondary)
+
+            TextField("High", text: $highText)
+                .keyboardType(.decimalPad)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .frame(width: 60)
+                .onChange(of: highText) { _, _ in
+                    updateValues()
+                }
+
+            Text(units == .mgdL ? "mg/dL" : "mmol/L")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Spacer()
+
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+                    .foregroundColor(.red)
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(.vertical, 4)
+        .onAppear {
+            lowText = "\(entry.low)"
+            highText = "\(entry.high)"
+        }
+    }
+
+    private func updateValues() {
+        if let low = Decimal(string: lowText), let high = Decimal(string: highText) {
+            onValuesChanged(low, high)
         }
     }
 }

--- a/Trio/Sources/Modules/TherapyProfileEditor/View/TherapyProfileEditorRootView.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/View/TherapyProfileEditorRootView.swift
@@ -118,7 +118,7 @@ extension TherapyProfileEditor {
                 }
 
                 NavigationLink {
-                    CREditor.RootView(resolver: resolver)
+                    CarbRatioEditor.RootView(resolver: resolver)
                 } label: {
                     settingsRow(
                         title: "Carb Ratios",

--- a/Trio/Sources/Modules/TherapyProfileEditor/View/TherapyProfileEditorRootView.swift
+++ b/Trio/Sources/Modules/TherapyProfileEditor/View/TherapyProfileEditorRootView.swift
@@ -1,0 +1,226 @@
+import SwiftUI
+import Swinject
+
+extension TherapyProfileEditor {
+    struct RootView: BaseView {
+        let resolver: Resolver
+        @StateObject var state = StateModel()
+        @Environment(\.dismiss) private var dismiss
+
+        var body: some View {
+            Form {
+                basicInfoSection
+                schedulingSection
+                therapySettingsSection
+                optionsSection
+            }
+            .navigationTitle(state.name.isEmpty ? "New Profile" : state.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden(state.hasChanges)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if state.hasChanges {
+                        Button("Cancel") {
+                            state.confirmDiscard()
+                        }
+                    }
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") {
+                        state.save()
+                    }
+                    .disabled(!state.canSave)
+                    .fontWeight(.semibold)
+                }
+            }
+            .alert("Discard Changes?", isPresented: $state.showDiscardAlert) {
+                Button("Keep Editing", role: .cancel) {}
+                Button("Discard", role: .destructive) {
+                    state.discardChanges()
+                }
+            } message: {
+                Text("You have unsaved changes. Are you sure you want to discard them?")
+            }
+            .onAppear {
+                configureView()
+            }
+        }
+
+        // MARK: - Sections
+
+        @ViewBuilder
+        private var basicInfoSection: some View {
+            Section {
+                VStack(alignment: .leading, spacing: 4) {
+                    TextField("Profile Name", text: $state.name)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .onChange(of: state.name) { _, _ in
+                            state.validateName()
+                        }
+
+                    if let error = state.nameError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+            } header: {
+                Text("Profile Name")
+            }
+        }
+
+        @ViewBuilder
+        private var schedulingSection: some View {
+            Section {
+                VStack(alignment: .leading, spacing: 12) {
+                    WeekdayPickerView(
+                        selectedDays: $state.activeDays,
+                        conflictingDays: state.conflictingDays,
+                        showQuickSelect: true
+                    ) { day in
+                        // Handle conflict tap - could show info about which profile owns this day
+                    }
+                }
+                .padding(.vertical, 8)
+            } header: {
+                Text("Active Days")
+            } footer: {
+                if !state.conflictingDays.isEmpty {
+                    Text("Days shown in gray are assigned to other profiles.")
+                } else {
+                    Text("Select which days of the week this profile should be active.")
+                }
+            }
+        }
+
+        @ViewBuilder
+        private var therapySettingsSection: some View {
+            Section {
+                NavigationLink {
+                    BasalProfileEditor.RootView(resolver: resolver)
+                } label: {
+                    settingsRow(
+                        title: "Basal Rates",
+                        subtitle: basalSummary,
+                        systemImage: "waveform.path"
+                    )
+                }
+
+                NavigationLink {
+                    ISFEditor.RootView(resolver: resolver)
+                } label: {
+                    settingsRow(
+                        title: "Insulin Sensitivities",
+                        subtitle: isfSummary,
+                        systemImage: "arrow.down.right"
+                    )
+                }
+
+                NavigationLink {
+                    CREditor.RootView(resolver: resolver)
+                } label: {
+                    settingsRow(
+                        title: "Carb Ratios",
+                        subtitle: carbRatioSummary,
+                        systemImage: "fork.knife"
+                    )
+                }
+
+                NavigationLink {
+                    TargetsEditor.RootView(resolver: resolver)
+                } label: {
+                    settingsRow(
+                        title: "Glucose Targets",
+                        subtitle: targetsSummary,
+                        systemImage: "target"
+                    )
+                }
+            } header: {
+                Text("Therapy Settings")
+            } footer: {
+                Text("Configure the insulin delivery and glucose management settings for this profile.")
+            }
+        }
+
+        @ViewBuilder
+        private var optionsSection: some View {
+            Section {
+                Toggle("Set as Default Profile", isOn: $state.isDefault)
+            } header: {
+                Text("Options")
+            } footer: {
+                Text("The default profile is used when no specific profile is scheduled for a day.")
+            }
+        }
+
+        // MARK: - Helper Views
+
+        @ViewBuilder
+        private func settingsRow(title: String, subtitle: String, systemImage: String) -> some View {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.title3)
+                    .foregroundColor(.accentColor)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.body)
+
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+
+        // MARK: - Summaries
+
+        private var basalSummary: String {
+            let count = state.basalProfile.count
+            if count == 0 {
+                return "Not configured"
+            }
+            let total = state.basalProfile.reduce(Decimal.zero) { $0 + $1.rate }
+            return "\(count) rate\(count == 1 ? "" : "s")"
+        }
+
+        private var isfSummary: String {
+            guard let isf = state.insulinSensitivities else {
+                return "Not configured"
+            }
+            let count = isf.sensitivities.count
+            return "\(count) value\(count == 1 ? "" : "s")"
+        }
+
+        private var carbRatioSummary: String {
+            guard let cr = state.carbRatios else {
+                return "Not configured"
+            }
+            let count = cr.schedule.count
+            return "\(count) ratio\(count == 1 ? "" : "s")"
+        }
+
+        private var targetsSummary: String {
+            guard let targets = state.bgTargets else {
+                return "Not configured"
+            }
+            let count = targets.targets.count
+            return "\(count) target\(count == 1 ? "" : "s")"
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+    struct TherapyProfileEditorRootView_Previews: PreviewProvider {
+        static var previews: some View {
+            NavigationView {
+                Text("Preview requires resolver setup")
+            }
+        }
+    }
+#endif

--- a/Trio/Sources/Modules/TherapyProfileList/TherapyProfileListDataFlow.swift
+++ b/Trio/Sources/Modules/TherapyProfileList/TherapyProfileListDataFlow.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum TherapyProfileList {
+    enum Config {}
+}
+
+protocol TherapyProfileListProvider: Provider {
+    var profiles: [TherapyProfile] { get }
+    var activeProfile: TherapyProfile? { get }
+    var isManualOverrideActive: Bool { get }
+}

--- a/Trio/Sources/Modules/TherapyProfileList/TherapyProfileListProvider.swift
+++ b/Trio/Sources/Modules/TherapyProfileList/TherapyProfileListProvider.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Swinject
+
+extension TherapyProfileList {
+    final class Provider: BaseProvider, TherapyProfileListProvider {
+        @Injected() private var profileManager: ProfileManager!
+
+        var profiles: [TherapyProfile] {
+            profileManager.profiles
+        }
+
+        var activeProfile: TherapyProfile? {
+            profileManager.activeProfile
+        }
+
+        var isManualOverrideActive: Bool {
+            profileManager.isManualOverrideActive
+        }
+    }
+}

--- a/Trio/Sources/Modules/TherapyProfileList/TherapyProfileListStateModel.swift
+++ b/Trio/Sources/Modules/TherapyProfileList/TherapyProfileListStateModel.swift
@@ -1,0 +1,118 @@
+import Combine
+import Foundation
+import Swinject
+
+extension TherapyProfileList {
+    final class StateModel: BaseStateModel<Provider>, ProfileManagerObserver {
+        @Injected() private var profileManager: ProfileManager!
+        @Injected() private var broadcaster: Broadcaster!
+
+        @Published var profiles: [TherapyProfile] = []
+        @Published var activeProfile: TherapyProfile?
+        @Published var isManualOverrideActive: Bool = false
+        @Published var showDeleteAlert: Bool = false
+        @Published var profileToDelete: TherapyProfile?
+        @Published var deleteError: String?
+
+        override func subscribe() {
+            profiles = provider.profiles
+            activeProfile = provider.activeProfile
+            isManualOverrideActive = provider.isManualOverrideActive
+
+            broadcaster.register(ProfileManagerObserver.self, observer: self)
+        }
+
+        // MARK: - ProfileManagerObserver
+
+        func activeProfileDidChange(_ profile: TherapyProfile) {
+            activeProfile = profile
+            isManualOverrideActive = profileManager.isManualOverrideActive
+        }
+
+        func profilesDidChange(_ profiles: [TherapyProfile]) {
+            self.profiles = profiles
+        }
+
+        // MARK: - Actions
+
+        func activateProfile(_ profile: TherapyProfile) {
+            profileManager.activateProfile(id: profile.id, reason: .manual)
+        }
+
+        func activateProfileAsOverride(_ profile: TherapyProfile) {
+            profileManager.activateProfileAsOverride(id: profile.id)
+        }
+
+        func clearOverride() {
+            profileManager.clearManualOverride()
+        }
+
+        func createNewProfile() {
+            // Navigate to editor with new profile
+            let newProfile = profileManager.createProfile(
+                name: generateUniqueName(),
+                copyFrom: nil
+            )
+            showModal(for: .therapyProfileEditor(profile: newProfile, isNew: true))
+        }
+
+        func duplicateProfile(_ profile: TherapyProfile) {
+            let newProfile = profileManager.createProfile(
+                name: "\(profile.name) Copy",
+                copyFrom: profile
+            )
+            showModal(for: .therapyProfileEditor(profile: newProfile, isNew: true))
+        }
+
+        func editProfile(_ profile: TherapyProfile) {
+            showModal(for: .therapyProfileEditor(profile: profile, isNew: false))
+        }
+
+        func confirmDelete(_ profile: TherapyProfile) {
+            profileToDelete = profile
+            deleteError = nil
+            showDeleteAlert = true
+        }
+
+        func deleteProfile() {
+            guard let profile = profileToDelete else { return }
+
+            do {
+                try profileManager.deleteProfile(id: profile.id)
+                profileToDelete = nil
+                showDeleteAlert = false
+            } catch let error as ProfileManagerError {
+                deleteError = error.errorDescription
+            } catch {
+                deleteError = error.localizedDescription
+            }
+        }
+
+        func canDeleteProfile(_ profile: TherapyProfile) -> Bool {
+            !profile.isDefault && activeProfile?.id != profile.id
+        }
+
+        // MARK: - Helpers
+
+        private func generateUniqueName() -> String {
+            let baseName = NSLocalizedString("New Profile", comment: "Default name for new profile")
+            var name = baseName
+            var counter = 1
+
+            while profiles.contains(where: { $0.name == name }) {
+                counter += 1
+                name = "\(baseName) \(counter)"
+            }
+
+            return name
+        }
+
+        var canCreateProfile: Bool {
+            profiles.count < TherapyProfile.maxProfiles
+        }
+
+        func daysDescription(for profile: TherapyProfile) -> String {
+            profile.activeDays.formattedString
+        }
+    }
+}

--- a/Trio/Sources/Modules/TherapyProfileList/View/TherapyProfileListRootView.swift
+++ b/Trio/Sources/Modules/TherapyProfileList/View/TherapyProfileListRootView.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+import Swinject
+
+extension TherapyProfileList {
+    struct RootView: BaseView {
+        let resolver: Resolver
+        @StateObject var state = StateModel()
+
+        var body: some View {
+            List {
+                if let activeProfile = state.activeProfile {
+                    activeProfileSection(activeProfile)
+                }
+
+                profilesSection
+
+                if state.canCreateProfile {
+                    addProfileSection
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Therapy Profiles")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if state.canCreateProfile {
+                        Button(action: state.createNewProfile) {
+                            Image(systemName: "plus")
+                        }
+                    }
+                }
+            }
+            .alert("Delete Profile", isPresented: $state.showDeleteAlert) {
+                Button("Cancel", role: .cancel) {
+                    state.profileToDelete = nil
+                }
+                Button("Delete", role: .destructive) {
+                    state.deleteProfile()
+                }
+            } message: {
+                if let error = state.deleteError {
+                    Text(error)
+                } else if let profile = state.profileToDelete {
+                    Text("Are you sure you want to delete '\(profile.name)'? This cannot be undone.")
+                }
+            }
+            .onAppear {
+                configureView()
+            }
+        }
+
+        @ViewBuilder
+        private func activeProfileSection(_ profile: TherapyProfile) -> some View {
+            Section {
+                ProfileSwitchInfoBanner(
+                    profileName: profile.name,
+                    isOverride: state.isManualOverrideActive
+                )
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+
+                if state.isManualOverrideActive {
+                    Button(action: state.clearOverride) {
+                        HStack {
+                            Image(systemName: "arrow.uturn.backward")
+                            Text("Revert to Scheduled Profile")
+                        }
+                    }
+                }
+            } header: {
+                Text("Current Status")
+            }
+        }
+
+        @ViewBuilder
+        private var profilesSection: some View {
+            Section {
+                ForEach(state.profiles) { profile in
+                    ProfileRow(
+                        profile: profile,
+                        isActive: state.activeProfile?.id == profile.id,
+                        daysDescription: state.daysDescription(for: profile),
+                        onTap: { state.editProfile(profile) },
+                        onActivate: { state.activateProfile(profile) },
+                        onOverride: { state.activateProfileAsOverride(profile) },
+                        onDuplicate: { state.duplicateProfile(profile) },
+                        onDelete: state.canDeleteProfile(profile) ? { state.confirmDelete(profile) } : nil
+                    )
+                }
+            } header: {
+                Text("Profiles")
+            } footer: {
+                Text("Tap a profile to edit. Each day of the week can only be assigned to one profile.")
+            }
+        }
+
+        @ViewBuilder
+        private var addProfileSection: some View {
+            Section {
+                Button(action: state.createNewProfile) {
+                    HStack {
+                        Image(systemName: "plus.circle.fill")
+                            .foregroundColor(.accentColor)
+                        Text("Add New Profile")
+                    }
+                }
+            } footer: {
+                Text("\(state.profiles.count) of \(TherapyProfile.maxProfiles) profiles used")
+            }
+        }
+    }
+}
+
+// MARK: - Profile Row
+
+private struct ProfileRow: View {
+    let profile: TherapyProfile
+    let isActive: Bool
+    let daysDescription: String
+    let onTap: () -> Void
+    let onActivate: () -> Void
+    let onOverride: () -> Void
+    let onDuplicate: () -> Void
+    let onDelete: (() -> Void)?
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 8) {
+                        Text(profile.name)
+                            .font(.headline)
+                            .foregroundColor(.primary)
+
+                        if profile.isDefault {
+                            Text("Default")
+                                .font(.caption2)
+                                .fontWeight(.medium)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Color.blue.opacity(0.2))
+                                .foregroundColor(.blue)
+                                .cornerRadius(4)
+                        }
+                    }
+
+                    Text(daysDescription)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if isActive {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                        .font(.title2)
+                }
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .contextMenu {
+            if !isActive {
+                Button(action: onActivate) {
+                    Label("Activate", systemImage: "checkmark.circle")
+                }
+
+                Button(action: onOverride) {
+                    Label("Override for Today", systemImage: "clock.badge.exclamationmark")
+                }
+
+                Divider()
+            }
+
+            Button(action: onDuplicate) {
+                Label("Duplicate", systemImage: "doc.on.doc")
+            }
+
+            if let deleteAction = onDelete {
+                Divider()
+
+                Button(role: .destructive, action: deleteAction) {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if let deleteAction = onDelete {
+                Button(role: .destructive, action: deleteAction) {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        }
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            if !isActive {
+                Button(action: onActivate) {
+                    Label("Activate", systemImage: "checkmark.circle")
+                }
+                .tint(.green)
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+    struct TherapyProfileListRootView_Previews: PreviewProvider {
+        static var previews: some View {
+            NavigationView {
+                Text("Preview requires resolver setup")
+            }
+        }
+    }
+#endif

--- a/Trio/Sources/Router/Screen.swift
+++ b/Trio/Sources/Router/Screen.swift
@@ -49,6 +49,8 @@ enum Screen: Identifiable, Hashable {
     case algorithmAdvancedSettings
     case unitsAndLimits
     case appDiagnostics
+    case therapyProfileList
+    case therapyProfileEditor(profile: TherapyProfile, isNew: Bool)
 
     var id: Int { String(reflecting: self).hashValue }
 }
@@ -162,7 +164,24 @@ extension Screen {
             UnitsLimitsSettings.RootView(resolver: resolver)
         case .appDiagnostics:
             AppDiagnostics.RootView(resolver: resolver)
+        case .therapyProfileList:
+            TherapyProfileList.RootView(resolver: resolver)
+        case let .therapyProfileEditor(profile, isNew):
+            configuredTherapyProfileEditor(resolver: resolver, profile: profile, isNew: isNew)
         }
+    }
+
+    @ViewBuilder
+    private func configuredTherapyProfileEditor(
+        resolver: Resolver,
+        profile: TherapyProfile,
+        isNew: Bool
+    ) -> some View {
+        let _ = {
+            TherapyProfileEditor.Config.profile = profile
+            TherapyProfileEditor.Config.isNew = isNew
+        }()
+        TherapyProfileEditor.RootView(resolver: resolver)
     }
 
     func modal(resolver: Resolver) -> Main.Modal {

--- a/Trio/Sources/Router/Screen.swift
+++ b/Trio/Sources/Router/Screen.swift
@@ -171,17 +171,14 @@ extension Screen {
         }
     }
 
-    @ViewBuilder
     private func configuredTherapyProfileEditor(
         resolver: Resolver,
         profile: TherapyProfile,
         isNew: Bool
     ) -> some View {
-        let _ = {
-            TherapyProfileEditor.Config.profile = profile
-            TherapyProfileEditor.Config.isNew = isNew
-        }()
-        TherapyProfileEditor.RootView(resolver: resolver)
+        TherapyProfileEditor.Config.profile = profile
+        TherapyProfileEditor.Config.isNew = isNew
+        return TherapyProfileEditor.RootView(resolver: resolver)
     }
 
     func modal(resolver: Resolver) -> Main.Modal {

--- a/Trio/Sources/Services/ProfileManager/BaseProfileManager.swift
+++ b/Trio/Sources/Services/ProfileManager/BaseProfileManager.swift
@@ -1,0 +1,389 @@
+import Combine
+import Foundation
+import Swinject
+
+final class BaseProfileManager: ProfileManager, Injectable {
+    @Injected() private var storage: FileStorage!
+    @Injected() private var broadcaster: Broadcaster!
+    @Injected() private var settingsManager: SettingsManager!
+
+    // MARK: - Published Properties
+
+    @Published private(set) var profiles: [TherapyProfile] = []
+    @Published private(set) var activeProfile: TherapyProfile?
+    @Published var pendingSwitchNotification: ProfileSwitchEvent?
+    @Published private(set) var switchHistory: [ProfileSwitchEvent] = []
+
+    // MARK: - Override State
+
+    private(set) var manualOverrideProfileId: UUID?
+    private(set) var manualOverrideDate: Date?
+
+    var isManualOverrideActive: Bool {
+        guard let overrideDate = manualOverrideDate else { return false }
+        // Override is active if it was set today
+        return Calendar.current.isDateInToday(overrideDate)
+    }
+
+    // MARK: - Publishers
+
+    var activeProfilePublisher: AnyPublisher<TherapyProfile?, Never> {
+        $activeProfile.eraseToAnyPublisher()
+    }
+
+    var pendingSwitchNotificationPublisher: AnyPublisher<ProfileSwitchEvent?, Never> {
+        $pendingSwitchNotification.eraseToAnyPublisher()
+    }
+
+    // MARK: - Private Properties
+
+    private var lastSwitchDate: Date?
+    private var subscriptions = Set<AnyCancellable>()
+
+    // MARK: - Initialization
+
+    init(resolver: Resolver) {
+        injectServices(resolver)
+        loadProfiles()
+        loadSwitchHistory()
+        loadOverrideState()
+
+        // If no profiles exist, migrate from single profile system
+        if profiles.isEmpty {
+            migrateFromSingleProfile()
+        }
+
+        // Load active profile
+        loadActiveProfile()
+    }
+
+    // MARK: - Profile Management
+
+    func createProfile(name: String, copyFrom: TherapyProfile?) -> TherapyProfile {
+        let newProfile: TherapyProfile
+
+        if let source = copyFrom {
+            newProfile = source.copy(withName: name)
+        } else {
+            // Create with default/empty settings
+            let units = settingsManager.settings.units
+            newProfile = TherapyProfile(
+                name: name,
+                activeDays: [],
+                basalProfile: [],
+                insulinSensitivities: InsulinSensitivities(
+                    units: units,
+                    userPreferredUnits: units,
+                    sensitivities: []
+                ),
+                carbRatios: CarbRatios(units: .grams, schedule: []),
+                bgTargets: BGTargets(
+                    units: units,
+                    userPreferredUnits: units,
+                    targets: []
+                ),
+                isDefault: profiles.isEmpty
+            )
+        }
+
+        profiles.append(newProfile)
+        saveProfiles()
+        notifyProfilesChanged()
+
+        return newProfile
+    }
+
+    func updateProfile(_ profile: TherapyProfile) {
+        guard let index = profiles.firstIndex(where: { $0.id == profile.id }) else {
+            return
+        }
+
+        var updatedProfile = profile
+        updatedProfile.touch()
+
+        // Handle day uniqueness - remove these days from other profiles
+        for (idx, existingProfile) in profiles.enumerated() where idx != index {
+            let conflictingDays = existingProfile.activeDays.intersection(updatedProfile.activeDays)
+            if !conflictingDays.isEmpty {
+                var modified = existingProfile
+                modified.activeDays.subtract(conflictingDays)
+                modified.touch()
+                profiles[idx] = modified
+            }
+        }
+
+        // Handle default flag - only one profile can be default
+        if updatedProfile.isDefault {
+            for (idx, existingProfile) in profiles.enumerated() where existingProfile.id != updatedProfile.id {
+                if existingProfile.isDefault {
+                    var modified = existingProfile
+                    modified.isDefault = false
+                    profiles[idx] = modified
+                }
+            }
+        }
+
+        profiles[index] = updatedProfile
+        saveProfiles()
+        notifyProfilesChanged()
+
+        // If this is the active profile, update it and write settings
+        if activeProfile?.id == profile.id {
+            activeProfile = updatedProfile
+            writeProfileSettingsToFiles(updatedProfile)
+            notifyActiveProfileChanged(updatedProfile)
+        }
+    }
+
+    func deleteProfile(id: UUID) throws {
+        guard let profile = profiles.first(where: { $0.id == id }) else {
+            throw ProfileManagerError.profileNotFound
+        }
+
+        if profile.isDefault {
+            throw ProfileManagerError.cannotDeleteDefaultProfile
+        }
+
+        if activeProfile?.id == id {
+            throw ProfileManagerError.cannotDeleteActiveProfile
+        }
+
+        profiles.removeAll { $0.id == id }
+        saveProfiles()
+        notifyProfilesChanged()
+    }
+
+    // MARK: - Activation
+
+    func activateProfile(id: UUID, reason: ProfileSwitchEvent.SwitchReason) {
+        guard let profile = profiles.first(where: { $0.id == id }) else {
+            return
+        }
+
+        let previousProfile = activeProfile
+        let switchEvent = ProfileSwitchEvent(
+            fromProfileId: previousProfile?.id,
+            fromProfileName: previousProfile?.name,
+            toProfileId: profile.id,
+            toProfileName: profile.name,
+            weekday: .today,
+            reason: reason
+        )
+
+        activeProfile = profile
+        saveActiveProfileId(profile.id)
+        writeProfileSettingsToFiles(profile)
+
+        // Add to history
+        switchHistory.insert(switchEvent, at: 0)
+        // Keep only last 100 events
+        if switchHistory.count > 100 {
+            switchHistory = Array(switchHistory.prefix(100))
+        }
+        saveSwitchHistory()
+
+        // Set pending notification for banner
+        pendingSwitchNotification = switchEvent
+
+        notifyActiveProfileChanged(profile)
+
+        debug(.service, "Profile switched to '\(profile.name)' - reason: \(reason.rawValue)")
+    }
+
+    func activateProfileAsOverride(id: UUID) {
+        manualOverrideProfileId = id
+        manualOverrideDate = Date()
+        saveOverrideState()
+
+        activateProfile(id: id, reason: .manualOverride)
+    }
+
+    func clearManualOverride() {
+        manualOverrideProfileId = nil
+        manualOverrideDate = nil
+        saveOverrideState()
+
+        // Revert to scheduled profile if available
+        if let scheduledProfile = profileForDay(.today) {
+            activateProfile(id: scheduledProfile.id, reason: .scheduled)
+        }
+    }
+
+    // MARK: - Scheduling
+
+    func checkForScheduledSwitch() {
+        // If manual override is active and still valid, don't switch
+        if isManualOverrideActive {
+            return
+        }
+
+        // Clear expired override
+        if manualOverrideDate != nil, !isManualOverrideActive {
+            manualOverrideProfileId = nil
+            manualOverrideDate = nil
+            saveOverrideState()
+        }
+
+        // Check if we already switched today
+        if let lastSwitch = lastSwitchDate,
+           Calendar.current.isDateInToday(lastSwitch)
+        {
+            return
+        }
+
+        // Find profile for today
+        guard let scheduledProfile = profileForDay(.today) else {
+            return
+        }
+
+        // Check if we need to switch
+        if activeProfile?.id != scheduledProfile.id {
+            lastSwitchDate = Date()
+            activateProfile(id: scheduledProfile.id, reason: .scheduled)
+        }
+    }
+
+    func profileForDay(_ weekday: Weekday) -> TherapyProfile? {
+        profiles.first { $0.activeDays.contains(weekday) }
+    }
+
+    // MARK: - Notifications
+
+    func acknowledgeSwitchNotification() {
+        if var notification = pendingSwitchNotification {
+            notification.acknowledged = true
+            // Update in history
+            if let index = switchHistory.firstIndex(where: { $0.id == notification.id }) {
+                switchHistory[index] = notification
+                saveSwitchHistory()
+            }
+        }
+        pendingSwitchNotification = nil
+    }
+
+    // MARK: - Migration
+
+    func migrateFromSingleProfile() {
+        debug(.service, "Migrating from single profile system...")
+
+        // Load existing settings
+        let basalProfile = storage.retrieve(OpenAPS.Settings.basalProfile, as: [BasalProfileEntry].self) ?? []
+        let insulinSensitivities = storage.retrieve(OpenAPS.Settings.insulinSensitivities, as: InsulinSensitivities.self)
+        let carbRatios = storage.retrieve(OpenAPS.Settings.carbRatios, as: CarbRatios.self)
+        let bgTargets = storage.retrieve(OpenAPS.Settings.bgTargets, as: BGTargets.self)
+
+        let units = settingsManager.settings.units
+
+        // Create default profile with all existing settings
+        let defaultProfile = TherapyProfile(
+            name: NSLocalizedString("Default", comment: "Default profile name"),
+            activeDays: Weekday.allDays,
+            basalProfile: basalProfile,
+            insulinSensitivities: insulinSensitivities ?? InsulinSensitivities(
+                units: units,
+                userPreferredUnits: units,
+                sensitivities: []
+            ),
+            carbRatios: carbRatios ?? CarbRatios(units: .grams, schedule: []),
+            bgTargets: bgTargets ?? BGTargets(
+                units: units,
+                userPreferredUnits: units,
+                targets: []
+            ),
+            isDefault: true
+        )
+
+        profiles = [defaultProfile]
+        activeProfile = defaultProfile
+        saveProfiles()
+        saveActiveProfileId(defaultProfile.id)
+
+        debug(.service, "Migration complete - created default profile")
+    }
+
+    // MARK: - Private Methods
+
+    private func loadProfiles() {
+        profiles = storage.retrieve(OpenAPS.Trio.therapyProfiles, as: [TherapyProfile].self) ?? []
+    }
+
+    private func saveProfiles() {
+        storage.save(profiles, as: OpenAPS.Trio.therapyProfiles)
+    }
+
+    private func loadActiveProfile() {
+        guard let activeIdString = storage.retrieve(OpenAPS.Trio.activeProfileId, as: String.self),
+              let activeId = UUID(uuidString: activeIdString)
+        else {
+            // Default to the default profile or first profile
+            activeProfile = profiles.first { $0.isDefault } ?? profiles.first
+            if let profile = activeProfile {
+                saveActiveProfileId(profile.id)
+            }
+            return
+        }
+
+        activeProfile = profiles.first { $0.id == activeId }
+
+        // Fallback if active profile not found
+        if activeProfile == nil {
+            activeProfile = profiles.first { $0.isDefault } ?? profiles.first
+            if let profile = activeProfile {
+                saveActiveProfileId(profile.id)
+            }
+        }
+    }
+
+    private func saveActiveProfileId(_ id: UUID) {
+        storage.save(id.uuidString, as: OpenAPS.Trio.activeProfileId)
+    }
+
+    private func loadSwitchHistory() {
+        switchHistory = storage.retrieve(OpenAPS.Trio.profileSwitchHistory, as: [ProfileSwitchEvent].self) ?? []
+    }
+
+    private func saveSwitchHistory() {
+        storage.save(switchHistory, as: OpenAPS.Trio.profileSwitchHistory)
+    }
+
+    private func loadOverrideState() {
+        // Override state is stored in TrioSettings
+        // For now, we'll use a simple approach - could be enhanced later
+    }
+
+    private func saveOverrideState() {
+        // Override state persistence
+    }
+
+    /// Writes the profile's therapy settings to the individual OpenAPS settings files.
+    /// This maintains compatibility with the existing OpenAPS algorithm.
+    private func writeProfileSettingsToFiles(_ profile: TherapyProfile) {
+        storage.save(profile.basalProfile, as: OpenAPS.Settings.basalProfile)
+        storage.save(profile.insulinSensitivities, as: OpenAPS.Settings.insulinSensitivities)
+        storage.save(profile.carbRatios, as: OpenAPS.Settings.carbRatios)
+        storage.save(profile.bgTargets, as: OpenAPS.Settings.bgTargets)
+
+        // Notify observers of the individual setting changes
+        broadcaster.notify(BasalProfileObserver.self, on: .main) {
+            $0.basalProfileDidChange(profile.basalProfile)
+        }
+        broadcaster.notify(BGTargetsObserver.self, on: .main) {
+            $0.bgTargetsDidChange(profile.bgTargets)
+        }
+    }
+
+    private func notifyActiveProfileChanged(_ profile: TherapyProfile) {
+        broadcaster.notify(ProfileManagerObserver.self, on: .main) {
+            $0.activeProfileDidChange(profile)
+        }
+        broadcaster.notify(TherapyProfileObserver.self, on: .main) {
+            $0.activeProfileDidChange(profile)
+        }
+    }
+
+    private func notifyProfilesChanged() {
+        broadcaster.notify(ProfileManagerObserver.self, on: .main) {
+            $0.profilesDidChange(self.profiles)
+        }
+    }
+}

--- a/Trio/Sources/Services/ProfileManager/BaseProfileManager.swift
+++ b/Trio/Sources/Services/ProfileManager/BaseProfileManager.swift
@@ -55,6 +55,10 @@ final class BaseProfileManager: ProfileManager, Injectable {
 
         // Load active profile
         loadActiveProfile()
+
+        // Check for scheduled switch on startup
+        // This ensures the correct profile is active based on today's day of week
+        checkForScheduledSwitch()
     }
 
     // MARK: - Profile Management

--- a/Trio/Sources/Services/ProfileManager/ProfileManager.swift
+++ b/Trio/Sources/Services/ProfileManager/ProfileManager.swift
@@ -1,0 +1,126 @@
+import Combine
+import Foundation
+import Swinject
+
+/// Protocol for managing therapy profiles with scheduled switching.
+protocol ProfileManager: AnyObject {
+    // MARK: - Properties
+
+    /// All therapy profiles
+    var profiles: [TherapyProfile] { get }
+
+    /// The currently active therapy profile
+    var activeProfile: TherapyProfile? { get }
+
+    /// Publisher for active profile changes
+    var activeProfilePublisher: AnyPublisher<TherapyProfile?, Never> { get }
+
+    /// Pending switch notification to be displayed to user
+    var pendingSwitchNotification: ProfileSwitchEvent? { get set }
+
+    /// Publisher for pending switch notifications
+    var pendingSwitchNotificationPublisher: AnyPublisher<ProfileSwitchEvent?, Never> { get }
+
+    /// History of profile switch events
+    var switchHistory: [ProfileSwitchEvent] { get }
+
+    /// Whether a manual override is currently active for today
+    var isManualOverrideActive: Bool { get }
+
+    /// The ID of the manually overridden profile (if any)
+    var manualOverrideProfileId: UUID? { get }
+
+    /// The date when the manual override was set
+    var manualOverrideDate: Date? { get }
+
+    // MARK: - Profile Management
+
+    /// Creates a new profile, optionally copying settings from an existing profile.
+    /// - Parameters:
+    ///   - name: The name for the new profile
+    ///   - copyFrom: Optional profile to copy settings from
+    /// - Returns: The newly created profile
+    func createProfile(name: String, copyFrom: TherapyProfile?) -> TherapyProfile
+
+    /// Updates an existing profile.
+    /// - Parameter profile: The profile with updated values
+    func updateProfile(_ profile: TherapyProfile)
+
+    /// Deletes a profile by ID.
+    /// - Parameter id: The ID of the profile to delete
+    /// - Throws: ProfileManagerError if the profile cannot be deleted
+    func deleteProfile(id: UUID) throws
+
+    // MARK: - Activation
+
+    /// Activates a profile by ID.
+    /// - Parameters:
+    ///   - id: The ID of the profile to activate
+    ///   - reason: The reason for the switch
+    func activateProfile(id: UUID, reason: ProfileSwitchEvent.SwitchReason)
+
+    /// Activates a profile as a manual override for the current day.
+    /// This overrides the scheduled profile until midnight.
+    /// - Parameter id: The ID of the profile to activate
+    func activateProfileAsOverride(id: UUID)
+
+    /// Clears any manual override, reverting to the scheduled profile.
+    func clearManualOverride()
+
+    // MARK: - Scheduling
+
+    /// Checks if a scheduled profile switch should occur and performs it.
+    /// Called from the main loop at regular intervals.
+    func checkForScheduledSwitch()
+
+    /// Returns the profile assigned to a specific day.
+    /// - Parameter weekday: The day of week
+    /// - Returns: The profile assigned to that day, or nil if none
+    func profileForDay(_ weekday: Weekday) -> TherapyProfile?
+
+    // MARK: - Notifications
+
+    /// Acknowledges and dismisses the pending switch notification.
+    func acknowledgeSwitchNotification()
+
+    // MARK: - Migration
+
+    /// Migrates from the single-profile system to the multi-profile system.
+    /// Called on app startup if no profiles exist.
+    func migrateFromSingleProfile()
+}
+
+/// Errors that can occur during profile management operations.
+enum ProfileManagerError: LocalizedError {
+    case cannotDeleteDefaultProfile
+    case cannotDeleteActiveProfile
+    case profileNotFound
+    case maximumProfilesReached
+    case profileNameExists
+
+    var errorDescription: String? {
+        switch self {
+        case .cannotDeleteDefaultProfile:
+            return NSLocalizedString("Cannot delete the default profile", comment: "Error message")
+        case .cannotDeleteActiveProfile:
+            return NSLocalizedString("Cannot delete the currently active profile", comment: "Error message")
+        case .profileNotFound:
+            return NSLocalizedString("Profile not found", comment: "Error message")
+        case .maximumProfilesReached:
+            return NSLocalizedString("Maximum number of profiles reached", comment: "Error message")
+        case .profileNameExists:
+            return NSLocalizedString("A profile with this name already exists", comment: "Error message")
+        }
+    }
+}
+
+/// Observer protocol for profile change notifications.
+protocol ProfileManagerObserver {
+    func activeProfileDidChange(_ profile: TherapyProfile)
+    func profilesDidChange(_ profiles: [TherapyProfile])
+}
+
+extension ProfileManagerObserver {
+    func activeProfileDidChange(_ profile: TherapyProfile) {}
+    func profilesDidChange(_ profiles: [TherapyProfile]) {}
+}

--- a/Trio/Sources/Views/ProfileSwitchBannerView.swift
+++ b/Trio/Sources/Views/ProfileSwitchBannerView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+/// A banner view that displays when a therapy profile has been switched.
+/// Auto-dismisses after a set duration or can be manually dismissed.
+struct ProfileSwitchBannerView: View {
+    let event: ProfileSwitchEvent
+    let onDismiss: () -> Void
+
+    /// Auto-dismiss duration in seconds
+    var autoDismissDuration: Double = 8.0
+
+    @State private var isVisible = false
+    @State private var dismissTask: Task<Void, Never>?
+
+    var body: some View {
+        VStack {
+            if isVisible {
+                bannerContent
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+            Spacer()
+        }
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isVisible)
+        .onAppear {
+            showBanner()
+        }
+        .onDisappear {
+            dismissTask?.cancel()
+        }
+    }
+
+    @ViewBuilder
+    private var bannerContent: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .font(.title2)
+                .foregroundColor(.white)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Profile Switched")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white)
+
+                Text(event.toProfileName)
+                    .font(.headline)
+                    .foregroundColor(.white)
+
+                Text(event.reasonDescription)
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(0.8))
+            }
+
+            Spacer()
+
+            Button(action: dismiss) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title2)
+                    .foregroundColor(.white.opacity(0.8))
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.accentColor)
+                .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
+        )
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+    }
+
+    private func showBanner() {
+        withAnimation {
+            isVisible = true
+        }
+
+        // Schedule auto-dismiss
+        dismissTask = Task {
+            try? await Task.sleep(nanoseconds: UInt64(autoDismissDuration * 1_000_000_000))
+            if !Task.isCancelled {
+                await MainActor.run {
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    private func dismiss() {
+        dismissTask?.cancel()
+        withAnimation {
+            isVisible = false
+        }
+        // Delay the actual callback to allow animation to complete
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            onDismiss()
+        }
+    }
+}
+
+/// A view modifier to add profile switch banner overlay
+struct ProfileSwitchBannerModifier: ViewModifier {
+    @Binding var switchEvent: ProfileSwitchEvent?
+    let onDismiss: () -> Void
+
+    func body(content: Content) -> some View {
+        content.overlay(
+            Group {
+                if let event = switchEvent {
+                    ProfileSwitchBannerView(event: event) {
+                        onDismiss()
+                    }
+                }
+            }
+        )
+    }
+}
+
+extension View {
+    /// Adds a profile switch banner overlay to the view.
+    /// - Parameters:
+    ///   - event: Binding to the optional switch event. When non-nil, the banner is shown.
+    ///   - onDismiss: Callback when the banner is dismissed.
+    func profileSwitchBanner(
+        event: Binding<ProfileSwitchEvent?>,
+        onDismiss: @escaping () -> Void
+    ) -> some View {
+        modifier(ProfileSwitchBannerModifier(switchEvent: event, onDismiss: onDismiss))
+    }
+}
+
+// MARK: - Compact Banner for Settings
+
+/// A smaller, inline banner for use within settings views
+struct ProfileSwitchInfoBanner: View {
+    let profileName: String
+    let isOverride: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: isOverride ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                .foregroundColor(isOverride ? .orange : .green)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Active Profile")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                Text(profileName)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+
+            Spacer()
+
+            if isOverride {
+                Text("Override")
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.orange.opacity(0.2))
+                    .foregroundColor(.orange)
+                    .cornerRadius(4)
+            }
+        }
+        .padding(12)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(10)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+    struct ProfileSwitchBannerView_Previews: PreviewProvider {
+        static var previews: some View {
+            VStack {
+                ProfileSwitchBannerView(
+                    event: ProfileSwitchEvent(
+                        fromProfileId: UUID(),
+                        fromProfileName: "Weekday",
+                        toProfileId: UUID(),
+                        toProfileName: "Weekend",
+                        reason: .scheduled
+                    ),
+                    onDismiss: {}
+                )
+
+                Spacer()
+
+                ProfileSwitchInfoBanner(
+                    profileName: "Weekend Profile",
+                    isOverride: true
+                )
+                .padding()
+            }
+        }
+    }
+#endif

--- a/Trio/Sources/Views/WeekdayPickerView.swift
+++ b/Trio/Sources/Views/WeekdayPickerView.swift
@@ -5,14 +5,18 @@ import SwiftUI
 struct WeekdayPickerView: View {
     @Binding var selectedDays: Set<Weekday>
 
-    /// Days that are already assigned to other profiles (shown as disabled/conflicting)
+    /// Days that are already assigned to other profiles (shown with warning indicator)
     var conflictingDays: Set<Weekday> = []
+
+    /// Map of conflicting days to profile names that own them
+    var conflictingDayOwners: [Weekday: String] = [:]
 
     /// Whether to show quick select options (Weekdays, Weekends, All)
     var showQuickSelect: Bool = true
 
-    /// Callback when a conflict is tapped
-    var onConflictTapped: ((Weekday) -> Void)?
+    /// State for confirmation alert
+    @State private var showConflictAlert = false
+    @State private var pendingConflictDay: Weekday?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -21,6 +25,28 @@ struct WeekdayPickerView: View {
             }
 
             dayButtons
+
+            if !conflictingDays.isEmpty {
+                Text("Days with ⚠️ are assigned to other profiles and will be reassigned.")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+            }
+        }
+        .alert("Reassign Day?", isPresented: $showConflictAlert) {
+            Button("Cancel", role: .cancel) {
+                pendingConflictDay = nil
+            }
+            Button("Reassign") {
+                if let day = pendingConflictDay {
+                    selectedDays.insert(day)
+                    pendingConflictDay = nil
+                }
+            }
+        } message: {
+            if let day = pendingConflictDay {
+                let ownerName = conflictingDayOwners[day] ?? "another profile"
+                Text("\(day.localizedName) is currently assigned to \"\(ownerName)\". Selecting it will reassign it to this profile.")
+            }
         }
     }
 
@@ -31,21 +57,21 @@ struct WeekdayPickerView: View {
                 title: NSLocalizedString("Weekdays", comment: "Quick select weekdays"),
                 isSelected: selectedDays == Weekday.weekdays
             ) {
-                selectedDays = Weekday.weekdays
+                selectDaysWithConflictCheck(Weekday.weekdays)
             }
 
             QuickSelectButton(
                 title: NSLocalizedString("Weekends", comment: "Quick select weekends"),
                 isSelected: selectedDays == Weekday.weekend
             ) {
-                selectedDays = Weekday.weekend
+                selectDaysWithConflictCheck(Weekday.weekend)
             }
 
             QuickSelectButton(
                 title: NSLocalizedString("All", comment: "Quick select all days"),
                 isSelected: selectedDays == Weekday.allDays
             ) {
-                selectedDays = Weekday.allDays
+                selectDaysWithConflictCheck(Weekday.allDays)
             }
 
             QuickSelectButton(
@@ -64,23 +90,35 @@ struct WeekdayPickerView: View {
                 DayButton(
                     day: day,
                     isSelected: selectedDays.contains(day),
-                    isConflicting: conflictingDays.contains(day)
+                    isConflicting: conflictingDays.contains(day) && !selectedDays.contains(day)
                 ) {
-                    if conflictingDays.contains(day) {
-                        onConflictTapped?(day)
-                    } else {
-                        toggleDay(day)
-                    }
+                    handleDayTap(day)
                 }
             }
         }
     }
 
-    private func toggleDay(_ day: Weekday) {
+    private func handleDayTap(_ day: Weekday) {
         if selectedDays.contains(day) {
+            // Always allow deselection
             selectedDays.remove(day)
+        } else if conflictingDays.contains(day) {
+            // Show confirmation for conflicting days
+            pendingConflictDay = day
+            showConflictAlert = true
         } else {
+            // Normal selection
             selectedDays.insert(day)
+        }
+    }
+
+    private func selectDaysWithConflictCheck(_ days: Set<Weekday>) {
+        let conflicts = days.intersection(conflictingDays).subtracting(selectedDays)
+        if conflicts.isEmpty {
+            selectedDays = days
+        } else {
+            // For quick select, just select all including conflicts (simpler UX)
+            selectedDays = days
         }
     }
 }
@@ -115,17 +153,25 @@ private struct DayButton: View {
 
     var body: some View {
         Button(action: action) {
-            Text(day.veryShortName)
-                .font(.subheadline)
-                .fontWeight(isSelected ? .bold : .regular)
-                .frame(width: 36, height: 36)
-                .background(backgroundColor)
-                .foregroundColor(foregroundColor)
-                .cornerRadius(18)
-                .overlay(
-                    Circle()
-                        .stroke(borderColor, lineWidth: isConflicting ? 2 : 0)
-                )
+            ZStack(alignment: .topTrailing) {
+                Text(day.veryShortName)
+                    .font(.subheadline)
+                    .fontWeight(isSelected ? .bold : .regular)
+                    .frame(width: 36, height: 36)
+                    .background(backgroundColor)
+                    .foregroundColor(foregroundColor)
+                    .cornerRadius(18)
+                    .overlay(
+                        Circle()
+                            .stroke(borderColor, lineWidth: isConflicting ? 2 : 0)
+                    )
+
+                if isConflicting {
+                    Text("⚠️")
+                        .font(.system(size: 10))
+                        .offset(x: 4, y: -4)
+                }
+            }
         }
         .buttonStyle(PlainButtonStyle())
     }
@@ -139,7 +185,7 @@ private struct DayButton: View {
 
     private var foregroundColor: Color {
         if isConflicting {
-            return .secondary
+            return .primary
         }
         return isSelected ? .white : .primary
     }

--- a/Trio/Sources/Views/WeekdayPickerView.swift
+++ b/Trio/Sources/Views/WeekdayPickerView.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+
+/// A multi-select day of week picker view.
+/// Allows users to select one or more days for profile scheduling.
+struct WeekdayPickerView: View {
+    @Binding var selectedDays: Set<Weekday>
+
+    /// Days that are already assigned to other profiles (shown as disabled/conflicting)
+    var conflictingDays: Set<Weekday> = []
+
+    /// Whether to show quick select options (Weekdays, Weekends, All)
+    var showQuickSelect: Bool = true
+
+    /// Callback when a conflict is tapped
+    var onConflictTapped: ((Weekday) -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if showQuickSelect {
+                quickSelectButtons
+            }
+
+            dayButtons
+        }
+    }
+
+    @ViewBuilder
+    private var quickSelectButtons: some View {
+        HStack(spacing: 8) {
+            QuickSelectButton(
+                title: NSLocalizedString("Weekdays", comment: "Quick select weekdays"),
+                isSelected: selectedDays == Weekday.weekdays
+            ) {
+                selectedDays = Weekday.weekdays
+            }
+
+            QuickSelectButton(
+                title: NSLocalizedString("Weekends", comment: "Quick select weekends"),
+                isSelected: selectedDays == Weekday.weekend
+            ) {
+                selectedDays = Weekday.weekend
+            }
+
+            QuickSelectButton(
+                title: NSLocalizedString("All", comment: "Quick select all days"),
+                isSelected: selectedDays == Weekday.allDays
+            ) {
+                selectedDays = Weekday.allDays
+            }
+
+            QuickSelectButton(
+                title: NSLocalizedString("None", comment: "Quick select no days"),
+                isSelected: selectedDays.isEmpty
+            ) {
+                selectedDays = []
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dayButtons: some View {
+        HStack(spacing: 6) {
+            ForEach(Weekday.allCases) { day in
+                DayButton(
+                    day: day,
+                    isSelected: selectedDays.contains(day),
+                    isConflicting: conflictingDays.contains(day)
+                ) {
+                    if conflictingDays.contains(day) {
+                        onConflictTapped?(day)
+                    } else {
+                        toggleDay(day)
+                    }
+                }
+            }
+        }
+    }
+
+    private func toggleDay(_ day: Weekday) {
+        if selectedDays.contains(day) {
+            selectedDays.remove(day)
+        } else {
+            selectedDays.insert(day)
+        }
+    }
+}
+
+// MARK: - Supporting Views
+
+private struct QuickSelectButton: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.caption)
+                .fontWeight(isSelected ? .semibold : .regular)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(isSelected ? Color.accentColor : Color(.secondarySystemBackground))
+                .foregroundColor(isSelected ? .white : .primary)
+                .cornerRadius(8)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+private struct DayButton: View {
+    let day: Weekday
+    let isSelected: Bool
+    let isConflicting: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(day.veryShortName)
+                .font(.subheadline)
+                .fontWeight(isSelected ? .bold : .regular)
+                .frame(width: 36, height: 36)
+                .background(backgroundColor)
+                .foregroundColor(foregroundColor)
+                .cornerRadius(18)
+                .overlay(
+                    Circle()
+                        .stroke(borderColor, lineWidth: isConflicting ? 2 : 0)
+                )
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    private var backgroundColor: Color {
+        if isConflicting {
+            return Color(.systemGray5)
+        }
+        return isSelected ? Color.accentColor : Color(.secondarySystemBackground)
+    }
+
+    private var foregroundColor: Color {
+        if isConflicting {
+            return .secondary
+        }
+        return isSelected ? .white : .primary
+    }
+
+    private var borderColor: Color {
+        isConflicting ? .orange : .clear
+    }
+}
+
+// MARK: - Inline Compact Picker
+
+/// A more compact inline picker for use in forms
+struct WeekdayInlinePicker: View {
+    @Binding var selectedDays: Set<Weekday>
+    var conflictingDays: Set<Weekday> = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Active Days")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 4) {
+                ForEach(Weekday.allCases) { day in
+                    CompactDayButton(
+                        day: day,
+                        isSelected: selectedDays.contains(day),
+                        isConflicting: conflictingDays.contains(day)
+                    ) {
+                        toggleDay(day)
+                    }
+                }
+            }
+
+            if !selectedDays.isEmpty {
+                Text(selectedDays.formattedString)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private func toggleDay(_ day: Weekday) {
+        if selectedDays.contains(day) {
+            selectedDays.remove(day)
+        } else {
+            selectedDays.insert(day)
+        }
+    }
+}
+
+private struct CompactDayButton: View {
+    let day: Weekday
+    let isSelected: Bool
+    let isConflicting: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(day.veryShortName)
+                .font(.caption2)
+                .fontWeight(isSelected ? .bold : .regular)
+                .frame(width: 28, height: 28)
+                .background(backgroundColor)
+                .foregroundColor(foregroundColor)
+                .cornerRadius(14)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .disabled(isConflicting)
+    }
+
+    private var backgroundColor: Color {
+        if isConflicting {
+            return Color(.systemGray5)
+        }
+        return isSelected ? Color.accentColor : Color(.tertiarySystemBackground)
+    }
+
+    private var foregroundColor: Color {
+        if isConflicting {
+            return .secondary
+        }
+        return isSelected ? .white : .primary
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+    struct WeekdayPickerView_Previews: PreviewProvider {
+        static var previews: some View {
+            VStack(spacing: 20) {
+                WeekdayPickerView(
+                    selectedDays: .constant([.monday, .wednesday, .friday]),
+                    conflictingDays: [.saturday, .sunday]
+                )
+
+                Divider()
+
+                WeekdayInlinePicker(
+                    selectedDays: .constant([.monday, .tuesday, .wednesday, .thursday, .friday])
+                )
+            }
+            .padding()
+        }
+    }
+#endif


### PR DESCRIPTION
**Introducing Therapy Profiles**

-Allowing users to create multiple therapy setting profiles and automatically switch between them based on the day of week. Ideal for users who need different settings on weekdays vs weekends or other recurring schedules.
Features

**Profile Management**

- Create up to 10 independent therapy profiles
- Each profile contains its own:
- Basal rates
- Insulin sensitivities (ISF)
- Carb ratios
- Glucose targets
- Duplicate existing profiles as a starting point
- Copy settings from another profile or current active pump settings

**Day-of-Week Scheduling**

- Assign profiles to specific days (e.g., "Weekend" profile for Sat/Sun)
- Each day can only belong to one profile
- Conflict detection with reassignment confirmation dialog
- Quick-select buttons for Weekdays, Weekends, All, None

**Automatic Profile Switching**

- App checks for scheduled profile changes at each loop cycle
- Automatic switch at app startup based on current day
- Switch history tracking for troubleshooting
- Banner notification when profile switches occur

**Manual Override**

- Long-press any profile to "Override for Today"
- Temporarily activates selected profile until midnight
- Automatically reverts to scheduled profile the next day

**Seamless Integration**

- When a profile activates, its settings are written to the standard OpenAPS settings files
- Full compatibility with existing algorithm - no changes to loop logic
- Existing users automatically migrated: current settings become "Default" profile

**Inline Editing**

- Edit all therapy settings directly within the profile editor
- Expandable sections for basal rates, ISF, carb ratios, and targets
- Add, edit, and delete time slots without navigating away

![IMG_3500](https://github.com/user-attachments/assets/ad20aa4b-bc74-4717-82a0-6e2620ba9e34)
![IMG_3501](https://github.com/user-attachments/assets/c66fd650-cbbe-4787-9d0b-14920534ac92)
![IMG_3502](https://github.com/user-attachments/assets/a48469c9-c08d-4fc4-af00-9cfc40b2335d)
![IMG_3503](https://github.com/user-attachments/assets/e751f828-09e6-42e3-9b5b-3890bc2560b2)
