### PR TITLE
Fix First Pod Alarm + Refactor Alert History Storage

### DIFF
--- a/Trio/Sources/APS/DeviceDataManager.swift
+++ b/Trio/Sources/APS/DeviceDataManager.swift
@@ -596,7 +596,7 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
 
 extension BaseDeviceDataManager: DeviceManagerDelegate {
     func issueAlert(_ alert: Alert) {
-        alertHistoryStorage.storeAlert(
+        alertHistoryStorage.addAlert(
             AlertEntry(
                 alertIdentifier: alert.identifier.alertIdentifier,
                 primitiveInterruptionLevel: alert.interruptionLevel.storedValue as? Decimal,
@@ -611,7 +611,7 @@ extension BaseDeviceDataManager: DeviceManagerDelegate {
     }
 
     func retractAlert(identifier: Alert.Identifier) {
-        alertHistoryStorage.deleteAlert(identifier: identifier.alertIdentifier)
+        alertHistoryStorage.removeAlert(identifier: identifier.alertIdentifier)
     }
 
     func doesIssuedAlertExist(identifier _: Alert.Identifier, completion _: @escaping (Result<Bool, Error>) -> Void) {
@@ -685,23 +685,23 @@ extension BaseDeviceDataManager: AlertObserver {
             if let omnipodBLE = self.pumpManager as? OmniBLEPumpManager {
                 if omnipodBLE.state.activeAlerts.isEmpty {
                     // force to ack alert in the alertStorage
-                    self.alertHistoryStorage.ackAlert(alertIssueDate, nil)
+                    self.alertHistoryStorage.acknowledgeAlert(alertIssueDate, nil)
                 }
             }
 
             if let omniPod = self.pumpManager as? OmnipodPumpManager {
                 if omniPod.state.activeAlerts.isEmpty {
                     // force to ack alert in the alertStorage
-                    self.alertHistoryStorage.ackAlert(alertIssueDate, nil)
+                    self.alertHistoryStorage.acknowledgeAlert(alertIssueDate, nil)
                 }
             }
 
             self.pumpManager?.acknowledgeAlert(alertIdentifier: alert.alertIdentifier) { error in
                 if let error = error {
-                    self.alertHistoryStorage.ackAlert(alertIssueDate, error.localizedDescription)
+                    self.alertHistoryStorage.acknowledgeAlert(alertIssueDate, error.localizedDescription)
                     debug(.deviceManager, "acknowledge not succeeded with error \(error)")
                 } else {
-                    self.alertHistoryStorage.ackAlert(alertIssueDate, nil)
+                    self.alertHistoryStorage.acknowledgeAlert(alertIssueDate, nil)
                 }
             }
 

--- a/Trio/Sources/APS/Storage/AlertStorage.swift
+++ b/Trio/Sources/APS/Storage/AlertStorage.swift
@@ -37,7 +37,7 @@ final class BaseAlertHistoryStorage: AlertHistoryStorage, Injectable {
                 storage.append(alert, to: file, uniqBy: \.issuedDate)
                 uniqEvents = storage.retrieve(file, as: [AlertEntry].self)?
                     .filter { $0.issuedDate.addingTimeInterval(1.days.timeInterval) > Date() }
-                    .sorted { $0.issuedDate > $1.issuedDate } ?? []
+                    .sorted { $0.issuedDate > $1.issuedDate } ?? [alert]
                 storage.save(Array(uniqEvents), as: file)
             }
             alertNotAck.send(self.recentNotAck().isNotEmpty)

--- a/Trio/Sources/APS/Storage/AlertStorage.swift
+++ b/Trio/Sources/APS/Storage/AlertStorage.swift
@@ -20,10 +20,6 @@ protocol AlertHistoryStorage {
 final class BaseAlertHistoryStorage: AlertHistoryStorage, Injectable {
     private let processQueue = DispatchQueue.markedQueue(label: "BaseAlertsStorage.processQueue")
 
-    /// Enable "re-entrant" access of DispatchQueue via identifier: public API methods can safely synchronize onto `processQueue`
-    /// without risking a deadlock when they are called from within other `processQueue`-synchronized code.
-    private let queueKeyForBaseAlertsStorageProcessQueue = DispatchSpecificKey<Void>()
-
     private let defaults: UserDefaults
 
     /// Legacy JSON file storage used only for one-time migration from the historical on-disk JSON file.
@@ -53,36 +49,12 @@ final class BaseAlertHistoryStorage: AlertHistoryStorage, Injectable {
     ///   - userDefaults: The UserDefaults instance used for persistence. Defaults to `.standard`.
     init(resolver: Resolver, userDefaults: UserDefaults = .standard) {
         defaults = userDefaults
-        processQueue.setSpecific(key: queueKeyForBaseAlertsStorageProcessQueue, value: ())
         injectServices(resolver)
 
         // FIXME: this can be removed in later releases
         migrateFromLegacyJSONIfNeeded()
 
         unacknowledgedAlertsPublisher.send(unacknowledgedAlertsWithinLast24Hours().isNotEmpty)
-    }
-
-    /// Executes the given block synchronously on `processQueue` with deadlock avoidance.
-    ///
-    /// All reads and writes of the alert history should be serialized through `processQueue` to prevent
-    /// races between callers on different threads (e.g., UI reads vs. background writes).
-    ///
-    /// However, some public API methods may be called both externally (from arbitrary threads) and internally
-    /// from within other `processQueue`-synchronized methods. Calling `processQueue.sync` unconditionally in that
-    /// situation can deadlock if the caller is already on `processQueue`.
-    ///
-    /// This helper checks whether execution is already on `processQueue` using `queueKey`:
-    /// - If already on `processQueue`, it executes the block immediately.
-    /// - Otherwise, it synchronizes execution onto `processQueue` via `processQueue.sync`.
-    ///
-    /// - Parameter block: The work to perform.
-    /// - Returns: The block's return value.
-    private func queueSync<T>(_ block: () -> T) -> T {
-        if DispatchQueue.getSpecific(key: queueKeyForBaseAlertsStorageProcessQueue) != nil {
-            return block()
-        } else {
-            return processQueue.sync { block() }
-        }
     }
 
     /// Stores a new alert entry and notifies observers.
@@ -102,7 +74,7 @@ final class BaseAlertHistoryStorage: AlertHistoryStorage, Injectable {
             let uniqEvents = pruneAndSort(dedupeByIssuedDate(all))
             saveAll(uniqEvents)
 
-            unacknowledgedAlertsPublisher.send(self.unacknowledgedAlertsWithinLast24Hours().isNotEmpty)
+            unacknowledgedAlertsPublisher.send(self.unacknowledgedAlertsWithinLast24HoursOnQueue().isNotEmpty)
             broadcaster.notify(AlertObserver.self, on: processQueue) {
                 $0.AlertDidUpdate(uniqEvents)
             }
@@ -118,11 +90,17 @@ final class BaseAlertHistoryStorage: AlertHistoryStorage, Injectable {
 
     /// Returns all unacknowledged alerts from the last 24 hours, sorted newest first.
     func unacknowledgedAlertsWithinLast24Hours() -> [AlertEntry] {
-        queueSync {
-            loadAll()
-                .filter { $0.issuedDate.addingTimeInterval(1.days.timeInterval) > Date() && $0.acknowledgedDate == nil }
-                .sorted { $0.issuedDate > $1.issuedDate }
+        processQueue.sync {
+            self.unacknowledgedAlertsWithinLast24HoursOnQueue()
         }
+    }
+
+    /// Returns all unacknowledged alerts from the last 24 hours, sorted newest first.
+    /// - Important: Must only be called while already executing on `processQueue`.
+    private func unacknowledgedAlertsWithinLast24HoursOnQueue() -> [AlertEntry] {
+        loadAll()
+            .filter { $0.issuedDate.addingTimeInterval(1.days.timeInterval) > Date() && $0.acknowledgedDate == nil }
+            .sorted { $0.issuedDate > $1.issuedDate }
     }
 
     /// Acknowledges an alert (by issued date), or stores an error for it.
@@ -147,7 +125,7 @@ final class BaseAlertHistoryStorage: AlertHistoryStorage, Injectable {
 
             let cleaned = pruneAndSort(dedupeByIssuedDate(all))
             saveAll(cleaned)
-            unacknowledgedAlertsPublisher.send(self.unacknowledgedAlertsWithinLast24Hours().isNotEmpty)
+            unacknowledgedAlertsPublisher.send(self.unacknowledgedAlertsWithinLast24HoursOnQueue().isNotEmpty)
         }
     }
 
@@ -165,7 +143,7 @@ final class BaseAlertHistoryStorage: AlertHistoryStorage, Injectable {
             let cleaned = pruneAndSort(dedupeByIssuedDate(all))
             saveAll(cleaned)
 
-            unacknowledgedAlertsPublisher.send(self.unacknowledgedAlertsWithinLast24Hours().isNotEmpty)
+            unacknowledgedAlertsPublisher.send(self.unacknowledgedAlertsWithinLast24HoursOnQueue().isNotEmpty)
             broadcaster.notify(AlertObserver.self, on: processQueue) {
                 $0.AlertDidUpdate(cleaned)
             }
@@ -178,7 +156,7 @@ final class BaseAlertHistoryStorage: AlertHistoryStorage, Injectable {
     func broadcastAlertUpdates() {
         processQueue.sync {
             let uniqEvents = pruneAndSort(loadAll())
-            unacknowledgedAlertsPublisher.send(self.unacknowledgedAlertsWithinLast24Hours().isNotEmpty)
+            unacknowledgedAlertsPublisher.send(self.unacknowledgedAlertsWithinLast24HoursOnQueue().isNotEmpty)
             broadcaster.notify(AlertObserver.self, on: processQueue) {
                 $0.AlertDidUpdate(uniqEvents)
             }

--- a/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/TherapySettings/InsulinSensitivityStepView.swift
+++ b/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/TherapySettings/InsulinSensitivityStepView.swift
@@ -145,7 +145,8 @@ struct InsulinSensitivityStepView: View {
     private var isfChart: some View {
         Chart {
             ForEach(Array(state.isfItems.enumerated()), id: \.element.id) { index, item in
-                let displayValue = state.units == .mgdL ? state.isfRateValues[item.rateIndex] : state.isfRateValues[item.rateIndex].asMmolL
+                let displayValue = state.units == .mgdL ? state.isfRateValues[item.rateIndex] : state
+                    .isfRateValues[item.rateIndex].asMmolL
 
                 let startDate = Calendar.current
                     .startOfDay(for: now)

--- a/Trio/Sources/Modules/PumpConfig/PumpConfigProvider.swift
+++ b/Trio/Sources/Modules/PumpConfig/PumpConfigProvider.swift
@@ -26,12 +26,12 @@ extension PumpConfig {
                 ?? PumpSettings(insulinActionCurve: 10, maxBolus: 10, maxBasal: 2)
         }
 
-        var alertNotAck: AnyPublisher<Bool, Never> {
-            deviceManager.alertHistoryStorage.alertNotAck.eraseToAnyPublisher()
+        var unacknowledgedAlertsPublisher: AnyPublisher<Bool, Never> {
+            deviceManager.alertHistoryStorage.unacknowledgedAlertsPublisher.eraseToAnyPublisher()
         }
 
-        func initialAlertNotAck() -> Bool {
-            deviceManager.alertHistoryStorage.recentNotAck().isNotEmpty
+        func hasInitialUnacknowledgedAlerts() -> Bool {
+            deviceManager.alertHistoryStorage.unacknowledgedAlertsWithinLast24Hours().isNotEmpty
         }
     }
 }

--- a/Trio/Sources/Modules/PumpConfig/PumpConfigStateModel.swift
+++ b/Trio/Sources/Modules/PumpConfig/PumpConfigStateModel.swift
@@ -9,7 +9,7 @@ extension PumpConfig {
         private(set) var setupPumpType: PumpType = .minimed
         @Published var pumpState: PumpDisplayState?
         private(set) var initialSettings: PumpInitialSettings = .default
-        @Published var alertNotAck: Bool = false
+        @Published var hasUnacknowledgedAlert: Bool = false
         @Injected() var bluetoothManager: BluetoothStateManager!
 
         override func subscribe() {
@@ -18,10 +18,10 @@ extension PumpConfig {
                 .assign(to: \.pumpState, on: self)
                 .store(in: &lifetime)
 
-            alertNotAck = provider.initialAlertNotAck()
-            provider.alertNotAck
+            hasUnacknowledgedAlert = provider.hasInitialUnacknowledgedAlerts()
+            provider.unacknowledgedAlertsPublisher
                 .receive(on: DispatchQueue.main)
-                .assign(to: \.alertNotAck, on: self)
+                .assign(to: \.hasUnacknowledgedAlert, on: self)
                 .store(in: &lifetime)
 
             Task {
@@ -49,7 +49,7 @@ extension PumpConfig {
         }
 
         func ack() {
-            provider.deviceManager.alertHistoryStorage.forceNotification()
+            provider.deviceManager.alertHistoryStorage.broadcastAlertUpdates()
         }
     }
 }

--- a/Trio/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
+++ b/Trio/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
@@ -41,7 +41,7 @@ extension PumpConfig {
                                     .frame(maxWidth: .infinity, minHeight: 50, alignment: .center)
                                     .font(.title2)
                                 }.padding()
-                                if state.alertNotAck {
+                                if state.hasUnacknowledgedAlert {
                                     Spacer()
                                     Button("Acknowledge all alerts") { state.ack() }
                                 }


### PR DESCRIPTION
This PR fixes an edge case where the first stored alert could be dropped, and modernizes alert history persistence by moving it from file-based JSON storage to `UserDefaults`.

#### What changed

* **Fix: initial alert storage (#375)**
  Ensures the first stored alert is kept when the history file is empty (fallback now includes the newly added alert).

* **Refactor: AlertHistoryStorage now persists via `UserDefaults`**
  Alert history is stored as encoded `[AlertEntry]` in `UserDefaults` (using existing `JSONCoding` encoder/decoder for consistency).

  * Keeps existing behavior: **dedupe by `issuedDate`**, **retain last 24h**, **newest-first sorting**.
  * Thread safety preserved via existing `processQueue`.

* **Migration logic (one-time)**
  On first initialization, if `UserDefaults` has no alert history but legacy `monitor/alerthistory.json` exists:

  * migrate + normalize alert history into `UserDefaults`
  * set a migration flag
  * remove the legacy file to prevent drift
    (`FileStorage` is kept temporarily for migration only; marked with FIXME to remove later.)

* **API + naming improvements + docstrings**

  * Renamed for clarity: `storeAlert` → `addAlert`, `recentNotAck` → `unacknowledgedAlertsWithinLast24Hours`, `forceNotification` → `broadcastAlertUpdates`, etc.
  * `alertNotAck` publisher renamed to `unacknowledgedAlertsPublisher`.
  * Updated call sites in `DeviceDataManager` + PumpConfig flow.
  * Added docstrings to clarify behavior and intent.

* **Minor linting cleanup** in `InsulinSensitivityStepView`.

#### Side Note

* Migration runs once per install and is safe to re-enter (guarded by flag + presence of UserDefaults payload).
