### PR TITLE
Update autosens to fetch 1.5 days worth of pump records + some lint updates

### DIFF
--- a/Model/Helper/PumpEvent+helper.swift
+++ b/Model/Helper/PumpEvent+helper.swift
@@ -79,8 +79,15 @@ public extension PumpEventStored {
 }
 
 extension NSPredicate {
+    /// Used to fetch the last 24 hours of pump history
     static var pumpHistoryLast1440Minutes: NSPredicate {
         let date = Date.oneDayAgoInMinutes
+        return NSPredicate(format: "timestamp >= %@", date as NSDate)
+    }
+
+    /// Used to fetch the last 1.5 days of pump history
+    static var pumpHistoryLast2160Minutes: NSPredicate {
+        let date = Date.oneDayAgoInMinutes - TimeInterval(hours: 12)
         return NSPredicate(format: "timestamp >= %@", date as NSDate)
     }
 

--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -171,11 +171,11 @@ final class OpenAPS {
         return json
     }
 
-    private func fetchPumpHistoryObjectIDs() async throws -> [NSManagedObjectID]? {
+    private func fetchPumpHistoryObjectIDs(predicate: NSPredicate) async throws -> [NSManagedObjectID]? {
         let results = try await CoreDataStack.shared.fetchEntitiesAsync(
             ofType: PumpEventStored.self,
             onContext: context,
-            predicate: NSPredicate.pumpHistoryLast1440Minutes,
+            predicate: predicate,
             key: "timestamp",
             ascending: false,
             batchSize: 50
@@ -290,7 +290,7 @@ final class OpenAPS {
         let tempBasal = currentTemp.rawJSON
 
         // Perform asynchronous calls in parallel
-        async let pumpHistoryObjectIDs = fetchPumpHistoryObjectIDs() ?? []
+        async let pumpHistoryObjectIDs = fetchPumpHistoryObjectIDs(predicate: NSPredicate.pumpHistoryLast1440Minutes) ?? []
         async let carbs = fetchAndProcessCarbs(additionalCarbs: simulatedCarbsAmount ?? 0, carbsDate: simulatedCarbsDate)
         async let glucose = fetchAndProcessGlucose(fetchLimit: 72)
         async let prepareTrioCustomOrefVariables = prepareTrioCustomOrefVariables()
@@ -465,7 +465,10 @@ final class OpenAPS {
         debug(.openAPS, "Start autosens")
 
         // Perform asynchronous calls in parallel
-        async let pumpHistoryObjectIDs = fetchPumpHistoryObjectIDs() ?? []
+        // For the pump history it's important that we get all of the pump
+        // entries that could impact IoB (activity) for 24 hours of glucose
+        // readings, thus pulling 36 hours of pump history
+        async let pumpHistoryObjectIDs = fetchPumpHistoryObjectIDs(predicate: NSPredicate.pumpHistoryLast2160Minutes) ?? []
         async let carbs = fetchAndProcessCarbs()
         async let glucose = fetchAndProcessGlucose(fetchLimit: nil)
         async let getProfile = loadFileFromStorageAsync(name: Settings.profile)

--- a/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/TherapySettings/InsulinSensitivityStepView.swift
+++ b/Trio/Sources/Modules/Onboarding/View/OnboardingSteps/TherapySettings/InsulinSensitivityStepView.swift
@@ -145,7 +145,8 @@ struct InsulinSensitivityStepView: View {
     private var isfChart: some View {
         Chart {
             ForEach(Array(state.isfItems.enumerated()), id: \.element.id) { index, item in
-                let displayValue = state.units == .mgdL ? state.isfRateValues[item.rateIndex] : state.isfRateValues[item.rateIndex].asMmolL
+                let displayValue = state.units == .mgdL ? state.isfRateValues[item.rateIndex] : state
+                    .isfRateValues[item.rateIndex].asMmolL
 
                 let startDate = Calendar.current
                     .startOfDay(for: now)


### PR DESCRIPTION
Currently autosens pulls 24 hours of glucose data and 24 hours of pump history. But the autosens algorithm looks for insulin activity across the entire 24 hours of glucose history, so we need to pull more pump history to make sure that the old glucose deviations have accurate insulin activity (and IoB).

I picked 1.5 days as the time span has this will give us the max dia settable via the UI (10 hours) + 2 hours to get any temp basal events that started before the oldest DIA but end after it.

I think that this PR will fix: https://github.com/nightscout/Trio/issues/574

I wrote up a more detailed issue to track the technical details: https://github.com/nightscout/Trio/issues/897