### PR TITLE
Adjust Y-scale for Percentile Charts

### DIFF
--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseDailyPercentileChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseDailyPercentileChart.swift
@@ -396,26 +396,25 @@ struct GlucoseDailyPercentileChart: View {
 
     // Calculate an appropriate Y axis domain for the chart
     private func glucoseYScaleDomain() -> ClosedRange<Double> {
-        // Find actual min/max from data
+        let padding = units == .mgdL ? 20.0 : 1.0
+        let bottomLimit = 40.0.asUnit(units)
+        let topLimit = 400.0.asUnit(units)
+
         if visibleDailyStats.isEmpty {
-            return 0 ... (units == .mgdL ? 250 : 14.0)
+            return bottomLimit ... topLimit
         }
 
         var allValues: [Double] = []
         for day in visibleDailyStats where day.minimum > 0 {
-            allValues.append(day.minimum.asUnit(units))
             allValues.append(day.maximum.asUnit(units))
         }
 
         guard !allValues.isEmpty else {
-            return 0 ... (units == .mgdL ? 250 : 14.0)
+            return bottomLimit ... topLimit
         }
 
-        let minValue = allValues.min() ?? 0
-        let maxValue = allValues.max() ?? (units == .mgdL ? 250 : 14.0)
+        let maxValue = allValues.max() ?? topLimit
 
-        // Add some padding
-        let padding = units == .mgdL ? 20.0 : 1.0
-        return max(0, minValue - padding) ... maxValue + padding
+        return bottomLimit ... max(Double(highLimit.asUnit(units)), maxValue + padding)
     }
 }

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucosePercentileChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucosePercentileChart.swift
@@ -47,7 +47,7 @@ struct GlucosePercentileChart: View {
         let validStats = hourlyStats.filter { $0.median > 0 }
         guard !validStats.isEmpty else { return topLimit }
         let maxPercentile90 = validStats.map(\.percentile90).max() ?? topLimit
-        return maxPercentile90.asUnit(units)
+        return max(maxPercentile90.asUnit(units), Double(highLimit.asUnit(units)))
     }
 
     var body: some View {


### PR DESCRIPTION
This is a PR to address Issue 883:
* #883 

In v0.6.0.26, the Percentile chart's Y-scale goes from 40 (2.2) to the highest 90th percentile value in the chart. This PR limits the top of the Y-scale to a minimum of 180 (10.0) to ensure the threshold lines don't get placed above the Y-scale which was visually confusing.

In v0.6.0.26, the Percentile (by day) chart's Y-scale went from the lowest value in the chart to the highest value in the chart, with a padding of 20 (1.0) on both ends. This PR changes the bottom of the scale to 40 (2.2) and ensures the top of the chart is at least 180 (10.0) but otherwise retains it's top of the highest value in the chart plus a padding of 20 (1.0).