### PR TITLE
update to fastlane 2.231.0 using bundler 4.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "fastlane", "2.230.0"
+gem "fastlane", "2.231.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.7)
-      base64
-      nkf
-      rexml
+    CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1163.0)
-    aws-sdk-core (3.232.0)
+    aws-partitions (1.1206.0)
+    aws-sdk-core (3.241.4)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -20,18 +17,18 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.112.0)
-      aws-sdk-core (~> 3, >= 3.231.0)
+    aws-sdk-kms (1.121.0)
+      aws-sdk-core (~> 3, >= 3.241.4)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.199.0)
-      aws-sdk-core (~> 3, >= 3.231.0)
+    aws-sdk-s3 (1.211.0)
+      aws-sdk-core (~> 3, >= 3.241.3)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     base64 (0.2.0)
-    bigdecimal (3.2.3)
+    bigdecimal (4.0.1)
     claide (1.1.0)
     colored (1.2)
     colored2 (3.1.2)
@@ -45,36 +42,32 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.4)
+    faraday (1.8.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
+      faraday-httpclient (~> 1.0.1)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+      multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
-    faraday-cookie_jar (0.0.7)
+    faraday-cookie_jar (0.0.8)
       faraday (>= 0.8.0)
-      http-cookie (~> 1.0.0)
+      http-cookie (>= 1.0.0)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.1)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.1.1)
-      multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.230.0)
+    fastlane (2.231.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       abbrev (~> 0.1.2)
       addressable (>= 2.8, < 3.0.0)
@@ -82,7 +75,7 @@ GEM
       aws-sdk-s3 (~> 1.0)
       babosa (>= 1.0.3, < 2.0.0)
       base64 (~> 0.2.0)
-      bundler (>= 1.12.0, < 3.0.0)
+      bundler (>= 1.17.3, < 5.0.0)
       colored (~> 1.2)
       commander (~> 4.6)
       csv (~> 3.3)
@@ -167,23 +160,23 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.15.0)
+    json (2.18.0)
     jwt (2.10.2)
       base64
     logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    multi_json (1.17.0)
+    multi_json (1.19.1)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     naturally (2.3.0)
     nkf (0.2.0)
-    optparse (0.6.0)
+    optparse (0.8.1)
     os (1.1.4)
     plist (3.7.2)
-    public_suffix (6.0.2)
-    rake (13.3.0)
+    public_suffix (7.0.2)
+    rake (13.3.1)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -227,16 +220,11 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-23
-  arm64-darwin-24
-  x86_64-darwin-19
-  x86_64-darwin-24
-  x86_64-linux
+  arm64-darwin-25
+  ruby
 
 DEPENDENCIES
-  fastlane (= 2.230.0)
+  fastlane (= 2.231.0)
 
 BUNDLED WITH
-   2.6.2
+  4.0.4


### PR DESCRIPTION
## Purpose

Keep the version of fastlane used by build actions up to date

## Method

* Update the version listed in Gemfile from `2.230.0` to `2.231.0`
* Current version of ruby is 4.0.0
* Update the bundler using the command `bundle update --bundler`
   * this updates to bundler 4.0.4
   * fastlane 2.231.0 is compatible with this bundler (2.230.0 was not)
* Update the Gemfile.lock using the command `bundle install`

## Test

Tests performed with [docs-test GitHub username](https://github.com/docs-test/Trio/actions)

* Set `fastlane_2.231.0` as the default branch
*  ✅ Delete a Trio identifier (Trio Watch App) and verify that [Add Identifiers](https://github.com/docs-test/Trio/actions/runs/21097497620) successfully creates it again
* Delete the Distribution certificate
* ✅ [Confirm Build_Trio](https://github.com/docs-test/Trio/actions/runs/21097561070) successfully nukes certs, creates them and builds