### PR TITLE
Carb quick add buttons

### DIFF
--- a/Trio/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/Trio/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -51,6 +51,53 @@ extension AddCarbs {
                         Text(state.carbs > state.maxCarbs ? "⚠️" : "g").foregroundColor(.secondary)
                     }.padding(.vertical)
 
+                    // Quick-add carb buttons
+                    HStack(spacing: 12) {
+                        Text("Quick Add:")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        Button(action: {
+                            state.carbs += 5
+                        }) {
+                            Text("+5g")
+                                .font(.subheadline.weight(.medium))
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(Color.blue.opacity(0.15))
+                                .foregroundColor(.blue)
+                                .cornerRadius(8)
+                        }
+                        .buttonStyle(.plain)
+
+                        Button(action: {
+                            state.carbs += 10
+                        }) {
+                            Text("+10g")
+                                .font(.subheadline.weight(.medium))
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(Color.blue.opacity(0.15))
+                                .foregroundColor(.blue)
+                                .cornerRadius(8)
+                        }
+                        .buttonStyle(.plain)
+
+                        Spacer()
+
+                        // Clear button
+                        if state.carbs > 0 {
+                            Button(action: {
+                                state.carbs = 0
+                            }) {
+                                Text("Clear")
+                                    .font(.caption)
+                                    .foregroundColor(.red)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
                     if state.useFPUconversion {
                         proteinAndFat()
                     }

--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -119,22 +119,74 @@ extension Treatments {
         }
 
         @ViewBuilder private func carbsTextField() -> some View {
-            HStack {
-                Text("Carbs")
-                Spacer()
-                TextFieldWithToolBar(
-                    text: $state.carbs,
-                    placeholder: "0",
-                    keyboardType: .numberPad,
-                    numberFormatter: mealFormatter,
-                    showArrows: true,
-                    previousTextField: { focusedField = previousField(from: .carbs) },
-                    nextTextField: { focusedField = nextField(from: .carbs) },
-                    unitsText: String(localized: "g", comment: "Units for carbs")
-                )
-                .focused($focusedField, equals: .carbs)
-                .onChange(of: state.carbs) {
-                    handleDebouncedInput()
+            VStack(spacing: 8) {
+                HStack {
+                    Text("Carbs")
+                    Spacer()
+                    TextFieldWithToolBar(
+                        text: $state.carbs,
+                        placeholder: "0",
+                        keyboardType: .numberPad,
+                        numberFormatter: mealFormatter,
+                        showArrows: true,
+                        previousTextField: { focusedField = previousField(from: .carbs) },
+                        nextTextField: { focusedField = nextField(from: .carbs) },
+                        unitsText: String(localized: "g", comment: "Units for carbs")
+                    )
+                    .focused($focusedField, equals: .carbs)
+                    .onChange(of: state.carbs) {
+                        handleDebouncedInput()
+                    }
+                }
+
+                // Quick-add carb buttons
+                HStack(spacing: 12) {
+                    Text("Quick Add:")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Button(action: {
+                        state.carbs += 5
+                        handleDebouncedInput()
+                    }) {
+                        Text("+5g")
+                            .font(.subheadline.weight(.medium))
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Color.blue.opacity(0.15))
+                            .foregroundColor(.blue)
+                            .cornerRadius(8)
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: {
+                        state.carbs += 10
+                        handleDebouncedInput()
+                    }) {
+                        Text("+10g")
+                            .font(.subheadline.weight(.medium))
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Color.blue.opacity(0.15))
+                            .foregroundColor(.blue)
+                            .cornerRadius(8)
+                    }
+                    .buttonStyle(.plain)
+
+                    Spacer()
+
+                    // Clear button
+                    if state.carbs > 0 {
+                        Button(action: {
+                            state.carbs = 0
+                            handleDebouncedInput()
+                        }) {
+                            Text("Clear")
+                                .font(.caption)
+                                .foregroundColor(.red)
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Feature includes:**

+5g button for quick carb counting (tap multiple times)
+10g button for faster entry of larger amounts
Clear button (appears when carbs > 0) to reset to zero
Styled with subtle blue background

![IMG_3504](https://github.com/user-attachments/assets/24a2e871-7aef-4963-bc67-eedcb4257cf1)
