### PR TITLE
fix: stats glucose percentile max y-Axis

### DIFF
--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucosePercentileChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucosePercentileChart.swift
@@ -47,7 +47,7 @@ struct GlucosePercentileChart: View {
         let validStats = hourlyStats.filter { $0.median > 0 }
         guard !validStats.isEmpty else { return topLimit }
         let maxPercentile90 = validStats.map(\.percentile90).max() ?? topLimit
-        return maxPercentile90.asUnit(units)
+        return max(maxPercentile90.asUnit(units), Double(highLimit.asUnit(units)))
     }
 
     var body: some View {


### PR DESCRIPTION
Currently, the Stats glucose percentile chart might go out-of-bounds.
If you have a perfect day, the upper limit (10.0 mmol/L would jump out of the chart to somewhere "random" on the screen.

Example before fix (current dev, the orange line if above the chart title):
<img height="400" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-18 at 20 46 23" src="https://github.com/user-attachments/assets/cbd3fbe1-8401-4d48-b951-ba3c08c45326" />

After fix (chart yAxis has a minimum of 10.0 mmol/L):
<img height="400" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-18 at 20 52 13" src="https://github.com/user-attachments/assets/489f013d-3f23-4299-bf63-69397289d694" />
