### PR TITLE
Add "Color Mode" to Contact Complication Image options

### DIFF
--- a/Model/Classes+Properties/ContactTrickEntryStored+CoreDataProperties.swift
+++ b/Model/Classes+Properties/ContactTrickEntryStored+CoreDataProperties.swift
@@ -17,6 +17,7 @@ public extension ContactImageEntryStored {
     @NSManaged var ringWidth: Int16
     @NSManaged var ringGap: Int16
     @NSManaged var id: UUID?
+    @NSManaged var colorMode: String?
     @NSManaged var fontSize: Int16
     @NSManaged var fontSizeSecondary: Int16
     @NSManaged var fontWidth: String?

--- a/Model/TrioCoreDataPersistentContainer.xcdatamodeld/TrioCoreDataPersistentContainer.xcdatamodel/contents
+++ b/Model/TrioCoreDataPersistentContainer.xcdatamodeld/TrioCoreDataPersistentContainer.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24G84" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24512" systemVersion="25B78" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="BolusStored" representedClassName="BolusStored" syncable="YES">
         <attribute name="amount" optional="YES" attributeType="Decimal" defaultValueString="0"/>
         <attribute name="isExternal" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -27,6 +27,7 @@
     </entity>
     <entity name="ContactImageEntryStored" representedClassName="ContactImageEntryStored" syncable="YES" codeGenerationType="class">
         <attribute name="bottom" optional="YES" attributeType="String"/>
+        <attribute name="colorMode" optional="YES" attributeType="String"/>
         <attribute name="contactId" optional="YES" attributeType="String"/>
         <attribute name="fontSize" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="fontSizeSecondary" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Trio/Sources/APS/Storage/ContactImageStorage.swift
+++ b/Trio/Sources/APS/Storage/ContactImageStorage.swift
@@ -90,8 +90,8 @@ final class BaseContactImageStorage: ContactImageStorage, Injectable {
             newContactImageEntry.ringGap = Int16(contactImageEntry.ringGap.rawValue)
             newContactImageEntry.fontSize = Int16(contactImageEntry.fontSize.rawValue)
             newContactImageEntry.fontSizeSecondary = Int16(contactImageEntry.secondaryFontSize.rawValue)
-            newContactImageEntry.fontWidth = contactImageEntry.fontWeight.asString
-            newContactImageEntry.fontWeight = contactImageEntry.fontWidth.asString
+            newContactImageEntry.fontWidth = contactImageEntry.fontWidth.asString
+            newContactImageEntry.fontWeight = contactImageEntry.fontWeight.asString
 
             do {
                 guard self.backgroundContext.hasChanges else { return }

--- a/Trio/Sources/APS/Storage/ContactImageStorage.swift
+++ b/Trio/Sources/APS/Storage/ContactImageStorage.swift
@@ -52,6 +52,7 @@ final class BaseContactImageStorage: ContactImageStorage, Injectable {
                         hasHighContrast: entry.hasHighContrast,
                         ringWidth: ContactImageEntry.RingWidth(rawValue: Int(entry.ringWidth)) ?? .regular,
                         ringGap: ContactImageEntry.RingGap(rawValue: Int(entry.ringGap)) ?? .small,
+                        colorMode: ContactImageEntry.ColorMode(rawValue: entry.colorMode ?? "Color") ?? .color,
                         fontSize: ContactImageEntry.FontSize(rawValue: Int(entry.fontSize)) ?? .regular,
                         secondaryFontSize: ContactImageEntry.FontSize(rawValue: Int(entry.fontSizeSecondary)) ?? .small,
                         fontWeight: Font.Weight.fromString(entry.fontWeight ?? "regular"),
@@ -88,6 +89,7 @@ final class BaseContactImageStorage: ContactImageStorage, Injectable {
             newContactImageEntry.hasHighContrast = contactImageEntry.hasHighContrast
             newContactImageEntry.ringWidth = Int16(contactImageEntry.ringWidth.rawValue)
             newContactImageEntry.ringGap = Int16(contactImageEntry.ringGap.rawValue)
+            newContactImageEntry.colorMode = contactImageEntry.colorMode.rawValue
             newContactImageEntry.fontSize = Int16(contactImageEntry.fontSize.rawValue)
             newContactImageEntry.fontSizeSecondary = Int16(contactImageEntry.secondaryFontSize.rawValue)
             newContactImageEntry.fontWidth = contactImageEntry.fontWidth.asString
@@ -128,6 +130,7 @@ final class BaseContactImageStorage: ContactImageStorage, Injectable {
                     existingEntry.hasHighContrast = contactImageEntry.hasHighContrast
                     existingEntry.ringWidth = Int16(contactImageEntry.ringWidth.rawValue)
                     existingEntry.ringGap = Int16(contactImageEntry.ringGap.rawValue)
+                    existingEntry.colorMode = contactImageEntry.colorMode.rawValue
                     existingEntry.fontSize = Int16(contactImageEntry.fontSize.rawValue)
                     existingEntry.fontSizeSecondary = Int16(contactImageEntry.secondaryFontSize.rawValue)
                     existingEntry.fontWeight = contactImageEntry.fontWeight.asString

--- a/Trio/Sources/Models/ContactTrickEntry.swift
+++ b/Trio/Sources/Models/ContactTrickEntry.swift
@@ -13,6 +13,7 @@ struct ContactImageEntry: Hashable, Equatable, Sendable {
     var hasHighContrast: Bool = true
     var ringWidth: RingWidth = .regular
     var ringGap: RingGap = .small
+    var colorMode: ColorMode = .color
     var fontSize: FontSize = .regular
     var secondaryFontSize: FontSize = .small
     var fontWeight: Font.Weight = .medium
@@ -31,6 +32,7 @@ struct ContactImageEntry: Hashable, Equatable, Sendable {
             lhs.hasHighContrast == rhs.hasHighContrast &&
             lhs.ringWidth == rhs.ringWidth &&
             lhs.ringGap == rhs.ringGap &&
+            lhs.colorMode == rhs.colorMode &&
             lhs.fontSize == rhs.fontSize &&
             lhs.secondaryFontSize == rhs.secondaryFontSize &&
             lhs.fontWeight == rhs.fontWeight &&
@@ -55,6 +57,21 @@ struct ContactImageEntry: Hashable, Equatable, Sendable {
     // Initialize `fontWidth` from a String
     static func fontWidth(from string: String) -> Font.Width {
         Font.Width.fromString(string)
+    }
+
+    enum ColorMode: String, JSON, CaseIterable, Identifiable, Codable {
+        var id: String { rawValue }
+        case color
+        case monochrome
+
+        var displayName: String {
+            switch self {
+            case .color:
+                return String(localized: "Color", comment: "")
+            case .monochrome:
+                return String(localized: "Monochrome", comment: "")
+            }
+        }
     }
 
     enum FontSize: Int, Codable, Sendable, CaseIterable {

--- a/Trio/Sources/Modules/ContactImage/View/AddContactImageSheet.swift
+++ b/Trio/Sources/Modules/ContactImage/View/AddContactImageSheet.swift
@@ -16,6 +16,7 @@ struct AddContactImageSheet: View {
     @State private var top: ContactImageValue = .none
     @State private var bottom: ContactImageValue = .trend
     @State private var ring: ContactImageLargeRing = .none
+    @State private var colorMode: ContactImageEntry.ColorMode = .color
     @State private var fontSize: ContactImageEntry.FontSize = .regular
     @State private var secondaryFontSize: ContactImageEntry.FontSize = .small
     @State private var fontWeight: Font.Weight = .medium
@@ -34,6 +35,7 @@ struct AddContactImageSheet: View {
             hasHighContrast: hasHighContrast,
             ringWidth: ringWidth,
             ringGap: ringGap,
+            colorMode: colorMode,
             fontSize: fontSize,
             secondaryFontSize: secondaryFontSize,
             fontWeight: fontWeight,
@@ -136,6 +138,7 @@ struct AddContactImageSheet: View {
 
                     // Font Settings Section
                     Section(header: Text("Font Settings")) {
+                        colorModePicker
                         fontSizePicker
                         if layout == .split {
                             secondaryFontSizePicker
@@ -198,6 +201,14 @@ struct AddContactImageSheet: View {
                 .tint(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .padding(5)
+        }
+    }
+
+    private var colorModePicker: some View {
+        Picker("Color Mode", selection: $colorMode) {
+            ForEach(ContactImageEntry.ColorMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+            }
         }
     }
 

--- a/Trio/Sources/Modules/ContactImage/View/ContactImageDetailView.swift
+++ b/Trio/Sources/Modules/ContactImage/View/ContactImageDetailView.swift
@@ -109,6 +109,7 @@ struct ContactImageDetailView: View {
 
                 // Font Settings Section
                 Section(header: Text("Font Settings")) {
+                    colorModePicker
                     fontSizePicker
                     if contactImageEntry.layout == .split {
                         secondaryFontSizePicker
@@ -174,6 +175,14 @@ struct ContactImageDetailView: View {
                 .tint(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .padding(5)
+        }
+    }
+
+    private var colorModePicker: some View {
+        Picker("Color Mode", selection: $contactImageEntry.colorMode) {
+            ForEach(ContactImageEntry.ColorMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+            }
         }
     }
 

--- a/Trio/Sources/Services/ContactImage/ContactPicture.swift
+++ b/Trio/Sources/Services/ContactImage/ContactPicture.swift
@@ -289,7 +289,7 @@ struct ContactPicture: View {
                 fontSize: fontSize,
                 fontWeight: fontWeight,
                 fontWidth: fontWidth,
-                color: textColor
+                color: contact.colorMode == .color ? textColor : .white
             )
         }
     }
@@ -634,6 +634,7 @@ struct ContactPicture_Previews: PreviewProvider {
     struct Preview: View {
         @State var rangeIndicator: Bool = true
         @State var hasHighContrast: Bool = true
+        @State var colorMode: ContactImageEntry.ColorMode = .color
         @State var fontSize: ContactImageEntry.FontSize = .small
         @State var fontWeight: UIFont.Weight = .bold
         @State var fontName: String? = "AmericanTypewriter"
@@ -645,6 +646,7 @@ struct ContactPicture_Previews: PreviewProvider {
                         primary: .glucose,
                         top: .delta,
                         bottom: .trend,
+                        colorMode: .color,
                         fontSize: fontSize,
                         fontWeight: .medium
                     )
@@ -683,6 +685,7 @@ struct ContactPicture_Previews: PreviewProvider {
                         primary: .glucose,
                         top: .ring,
                         bottom: .trend,
+                        colorMode: .color,
                         fontSize: fontSize,
                         fontWeight: .medium
                     )
@@ -702,6 +705,7 @@ struct ContactPicture_Previews: PreviewProvider {
                         primary: .glucose,
                         top: .none,
                         bottom: .trend,
+                        colorMode: .color,
                         fontSize: fontSize,
                         fontWeight: .medium
                     )
@@ -720,6 +724,7 @@ struct ContactPicture_Previews: PreviewProvider {
                         primary: .glucose,
                         top: .none,
                         bottom: .eventualBG,
+                        colorMode: .color,
                         fontSize: fontSize,
                         fontWeight: .medium
                     )
@@ -738,6 +743,7 @@ struct ContactPicture_Previews: PreviewProvider {
                         primary: .lastLoopDate,
                         top: .none,
                         bottom: .none,
+                        colorMode: .color,
                         fontSize: fontSize,
                         fontWeight: .medium
                     )
@@ -756,6 +762,7 @@ struct ContactPicture_Previews: PreviewProvider {
                         primary: .glucose,
                         top: .none,
                         bottom: .none,
+                        colorMode: .color,
                         fontSize: fontSize,
                         fontWeight: .medium
                     )
@@ -775,6 +782,7 @@ struct ContactPicture_Previews: PreviewProvider {
                         layout: .split,
                         top: .iob,
                         bottom: .cob,
+                        colorMode: .color,
                         fontSize: fontSize,
                         fontWeight: .medium
                     )


### PR DESCRIPTION
This option was requested by a user on Discord because the dynamic color made the glucose hard to read when used on a monochrome watch face.

User's screenshot before this PR:

<img width="333" src="https://github.com/user-attachments/assets/f4e46736-da00-4e83-acdf-d5f43b9b9f3e" />

Color Mode option this PR adds:

<img width="350" src="https://github.com/user-attachments/assets/222890db-8711-4eb4-92ec-8ab563b3a5b4" />