### PR TITLE
Prevent "New Preset" from resetting list

### DIFF
--- a/Trio/Sources/Modules/Treatments/View/MealPreset/MealPresetView.swift
+++ b/Trio/Sources/Modules/Treatments/View/MealPreset/MealPresetView.swift
@@ -66,7 +66,6 @@ struct MealPresetView: View {
                 ToolbarItem(placement: .topBarLeading) {
                     Button {
                         dismiss()
-                        resetValues()
                     } label: {
                         Text("Close")
                     }
@@ -74,7 +73,6 @@ struct MealPresetView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(action: {
                         showAddNewPresetSheet.toggle()
-                        resetValues()
                     }, label: {
                         HStack {
                             Text("New Preset")
@@ -93,7 +91,7 @@ struct MealPresetView: View {
                     onSave: savePreset,
                     onCancel: {
                         showAddNewPresetSheet.toggle()
-                        resetValues()
+                        resetNewPresetForm()
                     }
                 )
             }
@@ -267,12 +265,15 @@ struct MealPresetView: View {
     }
 
     private func resetValues() {
+        state.selection = nil
+        state.summation.removeAll()
+    }
+
+    private func resetNewPresetForm() {
         dish = ""
         presetCarbs = 0
         presetFat = 0
         presetProtein = 0
-        state.selection = nil
-        state.summation.removeAll()
     }
 
     private var minusButton: some View {
@@ -345,7 +346,6 @@ struct MealPresetView: View {
                 guard moc.hasChanges else { return }
                 try moc.save()
                 showAddNewPresetSheet.toggle()
-                resetValues()
             } catch let error as NSError {
                 debugPrint("\(DebuggingIdentifiers.failed) Failed to save Meal Preset with error: \(error.userInfo)")
             }


### PR DESCRIPTION
  Addresses Issue:
  * #928
  
  and possibly:
  *  #912 
  
  ---
  
  1. Removed resetValues() from "New Preset" button

  This was the root cause of the bug. When tapping "New Preset", it immediately cleared
  state.summation and all accumulated values before the sheet opened. If you then
  cancelled, the data was already gone.

  2. Changed onCancel to use resetNewPresetForm() instead of resetValues()

  When cancelling the "New Preset" sheet, only clear the form fields for the new preset
  being created, not the presets already added to the meal.

  3. Added resetNewPresetForm() function

  A targeted reset that only clears the 4 form fields (dish, presetCarbs, presetFat,
  presetProtein).

  4. Simplified resetValues() to only clear state model properties

  Removed clearing of @State variables that are destroyed when the view disappears anyway.
   Now only clears state.selection and state.summation.

  5. Removed redundant resetValues() from "Close" button

  The .onDisappear modifier already handles this when the view dismisses.

  6. Removed resetValues() from savePreset()

  The form fields reset automatically when the sheet dismisses, and we don't want to clear
   the accumulated meal values after saving a new preset definition.