### PR TITLE
Fix faulty target display when editing overrides #924

### DIFF
--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -228,7 +228,7 @@ extension Home {
             let percentString = percent == 100 ? "" : "\(percent.formatted(.number)) %"
 
             let unit = state.units
-            var target = (latestOverride.target ?? 100) as Decimal
+            var target = (latestOverride.target ?? 0) as Decimal
             target = unit == .mmolL ? target.asMmolL : target
 
             var targetString = target == 0 ? "" : (fetchedTargetFormatter.string(from: target as NSNumber) ?? "") + " " + unit


### PR DESCRIPTION
### Summary

Fixes an issue where an override target was displayed incorrectly while editing.
Fixes #924.

### Details

* Default target value is now treated as `0` instead of `100`
* Prevents showing an unintended target value when no explicit override target is set
* Ensures the override summary only displays a target when one is actually defined

### Screenshots from Simulator

| Initial OR | OR Edit1 | OR Edit2 |
|--------|--------|--------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e69a3681-0d7e-4c95-9c0f-5c3757971712" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/37fc6684-7074-4ea4-b7bd-ba5595669581" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c2d9b0fe-f71d-4b45-ac39-e1f586349bb3" /> | 