### PR TITLE
Adjust when SMB/UAM Mins are shown in Adjustment Banner

### DIFF
--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -273,7 +273,7 @@ extension Home {
             var smbMinuteString: String = ""
             var uamMinuteString: String = ""
 
-            if !latestOverride.smbIsOff || !latestOverride.smbIsScheduledOff {
+            if !latestOverride.smbIsOff, latestOverride.advancedSettings {
                 if let smbMinutes = latestOverride.smbMinutes,
                    smbMinutes.decimalValue != settingsManager.preferences.maxSMBBasalMinutes
                 {


### PR DESCRIPTION
Since 0.6.0.37, the adjustments banner on the main view shows when

`smbIsOff` is false

or when

`smbIsScheduledOff` is false

... but they are never both true, so it always passes that line.

---

This can wrongly happen when using 0.6.0.37 without this PR:

<img width="350" src="https://github.com/user-attachments/assets/f152dfd9-f23e-4183-9edb-e86e990eca92" />


---

I removed the `smbIsScheduledOff` check, because when `smbIsScheduledOff` is true you can still change the SMB/UAM Minutes for the times SMB is not scheduled off.

I added a check for `advancedSettings` which is the boolean that the `Override Max SMB Minutes` toggle controls.