### PR TITLE
Refactor Garmin: simplify manager, add documentation, and improve simulator testing

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -267,8 +267,8 @@
 		491D6FBE2D56741C00C49F67 /* TempTargetRunStored+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D6FB92D56741C00C49F67 /* TempTargetRunStored+CoreDataClass.swift */; };
 		491D6FBF2D56741C00C49F67 /* TempTargetRunStored+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D6FBA2D56741C00C49F67 /* TempTargetRunStored+CoreDataProperties.swift */; };
 		491D6FC02D56741C00C49F67 /* TempTargetStored+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D6FBB2D56741C00C49F67 /* TempTargetStored+CoreDataClass.swift */; };
-		4984D1D42EA2939E00263E83 /* WatchConfigGarminAppConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4984D1D32EA2939E00263E83 /* WatchConfigGarminAppConfigView.swift */; };
 		49239B432EEA27AD00469145 /* TempTargetCalculations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49239B422EEA27AD00469145 /* TempTargetCalculations.swift */; };
+		4984D1D42EA2939E00263E83 /* WatchConfigGarminAppConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4984D1D32EA2939E00263E83 /* WatchConfigGarminAppConfigView.swift */; };
 		49B9B57F2D5768D2009C6B59 /* AdjustmentStored+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B9B57E2D5768D2009C6B59 /* AdjustmentStored+Helper.swift */; };
 		5075C1608E6249A51495C422 /* TargetsEditorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDEA2DC60EDE0A3CA54DC73 /* TargetsEditorProvider.swift */; };
 		53F2382465BF74DB1A967C8B /* PumpConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8630D58BDAD6D9C650B9B39 /* PumpConfigProvider.swift */; };
@@ -1096,8 +1096,8 @@
 		491D6FBA2D56741C00C49F67 /* TempTargetRunStored+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TempTargetRunStored+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		491D6FBB2D56741C00C49F67 /* TempTargetStored+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TempTargetStored+CoreDataClass.swift"; sourceTree = "<group>"; };
 		491D6FBC2D56741C00C49F67 /* TempTargetStored+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TempTargetStored+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		4984D1D32EA2939E00263E83 /* WatchConfigGarminAppConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConfigGarminAppConfigView.swift; sourceTree = "<group>"; };
 		49239B422EEA27AD00469145 /* TempTargetCalculations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempTargetCalculations.swift; sourceTree = "<group>"; };
+		4984D1D32EA2939E00263E83 /* WatchConfigGarminAppConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConfigGarminAppConfigView.swift; sourceTree = "<group>"; };
 		49B9B57E2D5768D2009C6B59 /* AdjustmentStored+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdjustmentStored+Helper.swift"; sourceTree = "<group>"; };
 		4DD795BA46B193644D48138C /* TargetsEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorRootView.swift; sourceTree = "<group>"; };
 		505E09DC17A0C3D0AF4B66FE /* ISFEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorStateModel.swift; sourceTree = "<group>"; };

--- a/Trio.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Trio.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/garmin/connectiq-companion-app-sdk-ios",
       "state" : {
-        "revision" : "00594907c84884a9430c6a33825940c2769f261a",
-        "version" : "1.7.0"
+        "revision" : "f0d29ff691d700a132d86205ed9bb091e336c2f7",
+        "version" : "1.8.0"
       }
     },
     {

--- a/Trio/Sources/Models/GarminWatchSettings.swift
+++ b/Trio/Sources/Models/GarminWatchSettings.swift
@@ -99,7 +99,9 @@ enum GarminDatafield: String, JSON, CaseIterable, Identifiable, Codable, Hashabl
     var datafieldUUID: UUID? {
         switch self {
         case .trio:
-            return UUID(uuidString: "71cf0982-ca41-42a5-8441-ea81d36056c3")
+            // return UUID(uuidString: "71cf0982-ca41-42a5-8441-ea81d36056c3")  // local build
+            // return UUID(uuidString: "f07f4ef9-108b-4397-95c9-217b5173412e")  // ConnectIQ test build
+            return UUID(uuidString: "3d9b6528-8c84-459a-bbab-989b5f001ebd") // ConnectIQ live build
         case .swissalpine:
             // return UUID(uuidString: "7A2268F6-3381-4474-81BD-0A3E7F458CB7") // ConnectIQ test build
             return UUID(uuidString: "dec5292a-74b0-41bc-8e45-cd93f1d5e137") // ConnectIQ live build

--- a/Trio/Sources/Models/GarminWatchState.swift
+++ b/Trio/Sources/Models/GarminWatchState.swift
@@ -15,16 +15,38 @@ import SwiftUI
 struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
     /// Timestamp of the glucose reading in milliseconds since Unix epoch
     var date: UInt64?
+
+    /// Sensor glucose value in raw mg/dL (no unit conversion applied)
     var sgv: Int16?
+
+    /// Change in glucose since previous reading as an integer
     var delta: Int16?
+
+    /// Glucose trend direction (e.g., "Flat", "FortyFiveUp", "SingleUp")
     var direction: String?
+
+    /// Signal noise level (optional, typically not used)
     var noise: Double?
+
+    /// Unit hint for the watchface ("mgdl" or "mmol")
     var units_hint: String?
+
+    /// Insulin on board as a decimal value (only in first array entry)
     var iob: Double?
+
+    /// Current temp basal rate in U/hr (only in first array entry)
     var tbr: Double?
+
+    /// Carbs on board as a decimal value (only in first array entry)
     var cob: Double?
+
+    /// Predicted eventual blood glucose (excluded if data type 2 is set to TBR)
     var eventualBG: Int16?
+
+    /// Current insulin sensitivity factor as an integer (only in first array entry)
     var isf: Int16?
+
+    /// AutoISF sensitivity ratio (included only if data type 1 is set to sensRatio)
     var sensRatio: Double?
 
     // MARK: - Display Configuration Fields

--- a/Trio/Sources/Models/GarminWatchState.swift
+++ b/Trio/Sources/Models/GarminWatchState.swift
@@ -1,3 +1,9 @@
+//
+//  GarminWatchState.swift
+//  Trio
+//
+//  Created by Cengiz Deniz on 25.01.25.
+//
 import Foundation
 import SwiftUI
 
@@ -9,38 +15,16 @@ import SwiftUI
 struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
     /// Timestamp of the glucose reading in milliseconds since Unix epoch
     var date: UInt64?
-
-    /// Sensor glucose value in raw mg/dL (no unit conversion applied)
     var sgv: Int16?
-
-    /// Change in glucose since previous reading as an integer
     var delta: Int16?
-
-    /// Glucose trend direction (e.g., "Flat", "FortyFiveUp", "SingleUp")
     var direction: String?
-
-    /// Signal noise level (optional, typically not used)
     var noise: Double?
-
-    /// Unit hint for the watchface ("mgdl" or "mmol")
     var units_hint: String?
-
-    /// Insulin on board as a decimal value (only in first array entry)
     var iob: Double?
-
-    /// Current temp basal rate in U/hr (only in first array entry)
     var tbr: Double?
-
-    /// Carbs on board as a decimal value (only in first array entry)
     var cob: Double?
-
-    /// Predicted eventual blood glucose (excluded if data type 2 is set to TBR)
     var eventualBG: Int16?
-
-    /// Current insulin sensitivity factor as an integer (only in first array entry)
     var isf: Int16?
-
-    /// AutoISF sensitivity ratio (included only if data type 1 is set to sensRatio)
     var sensRatio: Double?
 
     // MARK: - Display Configuration Fields
@@ -105,6 +89,7 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
     }
 
     /// Custom encoding that excludes nil values from the JSON output
+    /// Double values are rounded to 2 decimal places to prevent floating point artifacts
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(date, forKey: .date)
@@ -113,12 +98,13 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
         try container.encodeIfPresent(direction, forKey: .direction)
         try container.encodeIfPresent(noise, forKey: .noise)
         try container.encodeIfPresent(units_hint, forKey: .units_hint)
-        try container.encodeIfPresent(iob, forKey: .iob)
-        try container.encodeIfPresent(tbr, forKey: .tbr)
+        // Round Double values to 2 decimal places to prevent floating point artifacts like "0.5600000000000001"
+        try container.encodeIfPresent(iob?.roundedDouble(toPlaces: 2), forKey: .iob)
+        try container.encodeIfPresent(tbr?.roundedDouble(toPlaces: 2), forKey: .tbr)
         try container.encodeIfPresent(cob, forKey: .cob)
         try container.encodeIfPresent(eventualBG, forKey: .eventualBG)
         try container.encodeIfPresent(isf, forKey: .isf)
-        try container.encodeIfPresent(sensRatio, forKey: .sensRatio)
+        try container.encodeIfPresent(sensRatio?.roundedDouble(toPlaces: 2), forKey: .sensRatio)
         try container.encodeIfPresent(displayPrimaryAttributeChoice, forKey: .displayPrimaryAttributeChoice)
         try container.encodeIfPresent(displaySecondaryAttributeChoice, forKey: .displaySecondaryAttributeChoice)
     }

--- a/Trio/Sources/Models/GarminWatchState.swift
+++ b/Trio/Sources/Models/GarminWatchState.swift
@@ -13,8 +13,13 @@ import SwiftUI
 /// Uses the SwissAlpine xDrip+ compatible data format.
 /// Sent as an array where the first entry contains all extended data fields.
 struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
-    /// Timestamp of the glucose reading in milliseconds since Unix epoch
+    /// Timestamp of the enacted loop determination in milliseconds since Unix epoch
+    /// Shows when the loop actually executed, used to indicate loop staleness
     var date: UInt64?
+
+    /// Timestamp of the glucose reading in milliseconds since Unix epoch
+    /// Used by watchface to determine glucose freshness for coloring logic
+    var glucoseDate: UInt64?
 
     /// Sensor glucose value in raw mg/dL (no unit conversion applied)
     var sgv: Int16?
@@ -61,6 +66,7 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
 
     static func == (lhs: GarminWatchState, rhs: GarminWatchState) -> Bool {
         lhs.date == rhs.date &&
+            lhs.glucoseDate == rhs.glucoseDate &&
             lhs.sgv == rhs.sgv &&
             lhs.delta == rhs.delta &&
             lhs.direction == rhs.direction &&
@@ -78,6 +84,7 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(date)
+        hasher.combine(glucoseDate)
         hasher.combine(sgv)
         hasher.combine(delta)
         hasher.combine(direction)
@@ -95,6 +102,7 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
 
     enum CodingKeys: String, CodingKey {
         case date
+        case glucoseDate
         case sgv
         case delta
         case direction
@@ -115,6 +123,7 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(date, forKey: .date)
+        try container.encodeIfPresent(glucoseDate, forKey: .glucoseDate)
         try container.encodeIfPresent(sgv, forKey: .sgv)
         try container.encodeIfPresent(delta, forKey: .delta)
         try container.encodeIfPresent(direction, forKey: .direction)

--- a/Trio/Sources/Modules/WatchConfig/View/WatchConfigGarminAppConfigView.swift
+++ b/Trio/Sources/Modules/WatchConfig/View/WatchConfigGarminAppConfigView.swift
@@ -53,6 +53,9 @@ struct WatchConfigGarminAppConfigView: View {
                             ).buttonStyle(BorderlessButtonStyle())
                         }.padding(.top)
                         Spacer()
+                        // Inverted binding: "Disable" toggle controls "isEnabled" boolean
+                        // When toggle is ON → data transmission is DISABLED (isEnabled = false)
+                        // When toggle is OFF → data transmission is ENABLED (isEnabled = true)
                         Toggle("Disable Watchface Data", isOn: Binding(
                             get: { !state.garminSettings.isWatchfaceDataEnabled },
                             set: { state.garminSettings.isWatchfaceDataEnabled = !$0 }

--- a/Trio/Sources/Modules/WatchConfig/View/WatchConfigGarminView.swift
+++ b/Trio/Sources/Modules/WatchConfig/View/WatchConfigGarminView.swift
@@ -19,14 +19,8 @@ struct WatchConfigGarminView: View {
     #if targetEnvironment(simulator)
         /// Adds a mock Garmin device for simulator UI testing
         private func addMockDevice() {
-            // Create a mock IQDevice using a simple class that conforms to the protocol
-            let mockDevice = MockIQDevice(
-                uuid: UUID(),
-                friendlyName: "Mock Garmin Fenix 7",
-                modelName: "fenix7"
-            )
+            let mockDevice = BaseGarminManager.MockIQDevice.createSimulated()
             state.devices.append(mockDevice)
-            // Persist to garmin manager so it survives view reloads
             state.deleteGarminDevice()
         }
     #endif
@@ -87,7 +81,6 @@ struct WatchConfigGarminView: View {
                                 .buttonStyle(.bordered)
                             } else {
                                 Button {
-                                    // Remove all devices
                                     state.devices.removeAll()
                                     state.deleteGarminDevice()
                                 } label: {
@@ -200,29 +193,3 @@ struct WatchConfigGarminView: View {
         }
     }
 }
-
-#if targetEnvironment(simulator)
-    // Mock IQDevice class for simulator testing
-    // Minimal implementation just for UI testing - no actual Garmin functionality
-    class MockIQDevice: IQDevice {
-        private let _uuid: UUID
-        private let _friendlyName: String
-        private let _modelName: String
-
-        override var uuid: UUID { _uuid }
-        override var friendlyName: String { _friendlyName }
-        override var modelName: String { _modelName }
-        var status: IQDeviceStatus { .connected }
-
-        init(uuid: UUID, friendlyName: String, modelName: String) {
-            _uuid = uuid
-            _friendlyName = friendlyName
-            _modelName = modelName
-            super.init()
-        }
-
-        @available(*, unavailable) required init?(coder _: NSCoder) {
-            fatalError("init(coder:) not implemented for mock device")
-        }
-    }
-#endif

--- a/Trio/Sources/Services/WatchManager/GarminManager.swift
+++ b/Trio/Sources/Services/WatchManager/GarminManager.swift
@@ -719,9 +719,9 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
         // Without this, hash deduplication could skip sending to new apps if data unchanged
         lastSentDataHash = nil
 
-        // Clear ready state - devices need to complete characteristic discovery again
-        // after re-registration (SDK 1.8+ requirement)
-        readyDevices.removeAll()
+        // Note: Do NOT clear readyDevices here. The device ready state is based on BLE
+        // characteristic discovery, which only happens on new connections. Re-registering
+        // for app messages doesn't affect the underlying BLE connection state.
 
         for device in devices {
             connectIQ?.register(forDeviceEvents: device, delegate: self)

--- a/Trio/Sources/Services/WatchManager/GarminManager.swift
+++ b/Trio/Sources/Services/WatchManager/GarminManager.swift
@@ -214,14 +214,28 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
         currentWatchface == .swissalpine
     }
 
-    /// Returns the display name for an app UUID (watchface or datafield)
+    /// Returns the display name for an app UUID (watchface or datafield).
+    /// Use this for routine log messages where UUID adds noise.
     private func appDisplayName(for uuid: UUID) -> String {
         if uuid == currentWatchface.watchfaceUUID {
             return "watchface:\(currentWatchface.displayName)"
         } else if uuid == currentDatafield.datafieldUUID {
             return "datafield:\(currentDatafield.displayName)"
         } else {
-            return uuid.uuidString
+            return "unknown app"
+        }
+    }
+
+    /// Returns the detailed display name including UUID for an app.
+    /// Use this for registration/connection messages and error scenarios where UUID identification is valuable.
+    /// This helps with debugging when multiple versions/distributions exist (local, test, live builds).
+    private func appDetailedName(for uuid: UUID) -> String {
+        if uuid == currentWatchface.watchfaceUUID {
+            return "watchface:\(currentWatchface.displayName) (\(uuid.uuidString))"
+        } else if uuid == currentDatafield.datafieldUUID {
+            return "datafield:\(currentDatafield.displayName) (\(uuid.uuidString))"
+        } else {
+            return "unknown app (\(uuid.uuidString))"
         }
     }
 
@@ -542,7 +556,7 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
                let watchfaceUUID = currentWatchface.watchfaceUUID,
                let watchfaceApp = IQApp(uuid: watchfaceUUID, store: UUID(), device: device)
             {
-                debugGarmin("Garmin: Registered watchface:\(currentWatchface.displayName)")
+                debugGarmin("Garmin: Registered \(appDetailedName(for: watchfaceUUID))")
                 watchApps.append(watchfaceApp)
                 connectIQ?.register(forAppMessages: watchfaceApp, delegate: self)
             } else if !isWatchfaceDataEnabled {
@@ -553,7 +567,7 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
             if let datafieldUUID = currentDatafield.datafieldUUID,
                let datafieldApp = IQApp(uuid: datafieldUUID, store: UUID(), device: device)
             {
-                debugGarmin("Garmin: Registered datafield:\(currentDatafield.displayName)")
+                debugGarmin("Garmin: Registered \(appDetailedName(for: datafieldUUID))")
                 watchApps.append(datafieldApp)
                 connectIQ?.register(forAppMessages: datafieldApp, delegate: self)
             }

--- a/Trio/Sources/Services/WatchManager/GarminManager.swift
+++ b/Trio/Sources/Services/WatchManager/GarminManager.swift
@@ -2,13 +2,7 @@ import Combine
 import ConnectIQ
 import CoreData
 import Foundation
-import os
 import Swinject
-
-// Data transmission logic:
-// - Datafield apps always receive data (bypass status checks as ConnectIQ status can be unreliable)
-// - Watchface apps only receive data when watchface data transmission is enabled
-// - Skip sending only if no apps are configured at all, or only watchface is configured with data disabled
 
 // MARK: - GarminManager Protocol
 
@@ -38,155 +32,85 @@ protocol GarminManager {
 ///  - Device registration/unregistration with Garmin ConnectIQ
 ///  - Data persistence for selected devices
 ///  - Generating & sending watch-state updates (glucose, IOB, COB, etc.) to Garmin watch apps.
-final class BaseGarminManager: NSObject, GarminManager, Injectable, @unchecked Sendable {
+final class BaseGarminManager: NSObject, GarminManager, Injectable {
     // MARK: - Dependencies & Properties
 
-    /// Observes system-wide notifications, including `.openFromGarminConnect`.
     @Injected() private var notificationCenter: NotificationCenter!
-
-    /// Broadcaster used for publishing or subscribing to global events (e.g., unit changes).
     @Injected() private var broadcaster: Broadcaster!
-
-    /// APSManager containing insulin pump logic, e.g., for making bolus requests, reading basal info, etc.
     @Injected() private var apsManager: APSManager!
-
-    /// Manages local user settings, such as glucose units (mg/dL or mmol/L).
     @Injected() private var settingsManager: SettingsManager!
-
-    /// Stores, retrieves, and updates glucose data in CoreData.
     @Injected() private var glucoseStorage: GlucoseStorage!
-
-    /// Stores, retrieves, and updates insulin dose determinations in CoreData.
     @Injected() private var determinationStorage: DeterminationStorage!
-
     @Injected() private var iobService: IOBService!
 
-    /// Persists the user's device list between app launches.
     @Persisted(key: "BaseGarminManager.persistedDevices") private var persistedDevices: [GarminDevice] = []
 
-    /// Router for presenting alerts or navigation flows (injected via Swinject).
     private let router: Router
-
-    /// Garmin ConnectIQ shared instance for watch interactions.
     private let connectIQ = ConnectIQ.sharedInstance()
-
-    /// Keeps references to watch apps (both watchface & data field) for each registered device.
     private var watchApps: [IQApp] = []
-
-    /// A set of Combine cancellables for managing the lifecycle of various subscriptions.
     private var cancellables = Set<AnyCancellable>()
-
-    /// Holds a promise used when the user is selecting devices (via `showDeviceSelection()`).
     private var deviceSelectionPromise: Future<[IQDevice], Never>.Promise?
 
-    /// Enable/disable debug logging for watch state (SwissAlpine/Trio data being sent)
-    private let debugWatchState = true // Set to false to disable debug logging
+    /// Subject for debouncing watch state updates
+    private let watchStateSubject = PassthroughSubject<Data, Never>()
 
-    /// Enable/disable general Garmin debug logging (connections, settings, throttling, etc.)
-    private let debugGarmin = true // Set to false to disable verbose Garmin logging
+    /// Current glucose units
+    private var units: GlucoseUnits = .mgdL
 
-    /// Enable simulated Garmin device for Xcode Simulator testing
-    /// When true, creates a fake Garmin device so you can test the workflow in Simulator
-    #if targetEnvironment(simulator)
-        private let enableSimulatedDevice = true // Set to false to disable simulated device
-    #else
-        private let enableSimulatedDevice = false // Never enable on real device
-    #endif
+    // MARK: - Debug Logging
+
+    /// Enable/disable verbose debug logging for watch state preparation
+    private let debugWatchState = true
+
+    /// Enable/disable general Garmin debug logging (connections, sends, etc.)
+    private let debugGarminEnabled = true
 
     /// Helper method for conditional Garmin debug logging
     private func debugGarmin(_ message: String) {
-        guard debugGarmin else { return }
+        guard debugGarminEnabled else { return }
         debug(.watchManager, message)
     }
 
-    /// Track when immediate sends happen to cancel throttled ones
-    private var lastImmediateSendTime: Date?
-    private var throttledUpdatePending = false
+    // MARK: - Deduplication
 
-    /// Track last sent data hash to prevent duplicate sends
+    /// Hash of last sent data to prevent duplicate broadcasts
     private var lastSentDataHash: Int?
-    private let lastSentHashLock = NSLock()
 
-    /// Cache last determination data to avoid CoreData staleness on immediate sends
-    private var cachedDeterminationData: Data?
-
-    /// Track when watchface was last changed to prevent caching stale format data
-    private var lastWatchfaceChangeTime: Date?
-
-    /// Cache of app installation status to avoid expensive checks before data preparation
-    /// Key: app UUID string, Value: (status, lastChecked)
-    /// Using enum to distinguish between "not installed" vs "unknown due to connection issue"
-    private var appInstallationCache: [String: (status: AppCacheStatus, lastChecked: Date)] = [:]
-    private let appStatusCacheLock = NSLock()
-
-    /// How long to trust cached app status (in seconds)
-    private let appStatusCacheTimeout: TimeInterval = 60 // 1 minute
-
-    /// Track device connection states to make intelligent caching decisions
-    private var deviceConnectionStates: [UUID: IQDeviceStatus] = [:]
-
-    /// App installation cache status enum
-    private enum AppCacheStatus {
-        case installed
-        case notInstalled
-        case unknown // Can't determine due to connection issues
-
-        var shouldSendData: Bool {
-            switch self {
-            case .installed: return true
-            case .notInstalled: return false
-            case .unknown: return true // Optimistic when uncertain
-            }
-        }
-    }
-
-    /// Throttle duration for non-critical updates (settings changes)
-    private let throttleDuration: TimeInterval = 10
-
-    /// Deduplication: Track last prepared data hash to prevent duplicate expensive work
+    /// Hash of last prepared data to skip redundant preparation
     private var lastPreparedDataHash: Int?
     private var lastPreparedWatchState: [GarminWatchState]?
-    private let hashLock = NSLock()
 
-    /// Array of Garmin `IQDevice` objects currently tracked.
-    /// Changing this property triggers re-registration and updates persisted devices.
-    private(set) var devices: [IQDevice] = [] {
-        didSet {
-            // Persist newly updated device list
-            persistedDevices = devices.map(GarminDevice.init)
-            // Re-register for events, app messages, etc.
-            registerDevices(devices)
-        }
-    }
+    // MARK: - Glucose/Determination Coordination
 
-    /// Current glucose units, either mg/dL or mmol/L, read from user settings.
-    private var units: GlucoseUnits = .mgdL
-    /// Track previous Garmin settings as a single struct
-    private var previousGarminSettings = GarminWatchSettings()
+    /// Delay before sending glucose if determination hasn't arrived (seconds)
+    /// Based on log analysis: avg delay ~5s, max ~24s, >15s occurs <1% of time
+    private let glucoseFallbackDelay: TimeInterval = 20
+
+    /// Pending glucose fallback task - cancelled if determination arrives first
+    private var pendingGlucoseFallback: DispatchWorkItem?
+
+    /// Queue for glucose fallback timer
+    private let timerQueue = DispatchQueue(label: "BaseGarminManager.timerQueue", qos: .utility)
 
     /// Queue for handling Core Data change notifications
     private let queue = DispatchQueue(label: "BaseGarminManager.queue", qos: .utility)
 
-    /// Dedicated queue for throttle timers to avoid blocking main thread
-    private let timerQueue = DispatchQueue(label: "BaseGarminManager.timerQueue", qos: .utility)
-
-    /// Publishes any changed CoreData objects that match our filters (e.g., OrefDetermination, GlucoseStored).
     private var coreDataPublisher: AnyPublisher<Set<NSManagedObjectID>, Never>?
-
-    /// Additional local subscriptions (separate from `cancellables`) for CoreData events.
     private var subscriptions = Set<AnyCancellable>()
 
-    /// Represents the context for background tasks in CoreData.
     let backgroundContext = CoreDataStack.shared.newTaskContext()
-
-    /// Represents the main (view) context for CoreData, typically used on the main thread.
     let viewContext = CoreDataStack.shared.persistentContainer.viewContext
+
+    /// Array of Garmin `IQDevice` objects currently tracked.
+    private(set) var devices: [IQDevice] = [] {
+        didSet {
+            persistedDevices = devices.map(GarminDevice.init)
+            registerDevices(devices)
+        }
+    }
 
     // MARK: - Initialization
 
-    /// Creates a new `BaseGarminManager`, injecting required services, restoring any persisted devices,
-    /// and setting up watchers for data changes (e.g., glucose updates).
-    /// - Parameter resolver: Swinject resolver for injecting dependencies like the Router.
     init(resolver: Resolver) {
         router = resolver.resolve(Router.self)!
         super.init()
@@ -196,19 +120,10 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable, @unchecked S
 
         restoreDevices()
 
-        // Add simulated device for Xcode Simulator testing
-        #if targetEnvironment(simulator)
-            if enableSimulatedDevice, devices.isEmpty {
-                addSimulatedGarminDevice()
-            }
-        #endif
-
         subscribeToOpenFromGarminConnect()
-        subscribeToDeterminationThrottle()
+        subscribeToWatchState()
 
         units = settingsManager.settings.units
-
-        previousGarminSettings = settingsManager.settings.garminSettings
 
         broadcaster.register(SettingsObserver.self, observer: self)
 
@@ -218,264 +133,136 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable, @unchecked S
                 .share()
                 .eraseToAnyPublisher()
 
-        // Glucose updates - only send immediately if loop is stale (> 8 minutes)
+        // Glucose updates - start 20s fallback timer
+        // When loop is working: determination arrives within ~5s, cancels timer, sends complete data
+        // When loop is slow/failing: timer fires after 20s, sends glucose with stale loop data
+        // This ensures watch gets fresh glucose even if loop doesn't complete
         glucoseStorage.updatePublisher
             .receive(on: DispatchQueue.global(qos: .background))
             .sink { [weak self] _ in
-                guard let self = self else { return }
-
-                // Skip if no Garmin devices are connected (unless in simulator)
-                #if targetEnvironment(simulator)
-                // Allow processing in simulator even without devices
-                #else
-                    guard !self.devices.isEmpty else { return }
-                #endif
-
-                Task {
-                    do {
-                        // Check loop age
-                        let determinationIds = try await self.determinationStorage.fetchLastDeterminationObjectID(
-                            predicate: NSPredicate.enactedDetermination
-                        )
-
-                        let loopAge = await self.getLoopAge(determinationIds)
-
-                        // Send if loop is stale (> 8 minutes) OR no recent loop data available (>30 min)
-                        if loopAge > 480 || loopAge.isInfinite {
-                            // Skip expensive data preparation if no apps are installed (based on cache)
-                            guard self.areAppsLikelyInstalled() else {
-                                return
-                            }
-
-                            let watchState = try await self.setupGarminWatchState(triggeredBy: "Glucose-Stale-Loop")
-                            let watchStateData = try JSONEncoder().encode(watchState)
-
-                            if loopAge.isInfinite {
-                                self.currentSendTrigger = "Glucose-Stale-Loop (no loop data)"
-                                debug(
-                                    .watchManager,
-                                    "[\\(self.formatTimeForLog())] Garmin: Glucose sent immediately - no loop data available (>30m)"
-                                )
-                            } else {
-                                let loopAgeMinutes = Int(loopAge / 60)
-                                self.currentSendTrigger = "Glucose-Stale-Loop (\\(loopAgeMinutes)m)"
-                                debug(
-                                    .watchManager,
-                                    "[\\(self.formatTimeForLog())] Garmin: Glucose sent immediately - loop age > 8 min (\\(loopAgeMinutes)m)"
-                                )
-                            }
-
-                            self.sendWatchStateDataImmediately(watchStateData)
-                            self.lastImmediateSendTime = Date()
-                        }
-                        // If loop age < 8 min, skip silently - determination trigger will handle it
-                    } catch {
-                        debug(
-                            .watchManager,
-                            "\\(DebuggingIdentifiers.failed) Error checking loop age: \\(error)"
-                        )
-                    }
-                }
+                self?.handleGlucoseUpdate()
             }
             .store(in: &subscriptions)
 
-        // IOB trigger - can be reactivated if needed
-        // Commented out to prevent duplicate updates since IOB changes are captured by determinations
-        /*
-         iobService.iobPublisher
-             .receive(on: DispatchQueue.global(qos: .background))
-             .sink { [weak self] _ in
-                 guard let self = self else { return }
-
-                 // Skip if no Garmin devices are connected (unless in simulator)
-                 #if targetEnvironment(simulator)
-                 // Allow processing in simulator even without devices
-                 #else
-                     guard !self.devices.isEmpty else { return }
-                 #endif
-
-                 Task {
-                     do {
-                         let watchState = try await self.setupGarminWatchState(triggeredBy: "IOB-Update")
-                         let watchStateData = try JSONEncoder().encode(watchState)
-                         self.currentSendTrigger = "IOB-Update"
-                         // Use same throttled pipeline as determinations
-                         self.determinationSubject.send(watchStateData)
-                     } catch {
-                         debug(
-                             .watchManager,
-                             "\(DebuggingIdentifiers.failed) Error updating watch state: \(error)"
-                         )
-                     }
-                 }
-             }
-             .store(in: &subscriptions)
-         */
+        // IOB updates - needed for manual boluses which update IOB independently of loop
+        iobService.iobPublisher
+            .receive(on: DispatchQueue.global(qos: .background))
+            .sink { [weak self] _ in
+                self?.triggerWatchStateUpdate(triggeredBy: "IOB")
+            }
+            .store(in: &subscriptions)
 
         registerHandlers()
     }
 
-    // MARK: - Helper Properties
+    // MARK: - Settings Helpers
 
-    /// Safely gets the current Garmin watchface setting
     private var currentWatchface: GarminWatchface {
-        // Direct access since it's not optional
         settingsManager.settings.garminSettings.watchface
     }
 
-    /// Check if current watchface needs historical glucose data (23 additional readings)
-    /// Only SwissAlpine watchface uses historical data, Trio only needs current reading
-    private var needsHistoricalGlucoseData: Bool {
-        // SwissAlpine watchface uses elements 1-23 for historical graph
-        // Trio watchface only uses element 0 (current reading)
-        currentWatchface == .swissalpine
+    private var currentDatafield: GarminDatafield {
+        settingsManager.settings.garminSettings.datafield
     }
 
-    /// Gets the current Garmin settings struct
-    private var currentGarminSettings: GarminWatchSettings {
-        settingsManager.settings.garminSettings
-    }
-
-    /// Check if watchface data transmission is enabled
     private var isWatchfaceDataEnabled: Bool {
         settingsManager.settings.garminSettings.isWatchfaceDataEnabled
     }
 
+    /// SwissAlpine watchface uses historical glucose data (24 entries)
+    /// Trio watchface only uses current reading
+    private var needsHistoricalGlucoseData: Bool {
+        currentWatchface == .swissalpine
+    }
+
+    /// Returns the display name for an app UUID (watchface or datafield)
+    private func appDisplayName(for uuid: UUID) -> String {
+        if uuid == currentWatchface.watchfaceUUID {
+            return "watchface:\(currentWatchface.displayName)"
+        } else if uuid == currentDatafield.datafieldUUID {
+            return "datafield:\(currentDatafield.displayName)"
+        } else {
+            return uuid.uuidString
+        }
+    }
+
     // MARK: - Internal Setup / Handlers
 
-    /// Sets up handlers for OrefDetermination and GlucoseStored entity changes in CoreData.
-    /// When these change, we re-compute the Garmin watch state and send updates to the watch.
     private func registerHandlers() {
-        // OrefDetermination - debounce at CoreData level to avoid redundant data preparation
-        // Multiple determination saves happen within 1-2 seconds during a loop run
-        // Debouncing here prevents fetching glucose/basals/IOB multiple times for the same loop
+        // OrefDetermination changes - debounce at CoreData level
         coreDataPublisher?
             .filteredByEntityName("OrefDetermination")
-            .debounce(for: .seconds(2), scheduler: DispatchQueue.main) // Wait 2s after last save before expensive work
+            .debounce(for: .seconds(2), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                guard let self = self else { return }
-
-                // Skip if no Garmin devices are connected (unless in simulator)
-                #if targetEnvironment(simulator)
-                // Allow processing in simulator even without devices
-                #else
-                    guard !self.devices.isEmpty else { return }
-                #endif
-
-                // Skip expensive data preparation if no apps are installed (based on cache)
-                guard self.areAppsLikelyInstalled() else {
-                    return
-                }
-
-                Task {
-                    do {
-                        let watchState = try await self.setupGarminWatchState(triggeredBy: "Determination")
-
-                        let watchStateData = try JSONEncoder().encode(watchState)
-                        self.currentSendTrigger = "Determination"
-
-                        // Send to subject for 2s debouncing before Bluetooth transmission
-                        // Hash-based caching in setupGarminWatchState prevents unnecessary work
-                        // No additional blocking needed - debounce handles deduplication
-                        self.determinationSubject.send(watchStateData)
-                    } catch {
-                        debug(
-                            .watchManager,
-                            "\(DebuggingIdentifiers.failed) Failed to update watch state: \(error)"
-                        )
-                    }
-                }
+                self?.triggerWatchStateUpdate(triggeredBy: "Determination")
             }
             .store(in: &subscriptions)
-
-        // Note: Glucose deletion handler removed - new glucose entries were incorrectly
-        // triggering this handler, causing duplicate sends before determination updates.
-        // Deletions are rare and will be handled by the next regular update cycle.
     }
 
-    /// Helper to get loop age in seconds
-    private func getLoopAge(_ determinationIds: [NSManagedObjectID]) async -> TimeInterval {
-        guard !determinationIds.isEmpty else { return .infinity }
+    /// Handles glucose updates with delayed fallback
+    /// Waits up to 20 seconds for determination to arrive before sending glucose-only update
+    /// This ensures we send complete data when loop is working, but still update watch if loop is slow/failing
+    private func handleGlucoseUpdate() {
+        guard !devices.isEmpty else { return }
 
-        do {
-            let determinations: [OrefDetermination] = try await CoreDataStack.shared
-                .getNSManagedObject(with: determinationIds, context: backgroundContext)
+        // Cancel any existing fallback timer
+        pendingGlucoseFallback?.cancel()
 
-            return await backgroundContext.perform {
-                guard let latest = determinations.first,
-                      let timestamp = latest.timestamp
-                else {
-                    return TimeInterval.infinity
+        // Create new fallback task
+        let fallback = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+
+            Task {
+                do {
+                    self
+                        .debugGarmin(
+                            "Garmin: Glucose fallback timer fired (no determination in \(Int(self.glucoseFallbackDelay))s)"
+                        )
+
+                    let watchState = try await self.setupGarminWatchState(triggeredBy: "Glucose (fallback)")
+                    let watchStateData = try JSONEncoder().encode(watchState)
+                    self.watchStateSubject.send(watchStateData)
+                } catch {
+                    debug(.watchManager, "Garmin: Error in glucose fallback: \(error)")
                 }
-
-                return Date().timeIntervalSince(timestamp)
             }
-        } catch {
-            return .infinity
+        }
+
+        pendingGlucoseFallback = fallback
+        timerQueue.asyncAfter(deadline: .now() + glucoseFallbackDelay, execute: fallback)
+
+        debugGarmin("Garmin: Glucose received - waiting \(Int(glucoseFallbackDelay))s for determination")
+    }
+
+    /// Triggers watch state preparation and sends to debounce subject
+    /// If triggered by Determination, cancels pending glucose fallback timer
+    private func triggerWatchStateUpdate(triggeredBy trigger: String) {
+        guard !devices.isEmpty else { return }
+
+        // If determination arrived, cancel the glucose fallback timer
+        // Determination includes both fresh glucose and loop data
+        if trigger == "Determination" {
+            if pendingGlucoseFallback != nil {
+                pendingGlucoseFallback?.cancel()
+                pendingGlucoseFallback = nil
+                debugGarmin("Garmin: Determination arrived - cancelled glucose fallback timer")
+            }
+        }
+
+        Task {
+            do {
+                let watchState = try await setupGarminWatchState(triggeredBy: trigger)
+                let watchStateData = try JSONEncoder().encode(watchState)
+                watchStateSubject.send(watchStateData)
+            } catch {
+                debug(.watchManager, "Garmin: Error preparing watch state (\(trigger)): \(error)")
+            }
         }
     }
 
-    /// Throttle for Status/Settings updates
-    private func sendWatchStateDataWithThrottle(_ data: Data) {
-        // Store the latest data (always keep the newest)
-        pendingThrottledData = data
+    // MARK: - CoreData Fetch Methods
 
-        // If work item is already scheduled, just update data - DON'T reschedule
-        if throttleWorkItem != nil {
-            debug(
-                .watchManager,
-                "[\(formatTimeForLog())] Garmin: throttle timer running, data updated [Trigger: \(currentSendTrigger)]"
-            )
-            return
-        }
-
-        // Create and schedule new work item on dedicated timer queue
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self = self,
-                  let dataToSend = self.pendingThrottledData
-            else {
-                return
-            }
-
-            // Check if immediate send happened while we were waiting
-            // Use throttle duration window to prevent duplicates
-            if let lastImmediate = self.lastImmediateSendTime,
-               Date().timeIntervalSince(lastImmediate) < self.throttleDuration
-            {
-                debugGarmin("[\(self.formatTimeForLog())] Garmin: timer cancelled - recent immediate send")
-                self.throttleWorkItem = nil
-                self.pendingThrottledData = nil
-                self.throttledUpdatePending = false
-                return
-            }
-
-            // Convert data to JSON object for sending
-            guard let jsonObject = try? JSONSerialization.jsonObject(with: dataToSend, options: []) else {
-                debugGarmin("[\(self.formatTimeForLog())] Garmin: Invalid JSON in throttled data")
-                self.throttleWorkItem = nil
-                self.pendingThrottledData = nil
-                self.throttledUpdatePending = false
-                return
-            }
-
-            debugGarmin("[\(self.formatTimeForLog())] Garmin: timer fired - sending collected updates")
-            self.broadcastStateToWatchApps(jsonObject as Any)
-
-            // Clean up
-            self.throttleWorkItem = nil
-            self.pendingThrottledData = nil
-            self.throttledUpdatePending = false
-        }
-
-        throttleWorkItem = workItem
-        timerQueue.asyncAfter(deadline: .now() + throttleDuration, execute: workItem)
-        throttledUpdatePending = true
-        debugGarmin("[\(formatTimeForLog())] Garmin: throttle timer started (\(Int(throttleDuration))s) on dedicated queue")
-    }
-
-    /// Fetches recent glucose readings from CoreData, up to specified limit.
-    /// - Returns: An array of `NSManagedObjectID`s for glucose readings.
-    private func fetchGlucose(limit: Int = 5) async throws -> [NSManagedObjectID] {
+    private func fetchGlucose(limit: Int = 2) async throws -> [NSManagedObjectID] {
         let results = try await CoreDataStack.shared.fetchEntitiesAsync(
             ofType: GlucoseStored.self,
             onContext: backgroundContext,
@@ -493,8 +280,6 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable, @unchecked S
         }
     }
 
-    /// Fetches recent temp basal events from CoreData pump history.
-    /// - Returns: An array of `NSManagedObjectID`s for pump events with temp basals.
     private func fetchTempBasals() async throws -> [NSManagedObjectID] {
         let tempBasalPredicate = NSPredicate(format: "tempBasal != nil")
         let compoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
@@ -507,7 +292,7 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable, @unchecked S
             onContext: backgroundContext,
             predicate: compoundPredicate,
             key: "timestamp",
-            ascending: false, // Most recent first
+            ascending: false,
             fetchLimit: 1
         )
 
@@ -521,808 +306,343 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable, @unchecked S
 
     // MARK: - Watch State Setup
 
-    /// Computes a hash of key data points to detect if watch state preparation would produce identical results.
-    /// This prevents expensive CoreData fetches and calculations when data hasn't actually changed.
-    /// - Returns: Hash value representing current state of glucose, IOB, COB, and basal data
-    private func computeDataHash() async -> Int {
-        var hasher = Hasher()
-
-        do {
-            // Hash latest glucose reading (most critical data point)
-            let glucoseIds = try await fetchGlucose(limit: 1)
-            let glucoseObjects: [GlucoseStored] = try await CoreDataStack.shared
-                .getNSManagedObject(with: glucoseIds, context: backgroundContext)
-
-            if let latestGlucose = glucoseObjects.first {
-                await backgroundContext.perform {
-                    hasher.combine(latestGlucose.glucose)
-                    hasher.combine(latestGlucose.date?.timeIntervalSince1970 ?? 0)
-                    hasher.combine(latestGlucose.direction ?? "")
-                }
-            }
-
-            // Hash IOB (changes frequently with insulin activity)
-            if let iob = iobService.currentIOB {
-                let iobValue = validateIOB(iob)
-                hasher.combine(iobValue)
-            }
-
-            // Hash latest determination data (includes COB, ISF, eventualBG, sensRatio)
-            let determinationIds = try await determinationStorage.fetchLastDeterminationObjectID(
-                predicate: NSPredicate.enactedDetermination
-            )
-            let determinationObjects: [OrefDetermination] = try await CoreDataStack.shared
-                .getNSManagedObject(with: determinationIds, context: backgroundContext)
-
-            if let determination = determinationObjects.first {
-                await backgroundContext.perform {
-                    // Hash COB (rounded to integer)
-                    let cobValue = self.validateCOB(determination.cob)
-                    hasher.combine(Int16(cobValue))
-
-                    // Hash sensRatio with 2 decimal precision
-                    let sensValue = self.validateSensRatio(determination.sensitivityRatio)
-                    hasher.combine(sensValue)
-
-                    // Hash ISF (insulinSensitivity)
-                    if let isf = self.validateISF(determination.insulinSensitivity) {
-                        hasher.combine(isf)
-                    }
-
-                    // Hash eventualBG
-                    if let eventualBG = self.validateEventualBG(determination.eventualBG) {
-                        hasher.combine(eventualBG)
-                    }
-                }
-            }
-
-            // Hash current basal rate (from temp basal or profile)
-            let tempBasalIds = try await fetchTempBasals()
-            let tempBasalObjects: [PumpEventStored] = try await CoreDataStack.shared
-                .getNSManagedObject(with: tempBasalIds, context: backgroundContext)
-
-            if let latestTempBasal = tempBasalObjects.first {
-                await backgroundContext.perform {
-                    if let tempBasalData = latestTempBasal.tempBasal,
-                       let rate = tempBasalData.rate
-                    {
-                        let rateDouble = Double(truncating: rate)
-                        if rateDouble.isFinite, !rateDouble.isNaN {
-                            let rateRounded = rateDouble.roundedDouble(toPlaces: 1)
-                            hasher.combine(rateRounded)
-                        }
-                    }
-                }
-            }
-
-        } catch {
-            debugGarmin("[\(formatTimeForLog())] ⚠️ Error computing data hash: \(error)")
-        }
-
-        return hasher.finalize()
-    }
-
-    /// Builds a GarminWatchState array for both Trio and SwissAlpine watchfaces.
-    /// Uses the SwissAlpine numeric format for all data, sent as an array.
-    /// Both watchfaces receive the same data structure with display configuration fields.
-    /// - Parameter triggeredBy: Source of the trigger (for logging/debugging purposes)
-    /// - Returns: Array of GarminWatchState objects ready to be sent to watch
+    /// Builds GarminWatchState array for watchfaces
     func setupGarminWatchState(triggeredBy: String = #function) async throws -> [GarminWatchState] {
-        // Skip expensive calculations if no Garmin devices are connected (except in simulator)
+        // Skip if no devices (unless in simulator with simulated device enabled)
         #if targetEnvironment(simulator)
-            let skipDeviceCheck = true
+            let skipDeviceCheck = enableSimulatedDevice
         #else
             let skipDeviceCheck = false
         #endif
 
         guard !devices.isEmpty || skipDeviceCheck else {
-            debug(.watchManager, "⌚️⛔ Skipping setupGarminWatchState - No Garmin devices connected")
             return []
         }
 
-        // Compute hash of current data to detect if preparation would produce identical results
-        let currentHash = await computeDataHash()
-
-        // Check if data is unchanged
-        hashLock.lock()
-        let hashMatches = (currentHash == lastPreparedDataHash)
-        let hasCachedState = (lastPreparedWatchState != nil)
-        hashLock.unlock()
-
-        if hashMatches, hasCachedState {
-            if debugWatchState {
-                debugGarmin(
-                    "[\(formatTimeForLog())] ⏭️ Skipping preparation - data unchanged (hash: \(currentHash)) [Triggered by: \(triggeredBy)]"
-                )
-            }
-            return lastPreparedWatchState!
-        }
-
         if debugWatchState {
-            debugGarmin("[\(formatTimeForLog())] ⌚️ Preparing data (hash: \(currentHash)) [Triggered by: \(triggeredBy)]")
+            debug(.watchManager, "Garmin: Preparing watch state [Trigger: \(triggeredBy)]")
         }
 
-        do {
-            // Optimize glucose fetch based on watchface needs
-            // SwissAlpine: Fetch 24 entries for historical graph (elements 0-23)
-            // Trio: Fetch 2 entries minimum (to calculate delta), but only send 1 to watchface
-            // We need at least 2 readings to calculate delta (current - previous)
-            let glucoseLimit = needsHistoricalGlucoseData ? 24 : 2
-            let glucoseIds = try await fetchGlucose(limit: glucoseLimit)
+        // Fetch glucose - SwissAlpine needs 24, Trio needs 2 (for delta calculation)
+        let glucoseLimit = needsHistoricalGlucoseData ? 24 : 2
+        let glucoseIds = try await fetchGlucose(limit: glucoseLimit)
 
-            if debugWatchState {
-                debug(
-                    .watchManager,
-                    "⌚️ Fetching \(glucoseLimit) glucose reading(s) for \(currentWatchface.displayName) watchface (need 2+ for delta)"
-                )
+        let determinationIds = try await determinationStorage.fetchLastDeterminationObjectID(
+            predicate: NSPredicate.enactedDetermination
+        )
+
+        let tempBasalIds = try await fetchTempBasals()
+
+        let glucoseObjects: [GlucoseStored] = try await CoreDataStack.shared
+            .getNSManagedObject(with: glucoseIds, context: backgroundContext)
+        let determinationObjects: [OrefDetermination] = try await CoreDataStack.shared
+            .getNSManagedObject(with: determinationIds, context: backgroundContext)
+        let tempBasalObjects: [PumpEventStored] = try await CoreDataStack.shared
+            .getNSManagedObject(with: tempBasalIds, context: backgroundContext)
+
+        return await backgroundContext.perform {
+            var watchStates: [GarminWatchState] = []
+
+            let unitsHint = self.units == .mgdL ? "mgdl" : "mmol"
+
+            // IOB with 1 decimal precision
+            let iobValue = self.formatIOB(self.iobService.currentIOB ?? Decimal(0))
+
+            // Extract determination data
+            var cobValue: Double?
+            var sensRatioValue: Double?
+            var isfValue: Int16?
+            var eventualBGValue: Int16?
+            var determinationTimestamp: Date?
+
+            if let latestDetermination = determinationObjects.first {
+                determinationTimestamp = latestDetermination.timestamp
+                cobValue = Double(latestDetermination.cob)
+
+                if let ratio = latestDetermination.sensitivityRatio {
+                    sensRatioValue = Double(truncating: ratio)
+                }
+
+                if let isf = latestDetermination.insulinSensitivity {
+                    isfValue = Int16(truncating: isf)
+                }
+
+                if let eventualBG = latestDetermination.eventualBG {
+                    eventualBGValue = Int16(truncating: eventualBG)
+                }
             }
 
-            // Fetch the latest OrefDetermination object if available
-            let determinationIds = try await determinationStorage.fetchLastDeterminationObjectID(
-                predicate: NSPredicate.enactedDetermination
-            )
-
-            // Fetch temp basal from pump history
-            let tempBasalIds = try await fetchTempBasals()
-
-            // Turn those IDs into live NSManagedObjects
-            let glucoseObjects: [GlucoseStored] = try await CoreDataStack.shared
-                .getNSManagedObject(with: glucoseIds, context: backgroundContext)
-            let determinationObjects: [OrefDetermination] = try await CoreDataStack.shared
-                .getNSManagedObject(with: determinationIds, context: backgroundContext)
-            let tempBasalObjects: [PumpEventStored] = try await CoreDataStack.shared
-                .getNSManagedObject(with: tempBasalIds, context: backgroundContext)
-
-            // Perform logic on the background context
-            return await backgroundContext.perform {
-                var watchStates: [GarminWatchState] = []
-
-                // Get units hint - always send "mgdl" since we're always transmitting mg/dL
-                let unitsHint = self.units == .mgdL ? "mgdl" : "mmol"
-
-                // Calculate IOB with 1 decimal precision using helper function
-                let iobValue = self.validateIOB(self.iobService.currentIOB ?? Decimal(0))
-
-                // Calculate COB, sensRatio, ISF, eventualBG, TBR from determination
-                var cobValue: Double?
-                var sensRatioValue: Double?
-                var isfValue: Int16?
-                var eventualBGValue: Int16?
-                var tbrValue: Double?
-
-                if let latestDetermination = determinationObjects.first {
-                    // Safe COB conversion using helper
-                    cobValue = self.validateCOB(latestDetermination.cob)
-                    if cobValue == 0, self.debugWatchState {
-                        debug(.watchManager, "⌚️ COB is invalid or 0")
-                    }
-
-                    // Calculate sensRatio using helper (returns 1.0 if invalid)
-                    sensRatioValue = self.validateSensRatio(latestDetermination.sensitivityRatio)
-                    if sensRatioValue == 1.0, latestDetermination.sensitivityRatio == nil, self.debugWatchState {
-                        debug(.watchManager, "⌚️ SensRatio is nil, using default 1.0")
-                    }
-
-                    // ISF validation using helper - stored as Int16 in CoreData (mg/dL values)
-                    isfValue = self.validateISF(latestDetermination.insulinSensitivity)
-                    if isfValue == nil, self.debugWatchState {
-                        debug(.watchManager, "⌚️ ISF out of range or invalid, excluding from data")
-                    }
-
-                    // EventualBG validation using helper
-                    eventualBGValue = self.validateEventualBG(latestDetermination.eventualBG)
-                    if eventualBGValue == nil, self.debugWatchState {
-                        debug(.watchManager, "⌚️ EventualBG out of range or invalid, excluding from data")
-                    }
-                }
-
-                // Get current basal rate directly from temp basal
-                if let firstTempBasal = tempBasalObjects.first, // Most recent temp basal
-                   let tempBasalData = firstTempBasal.tempBasal,
-                   let tempRate = tempBasalData.rate
-                {
-                    // Send raw value without rounding, with NaN/Infinity guard
-                    let tbrDouble = Double(truncating: tempRate)
-                    if tbrDouble.isFinite, !tbrDouble.isNaN {
-                        tbrValue = tbrDouble
-                        if self.debugWatchState {
-                            debug(.watchManager, "⌚️ Current basal rate: \(tbrValue!) U/hr from temp basal")
-                        }
-                    } else {
-                        tbrValue = nil
-                        if self.debugWatchState {
-                            debug(.watchManager, "⌚️ TBR is NaN or infinite, excluding from data")
-                        }
-                    }
-                } else {
-                    // If no temp basal, get scheduled basal from profile
-                    let basalProfile = self.settingsManager.preferences.basalProfile as? [BasalProfileEntry] ?? []
-                    if !basalProfile.isEmpty {
-                        let now = Date()
-                        let calendar = Calendar.current
-                        let currentTimeMinutes = calendar.component(.hour, from: now) * 60 + calendar
-                            .component(.minute, from: now)
-
-                        // Find the current basal rate from profile
-                        var currentBasalRate: Double = 0
-                        for entry in basalProfile.reversed() {
-                            if entry.minutes <= currentTimeMinutes {
-                                let rateDouble = Double(entry.rate)
-                                if rateDouble.isFinite, !rateDouble.isNaN {
-                                    currentBasalRate = rateDouble
-                                }
-                                break
-                            }
-                        }
-
-                        if currentBasalRate > 0 {
-                            // Send raw value without rounding
-                            tbrValue = currentBasalRate
-
-                            if self.debugWatchState {
-                                debug(.watchManager, "⌚️ Current scheduled basal rate: \(tbrValue!) U/hr from profile")
-                            }
-                        }
-                    }
-                }
-
-                // Get display configuration from settings
-                let displayPrimaryAttributeChoice = self.settingsManager.settings.garminSettings.primaryAttributeChoice.rawValue
-                let displaySecondaryAttributeChoice = self.settingsManager.settings.garminSettings.secondaryAttributeChoice
-                    .rawValue
-
-                // Process glucose readings
-                // For Trio: Process 2 readings (to calculate delta) but only send 1 entry
-                // For SwissAlpine: Process and send all 24 entries
-
-                // Calculate most recent timestamp once (outside loop)
-                let mostRecentTimestamp: UInt64? = {
-                    if let latestDetermination = determinationObjects.first,
-                       let loopTimestamp = latestDetermination.timestamp
-                    {
-                        return UInt64(loopTimestamp.timeIntervalSince1970 * 1000)
-                    }
-                    return nil
-                }()
-
-                // Process glucose readings
-                // All watchfaces expect array structure, but only SwissAlpine uses elements 1-23
-                let entriesToSend = self.needsHistoricalGlucoseData ? glucoseObjects.count : 1
-
-                for (index, glucose) in glucoseObjects.enumerated() {
-                    guard index < entriesToSend else { break }
-
-                    // Validate glucose value early
-                    let glucoseValue = glucose.glucose
-                    guard glucoseValue >= 0, glucoseValue <= 500 else {
-                        if self.debugWatchState {
-                            debug(.watchManager, "⌚️ Invalid glucose value (\(glucoseValue)), skipping")
-                        }
-                        continue
-                    }
-
-                    var watchState = GarminWatchState()
-
-                    // Set timestamp
-                    if index == 0 {
-                        watchState.date = mostRecentTimestamp ?? glucose.date.map { UInt64($0.timeIntervalSince1970 * 1000) }
-                    } else {
-                        watchState.date = glucose.date.map { UInt64($0.timeIntervalSince1970 * 1000) }
-                    }
-
-                    watchState.sgv = glucoseValue
-
-                    // Only add delta/direction for first entry
-                    if index == 0 {
-                        watchState.direction = glucose.direction ?? "--"
-
-                        if glucoseObjects.count > 1 {
-                            let deltaValue = glucose.glucose - glucoseObjects[1].glucose
-                            watchState.delta = (deltaValue >= -100 && deltaValue <= 100) ? deltaValue : nil
-                        } else {
-                            watchState.delta = 0
-                        }
-
-                        // Add extended data
-                        watchState.units_hint = unitsHint
-                        watchState.iob = iobValue
-                        watchState.cob = cobValue
-                        watchState.tbr = tbrValue
-                        watchState.isf = isfValue
-                        watchState.eventualBG = eventualBGValue
-                        watchState.sensRatio = sensRatioValue
-                        watchState.displayPrimaryAttributeChoice = displayPrimaryAttributeChoice
-                        watchState.displaySecondaryAttributeChoice = displaySecondaryAttributeChoice
-                    }
-
-                    watchStates.append(watchState)
-                }
-
-                // Log the watch states if debugging is enabled
-                if self.debugWatchState {
-                    self.logWatchState(watchStates)
-                }
-
-                // Cache the hash and prepared state for deduplication
-                self.hashLock.lock()
-                self.lastPreparedDataHash = currentHash
-                self.lastPreparedWatchState = watchStates
-                self.hashLock.unlock()
-
-                return watchStates
-            }
-        } catch {
-            debug(
-                .watchManager,
-                "\(DebuggingIdentifiers.failed) Error setting up unified Garmin watch state: \(error)"
-            )
-            throw error
-        }
-    }
-
-    // MARK: - Debug Logging Method for Watch State
-
-    private func logWatchState(_ watchState: [GarminWatchState]) {
-        guard debugWatchState else { return }
-
-        let watchface = currentWatchface
-        let datafield = currentGarminSettings.datafield
-        let watchfaceUUID = watchface.watchfaceUUID?.uuidString ?? "Unknown"
-        let datafieldUUID = datafield.datafieldUUID?.uuidString ?? "Unknown"
-
-        do {
-            let jsonData = try JSONEncoder().encode(watchState)
-            if let jsonString = String(data: jsonData, encoding: .utf8) {
-                let compactJson = jsonString.replacingOccurrences(of: "\n", with: "")
-                    .replacingOccurrences(of: "  ", with: " ")
-
-                // Show which apps will actually receive data
-                let destinations: String
-                if !isWatchfaceDataEnabled {
-                    destinations = "datafield \(datafieldUUID) only (watchface disabled)"
-                } else {
-                    destinations = "watchface \(watchfaceUUID) / datafield \(datafieldUUID)"
-                }
-
-                debug(
-                    .watchManager,
-                    "📱 (\(watchface.displayName)): Prepared \(watchState.count) entries for \(destinations): \(compactJson)"
-                )
-            }
-        } catch {
-            debug(.watchManager, "📱 Prepared \(watchState.count) entries (failed to encode for logging)")
-        }
-    }
-
-    // MARK: - Helper Methods
-
-    /// Formats a Date to HH:mm:ss string for logging
-    private func formatTimeForLog(_ date: Date = Date()) -> String {
-        Formatter.timeForLogFormatter.string(from: date)
-    }
-
-    // MARK: - Simulated Device (for Xcode Simulator Testing)
-
-    #if targetEnvironment(simulator)
-        /// Creates a simulated Garmin device for testing in Xcode Simulator
-        /// This allows testing the full workflow without a real Garmin watch
-        private func addSimulatedGarminDevice() {
-            guard enableSimulatedDevice else { return }
-
-            // Create a mock IQDevice for simulator testing
-            // Using a fixed UUID so it persists across app launches
-            let simulatedUUID = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
-
-            // Note: IQDevice initializer may vary - adjust as needed
-            // This is a placeholder that may need adjustment based on actual IQDevice API
-            if let simulatedDevice = createMockIQDevice(
-                uuid: simulatedUUID,
-                friendlyName: "Simulated Garmin Watch",
-                modelName: "Enduro 3 (Simulator)"
-            ) {
-                devices = [simulatedDevice]
-                debugGarmin("📱 Simulator: Added simulated Garmin device for testing")
-                debugGarmin("📱 Simulator: Device UUID: \(simulatedUUID)")
-                debugGarmin("📱 Simulator: Use this to test determination/IOB throttling, settings changes, etc.")
+            // TBR from temp basal or profile
+            var tbrValue: Double?
+            if let firstTempBasal = tempBasalObjects.first,
+               let tempBasalData = firstTempBasal.tempBasal,
+               let tempRate = tempBasalData.rate
+            {
+                tbrValue = Double(truncating: tempRate)
             } else {
-                debugGarmin("⚠️ Simulator: Could not create simulated device (IQDevice API may have changed)")
+                // Fall back to scheduled basal from profile
+                let basalProfile = self.settingsManager.preferences.basalProfile as? [BasalProfileEntry] ?? []
+                if !basalProfile.isEmpty {
+                    let now = Date()
+                    let calendar = Calendar.current
+                    let currentTimeMinutes = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
+
+                    for entry in basalProfile.reversed() {
+                        if entry.minutes <= currentTimeMinutes {
+                            tbrValue = Double(entry.rate)
+                            break
+                        }
+                    }
+                }
             }
+
+            // Display configuration from settings
+            let displayPrimaryChoice = self.settingsManager.settings.garminSettings.primaryAttributeChoice.rawValue
+            let displaySecondaryChoice = self.settingsManager.settings.garminSettings.secondaryAttributeChoice.rawValue
+
+            // Process glucose readings
+            let entriesToSend = self.needsHistoricalGlucoseData ? glucoseObjects.count : 1
+
+            for (index, glucose) in glucoseObjects.enumerated() {
+                guard index < entriesToSend else { break }
+
+                let glucoseValue = glucose.glucose
+
+                var watchState = GarminWatchState()
+
+                // Timestamp: Use determination timestamp to indicate loop staleness
+                // If loop hasn't run recently, the old determination timestamp shows data is stale
+                // Fall back to glucose timestamp only if no determination exists
+                if index == 0 {
+                    let timestamp = determinationTimestamp ?? glucose.date
+                    watchState.date = timestamp.map { UInt64($0.timeIntervalSince1970 * 1000) }
+                } else {
+                    watchState.date = glucose.date.map { UInt64($0.timeIntervalSince1970 * 1000) }
+                }
+
+                watchState.sgv = glucoseValue
+
+                // Only add extended data for first entry
+                if index == 0 {
+                    watchState.direction = glucose.direction ?? "--"
+
+                    // Delta calculation
+                    if glucoseObjects.count > 1 {
+                        watchState.delta = glucose.glucose - glucoseObjects[1].glucose
+                    } else {
+                        watchState.delta = 0
+                    }
+
+                    watchState.units_hint = unitsHint
+                    watchState.iob = iobValue
+                    watchState.cob = cobValue
+                    watchState.tbr = tbrValue
+                    watchState.isf = isfValue
+                    watchState.eventualBG = eventualBGValue
+                    watchState.sensRatio = sensRatioValue
+                    watchState.displayPrimaryAttributeChoice = displayPrimaryChoice
+                    watchState.displaySecondaryAttributeChoice = displaySecondaryChoice
+                }
+
+                watchStates.append(watchState)
+            }
+
+            // Deduplicate: Check if data is unchanged from last preparation
+            let currentHash = watchStates.hashValue
+            if currentHash == self.lastPreparedDataHash {
+                if self.debugWatchState {
+                    debug(.watchManager, "Garmin: Skipping - data unchanged (hash: \(currentHash))")
+                }
+                return self.lastPreparedWatchState ?? watchStates
+            }
+
+            if self.debugWatchState {
+                debug(
+                    .watchManager,
+                    "Garmin: Prepared \(watchStates.count) entries - sgv: \(watchStates.first?.sgv ?? 0), iob: \(watchStates.first?.iob ?? 0), cob: \(watchStates.first?.cob ?? 0), tbr: \(watchStates.first?.tbr ?? 0), eventualBG: \(watchStates.first?.eventualBG ?? 0), sensRatio: \(watchStates.first?.sensRatio ?? 0)"
+                )
+            }
+
+            // Cache for deduplication
+            self.lastPreparedDataHash = currentHash
+            self.lastPreparedWatchState = watchStates
+
+            return watchStates
         }
+    }
 
-        /// Helper to create a mock IQDevice - implementation depends on IQDevice's actual initializers
-        private func createMockIQDevice(uuid _: UUID, friendlyName _: String, modelName _: String) -> IQDevice? {
-            // Note: This is a placeholder - the actual IQDevice creation may require
-            // different parameters or may not be possible to mock directly.
-            // You may need to adjust this based on ConnectIQ SDK documentation.
-
-            // If IQDevice can't be created directly, you might need to:
-            // 1. Use a real device connection once and persist it
-            // 2. Or modify IQDevice to support test initialization
-            // 3. Or create a protocol and use dependency injection
-
-            // For now, returning nil as IQDevice likely requires Garmin SDK initialization
-            // Users should connect a real device once, then it will be persisted
-            nil
+    /// Formats IOB with 1 decimal precision
+    private func formatIOB(_ value: Decimal) -> Double {
+        let doubleValue = NSDecimalNumber(decimal: value).doubleValue
+        if doubleValue.magnitude < 0.1, doubleValue != 0 {
+            return doubleValue > 0 ? 0.1 : -0.1
         }
-    #endif
+        return (doubleValue * 10).rounded() / 10
+    }
 
     // MARK: - Device & App Registration
 
-    /// Registers the given devices for ConnectIQ events (device status changes) and watch app messages.
-    /// It also creates and registers watch apps (watchface + data field) for each device.
-    /// - Parameter devices: The devices to register.
     private func registerDevices(_ devices: [IQDevice]) {
-        // Clear out old references
         watchApps.removeAll()
 
-        // Clear app installation cache since we're re-registering
-        appStatusCacheLock.lock()
-        appInstallationCache.removeAll()
-        appStatusCacheLock.unlock()
-        debugGarmin("Garmin: Cleared app installation cache on device registration")
-
         for device in devices {
-            // Listen for device-level status changes
             connectIQ?.register(forDeviceEvents: device, delegate: self)
 
-            // Get current watchface setting
-            let watchface = currentWatchface
-
-            // Get current datafield setting
-            let datafield = currentGarminSettings.datafield
-
-            // Create a watchface app using the UUID from the enum
-            // Only register watchface if data is enabled
-            if isWatchfaceDataEnabled {
-                if let watchfaceUUID = watchface.watchfaceUUID,
-                   let watchfaceApp = IQApp(uuid: watchfaceUUID, store: UUID(), device: device)
-                {
-                    debug(
-                        .watchManager,
-                        "Garmin: Registering \(watchface.displayName) watchface (UUID: \(watchfaceUUID)) for device \(device.friendlyName ?? "Unknown")"
-                    )
-
-                    // Track watchface app
-                    watchApps.append(watchfaceApp)
-
-                    // Register to receive app-messages from the watchface
-                    connectIQ?.register(forAppMessages: watchfaceApp, delegate: self)
-                } else {
-                    debug(
-                        .watchManager,
-                        "Garmin: Could not create \(watchface.displayName) watchface app for device \(device.uuid!)"
-                    )
-                }
-            } else {
-                debugGarmin("Garmin: Skipping watchface registration - data disabled")
+            // Register watchface if enabled
+            if isWatchfaceDataEnabled,
+               let watchfaceUUID = currentWatchface.watchfaceUUID,
+               let watchfaceApp = IQApp(uuid: watchfaceUUID, store: UUID(), device: device)
+            {
+                debugGarmin("Garmin: Registered watchface:\(currentWatchface.displayName)")
+                watchApps.append(watchfaceApp)
+                connectIQ?.register(forAppMessages: watchfaceApp, delegate: self)
+            } else if !isWatchfaceDataEnabled {
+                debugGarmin("Garmin: Watchface data disabled - skipping watchface registration")
             }
 
-            // ALWAYS create and register data field app (not affected by disable setting)
-            if let datafieldUUID = datafield.datafieldUUID,
-               let watchDataFieldApp = IQApp(uuid: datafieldUUID, store: UUID(), device: device)
+            // Always register datafield (if configured)
+            if let datafieldUUID = currentDatafield.datafieldUUID,
+               let datafieldApp = IQApp(uuid: datafieldUUID, store: UUID(), device: device)
             {
-                debug(
-                    .watchManager,
-                    "Garmin: Registering \(datafield.displayName) datafield (UUID: \(datafieldUUID)) for device \(device.friendlyName ?? "Unknown")"
-                )
-
-                // Track datafield app
-                watchApps.append(watchDataFieldApp)
-
-                // Register to receive app-messages from the datafield
-                connectIQ?.register(forAppMessages: watchDataFieldApp, delegate: self)
-            } else {
-                debugGarmin("Garmin: Could not create datafield app for device \(device.uuid!)")
+                debugGarmin("Garmin: Registered datafield:\(currentDatafield.displayName)")
+                watchApps.append(datafieldApp)
+                connectIQ?.register(forAppMessages: datafieldApp, delegate: self)
             }
         }
     }
 
-    /// Restores previously persisted devices from local storage into `devices`.
     private func restoreDevices() {
         devices = persistedDevices.map(\.iqDevice)
     }
 
+    // MARK: - Simulator Support
+
+    #if targetEnvironment(simulator)
+        /// Mock IQDevice class for simulator testing
+        /// Minimal implementation just for testing - no actual Garmin functionality
+        class MockIQDevice: IQDevice {
+            private let _uuid: UUID
+            private let _friendlyName: String
+            private let _modelName: String
+
+            override var uuid: UUID { _uuid }
+            override var friendlyName: String { _friendlyName }
+            override var modelName: String { _modelName }
+            var status: IQDeviceStatus { .connected }
+
+            init(uuid: UUID, friendlyName: String, modelName: String) {
+                _uuid = uuid
+                _friendlyName = friendlyName
+                _modelName = modelName
+                super.init()
+            }
+
+            @available(*, unavailable) required init?(coder _: NSCoder) {
+                fatalError("init(coder:) not implemented for mock device")
+            }
+
+            /// Shared simulated device UUID for consistency across the app
+            static let simulatedUUID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
+            /// Creates the standard simulated Enduro 3 device
+            static func createSimulated() -> MockIQDevice {
+                MockIQDevice(
+                    uuid: simulatedUUID,
+                    friendlyName: "Enduro 3 Sim",
+                    modelName: "Enduro 3"
+                )
+            }
+        }
+    #endif
+
     // MARK: - Combine Subscriptions
 
-    /// Subscribes to the `.openFromGarminConnect` notification, parsing devices from the given URL
-    /// and updating the device list accordingly.
     private func subscribeToOpenFromGarminConnect() {
         notificationCenter
             .publisher(for: .openFromGarminConnect)
             .sink { [weak self] notification in
-                guard
-                    let self = self,
-                    let url = notification.object as? URL
-                else { return }
-
+                guard let self = self, let url = notification.object as? URL else { return }
                 self.parseDevices(for: url)
             }
             .store(in: &cancellables)
     }
 
-    /// Subscribes to determination updates with 2s debounce (waits for quiet period, then sends latest)
-    /// Also handles IOB updates since they fire simultaneously with determinations
-    /// Two-stage debouncing: 2s at CoreData level (skip redundant prep) + 2s here (skip redundant sends)
-    /// Total delay: ~4s from first CoreData save to Bluetooth transmission (faster than old 10s throttle)
-    private func subscribeToDeterminationThrottle() {
-        determinationSubject
-            .debounce(for: .seconds(2), scheduler: timerQueue)
+    /// Subscribes to watch state updates with debouncing
+    private func subscribeToWatchState() {
+        watchStateSubject
+            .debounce(for: .seconds(2), scheduler: DispatchQueue.main)
             .sink { [weak self] data in
-                guard let self = self else { return }
-
-                // Only cache if no recent watchface change (within last 6 seconds)
-                // This prevents caching stale format data that was in the debounce pipeline
-                let shouldCache: Bool
-                if let lastChange = self.lastWatchfaceChangeTime {
-                    let timeSinceChange = Date().timeIntervalSince(lastChange)
-                    shouldCache = timeSinceChange > 6 // 2s CoreData + 2s send debounce + 2s buffer
-                    if !shouldCache {
-                        debugGarmin(
-                            "[\(self.formatTimeForLog())] Garmin: Not caching - data may be from before watchface change (\(Int(timeSinceChange))s ago)"
-                        )
-                    }
-                } else {
-                    shouldCache = true // No recent watchface change
-                }
-
-                if shouldCache {
-                    self.cachedDeterminationData = data
-                }
-
-                self.lastImmediateSendTime = Date() // Mark for any pending throttled timers (status requests, settings)
-
-                // Cancel any pending throttled send since determination is sending immediately
-                self.throttleWorkItem?.cancel()
-                self.throttleWorkItem = nil
-                self.pendingThrottledData = nil
-                self.throttledUpdatePending = false
-
-                // Convert data to JSON object for sending
-                guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) else {
-                    debugGarmin("[\(self.formatTimeForLog())] Garmin: Invalid JSON in determination data")
-                    return
-                }
-
-                debugGarmin("[\(self.formatTimeForLog())] Garmin: Sending determination/IOB (2s debounce passed)")
-                self.broadcastStateToWatchApps(jsonObject as Any)
+                self?.broadcastWatchStateData(data)
             }
             .store(in: &cancellables)
     }
 
     // MARK: - Parsing & Broadcasting
 
-    /// Parses devices from a Garmin Connect URL and updates our `devices` property.
-    /// - Parameter url: The URL provided by Garmin Connect containing device selection info.
     private func parseDevices(for url: URL) {
         let parsed = connectIQ?.parseDeviceSelectionResponse(from: url) as? [IQDevice]
         devices = parsed ?? []
-
-        // Fulfill any pending promise in case this is in response to `selectDevices()`.
         deviceSelectionPromise?(.success(devices))
         deviceSelectionPromise = nil
     }
 
-    /// Broadcasts state to watch apps
-    /// Always sends to datafield (if exists), only checks status for watchface
-    /// - Parameter state: The dictionary representing the watch state to be broadcast.
-    private func broadcastStateToWatchApps(_ state: Any) {
-        // Deduplicate: Check if we're sending identical data by hashing the JSON content
+    /// Broadcasts watch state data to all registered apps
+    private func broadcastWatchStateData(_ data: Data) {
+        // Deduplicate: Use stable content-based hash (sorted JSON bytes)
         let currentHash: Int
-        if let jsonData = try? JSONSerialization.data(withJSONObject: state, options: [.sortedKeys]) {
-            currentHash = jsonData.hashValue
+        if let sortedData = try? JSONSerialization.data(
+            withJSONObject: JSONSerialization.jsonObject(with: data, options: []),
+            options: [.sortedKeys]
+        ) {
+            currentHash = sortedData.base64EncodedString().hashValue
         } else {
-            currentHash = 0 // Fallback if serialization fails
+            currentHash = data.count // Fallback
         }
 
-        lastSentHashLock.lock()
-        let isDuplicate = (lastSentDataHash == currentHash)
-        lastSentHashLock.unlock()
-
-        if isDuplicate {
-            debugGarmin("[\(formatTimeForLog())] Garmin: Skipping duplicate broadcast (hash: \(currentHash))")
+        if currentHash == lastSentDataHash {
+            debugGarmin("Garmin: Skipping broadcast - data unchanged")
             return
         }
 
-        // Store hash - will be marked as "sent" only after successful transmission
-        let hashToSend = currentHash
-
-        // Update display types in the state before sending (handles cached/throttled data)
-        let updatedState = updateDisplayTypesInState(state)
-
-        // Log connection health status if we have failures
-        if failedSendCount > 0 {
-            let timeString: String
-            if let lastSuccess = lastSuccessfulSendTime {
-                let timeSince = Date().timeIntervalSince(lastSuccess)
-                timeString = "\(Int(timeSince))s"
-            } else {
-                timeString = "never"
-            }
-            debug(
-                .watchManager,
-                "[\(formatTimeForLog())] Garmin: Broadcasting with \(failedSendCount) recent failures. Last success: \(timeString) ago"
-            )
+        guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) else {
+            debug(.watchManager, "Garmin: Invalid JSON for watch-state data")
+            return
         }
 
-        let watchface = currentWatchface
-        let datafield = currentGarminSettings.datafield
+        // In simulator, just log what would be sent (no actual ConnectIQ)
+        #if targetEnvironment(simulator)
+            if enableSimulatedDevice {
+                debug(.watchManager, "Garmin: [SIMULATOR] Would send data: \(jsonObject)")
+                lastSentDataHash = currentHash
+                return
+            }
+        #endif
 
         watchApps.forEach { app in
-            let isWatchfaceApp = app.uuid == watchface.watchfaceUUID
-            let isDatafieldApp = app.uuid == datafield.datafieldUUID
-
-            // 1. If it's a datafield, ALWAYS send (no status check)
-            if isDatafieldApp {
-                debug(.watchManager, "[\(formatTimeForLog())] Garmin: Sending to datafield \(app.uuid!) (no status check)")
-                // Store hash to mark as sent on successful send
-                currentSendHash = hashToSend
-                sendMessage(updatedState, to: app)
-                return
-            }
-
-            // 2. If it's a watchface and data is disabled, skip
-            if isWatchfaceApp, !isWatchfaceDataEnabled {
-                debugGarmin("[\(formatTimeForLog())] Garmin: Watchface data disabled, skipping")
-                return
-            }
-
-            // 3. For watchface with data enabled, do normal status check
-            // Replace lines 1179-1199 in your GarminManager.swift with this:
-
-            // 3. For watchface with data enabled, check cache first then send
-            let appUUID = app.uuid!.uuidString
-
-            // Check cache first
-            appStatusCacheLock.lock()
-            let cachedStatus = appInstallationCache[appUUID]
-            appStatusCacheLock.unlock()
-
-            // If we have fresh cache data (< 60s old), use it
-            if let cached = cachedStatus, Date().timeIntervalSince(cached.lastChecked) < appStatusCacheTimeout {
-                if cached.status.shouldSendData {
-                    debug(
-                        .watchManager,
-                        "[\(formatTimeForLog())] Garmin: Sending to watchface \(app.uuid!) (cached: \(cached.status))"
-                    )
-                    currentSendHash = hashToSend
-                    sendMessage(updatedState, to: app)
-                } else {
-                    debugGarmin(
-                        "[\(formatTimeForLog())] Garmin: Skipping watchface \(app.uuid!) (cached: not installed)"
-                    )
+            let appName = self.appDisplayName(for: app.uuid!)
+            connectIQ?.getAppStatus(app) { [weak self] status in
+                guard status?.isInstalled == true else {
+                    debug(.watchManager, "Garmin: App not installed: \(appName)")
+                    return
                 }
-            } else {
-                // Cache miss or stale - send optimistically and update cache in background
-                debug(
-                    .watchManager,
-                    "[\(formatTimeForLog())] Garmin: Sending to watchface \(app.uuid!) (optimistic - checking status async)"
-                )
-                currentSendHash = hashToSend
-                sendMessage(updatedState, to: app)
-
-                // Update cache in background with connection awareness
-                connectIQ?.getAppStatus(app) { [weak self] status in
-                    guard let self = self else { return }
-                    self.updateAppStatusCache(app: app, isInstalled: status?.isInstalled == true)
-                }
+                self?.debugGarmin("Garmin: Sending to \(appName)")
+                self?.sendMessage(jsonObject as Any, to: app, appName: appName)
             }
         }
-    }
 
-    /// Updates display type fields in the state array/object with current settings
-    /// - Parameter state: The state object (either array or dict) to update
-    /// - Returns: Updated state with current displayPrimaryAttributeChoice and displaySecondaryAttributeChoice
-    private func updateDisplayTypesInState(_ state: Any) -> Any {
-        let displayType1 = currentGarminSettings.primaryAttributeChoice.rawValue
-        let displayType2 = currentGarminSettings.secondaryAttributeChoice.rawValue
-
-        // Handle array of states (normal case)
-        if var stateArray = state as? [[String: Any]] {
-            // Only update the first element (index 0) which contains extended data
-            if !stateArray.isEmpty {
-                stateArray[0]["displayPrimaryAttributeChoice"] = displayType1
-                stateArray[0]["displaySecondaryAttributeChoice"] = displayType2
-            }
-            return stateArray
-        }
-
-        // Handle single state dict (shouldn't happen but be safe)
-        if var stateDict = state as? [String: Any] {
-            stateDict["displayPrimaryAttributeChoice"] = displayType1
-            stateDict["displaySecondaryAttributeChoice"] = displayType2
-            return stateDict
-        }
-
-        // Return unchanged if unexpected type
-        return state
-    }
-
-    // MARK: - App Status Cache Management
-
-    /// Updates the installation status cache for a given app UUID
-    /// Updates the installation status cache for a given app with connection awareness
-    private func updateAppStatusCache(app: IQApp, isInstalled: Bool) {
-        guard let appUUID = app.uuid else { return }
-
-        // Check if any device is actually connected using our tracked states
-        let deviceConnected = devices.contains { (device: IQDevice) in
-            if let deviceUUID = device.uuid {
-                let trackedStatus = deviceConnectionStates[deviceUUID]
-                return trackedStatus == .connected
-            }
-            return false
-        }
-
-        appStatusCacheLock.lock()
-        defer { appStatusCacheLock.unlock() }
-
-        let newStatus: AppCacheStatus = {
-            if isInstalled {
-                return .installed
-            } else if deviceConnected {
-                // Device is connected, so "not installed" is likely accurate
-                return .notInstalled
-            } else {
-                // Device not connected - don't trust "not installed" result
-                debugGarmin(
-                    "[\(formatTimeForLog())] Garmin: Skipping cache update for \(appUUID) - device not connected"
-                )
-                return .unknown
-            }
-        }()
-
-        // Only update cache if we have meaningful information
-        if newStatus != .unknown || appInstallationCache[appUUID.uuidString] == nil {
-            appInstallationCache[appUUID.uuidString] = (status: newStatus, lastChecked: Date())
-            debugGarmin(
-                "[\(formatTimeForLog())] Garmin: Updated app cache - \(appUUID) is \(newStatus)"
-            )
-        }
-    }
-
-    /// Returns true if we should prepare and send data
-    /// True if: datafield exists OR (watchface exists AND data is enabled)
-    /// False only if: no apps at all OR (only watchface AND data disabled)
-    private func areAppsLikelyInstalled() -> Bool {
-        let watchface = currentWatchface
-        let datafield = currentGarminSettings.datafield
-
-        // If datafield UUID exists, ALWAYS return true
-        if datafield.datafieldUUID != nil {
-            return true // Datafield exists, always send data
-        }
-
-        // No datafield, check watchface
-        if watchface.watchfaceUUID != nil {
-            // Watchface exists, check if data is enabled
-            if !isWatchfaceDataEnabled {
-                debugGarmin("[\(formatTimeForLog())] Garmin: ⏩ Skipping - only watchface exists and data disabled")
-                return false
-            }
-            return true // Watchface exists and data enabled
-        }
-
-        // No apps configured at all
-        debugGarmin("[\(formatTimeForLog())] Garmin: ⏩ Skipping - no apps configured")
-        return false
+        // Update last sent hash after initiating send
+        lastSentDataHash = currentHash
     }
 
     // MARK: - GarminManager Conformance
 
-    /// Prompts the user to select one or more Garmin devices, returning a publisher that emits
-    /// the final array of selected devices once the user finishes selection.
-    /// - Returns: An `AnyPublisher` emitting `[IQDevice]` on success, or empty array on error/timeout.
     func selectDevices() -> AnyPublisher<[IQDevice], Never> {
         Future { [weak self] promise in
             guard let self = self else {
-                // If self is gone, just resolve with an empty array
                 promise(.success([]))
                 return
             }
-            // Store the promise so we can fulfill it when the user selects devices
             self.deviceSelectionPromise = promise
-
-            // Show Garmin's default device selection UI
             self.connectIQ?.showDeviceSelection()
         }
         .timeout(.seconds(120), scheduler: DispatchQueue.main)
@@ -1330,139 +650,30 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable, @unchecked S
         .eraseToAnyPublisher()
     }
 
-    /// Updates the manager's list of devices, typically after user selection or manual changes.
-    /// - Parameter devices: The new array of `IQDevice` objects to track.
     func updateDeviceList(_ devices: [IQDevice]) {
         self.devices = devices
     }
 
-    /// Converts the given JSON data into an NSDictionary and sends it to all known watch apps.
-    /// Only used for throttled updates (IOB, DataType changes)
-    /// - Parameter data: JSON-encoded data representing the latest watch state.
     func sendWatchStateData(_ data: Data) {
-        sendWatchStateDataWithThrottle(data)
+        watchStateSubject.send(data)
     }
-
-    /// Sends watch state data immediately, bypassing the 30-second throttling
-    /// Used for critical updates like determinations, glucose deletions, and status requests
-    private func sendWatchStateDataImmediately(_ data: Data) {
-        guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) else {
-            debugGarmin("Garmin: Invalid JSON for immediate watch-state data")
-            return
-        }
-
-        if debugWatchState {
-            if let dict = jsonObject as? NSDictionary {
-                debugGarmin("Garmin: Immediately sending watch state dictionary with \(dict.count) fields (no throttle)")
-            } else if let array = jsonObject as? NSArray {
-                debugGarmin("Garmin: Immediately sending watch state array with \(array.count) entries (no throttle)")
-            }
-        }
-
-        // Directly broadcast without going through the throttled subject
-        broadcastStateToWatchApps(jsonObject)
-    }
-
-    // Track current send trigger for debugging (thread-safe)
-    private let triggerLock = OSAllocatedUnfairLock()
-    private var _currentSendTrigger: String = "Unknown"
-
-    private var currentSendTrigger: String {
-        get { triggerLock.withLock { _currentSendTrigger } }
-        set { triggerLock.withLock { _currentSendTrigger = newValue } }
-    }
-
-    // Track hash of data currently being sent (thread-safe)
-    private let sendHashLock = OSAllocatedUnfairLock()
-    private var _currentSendHash: Int?
-
-    private var currentSendHash: Int? {
-        get { sendHashLock.withLock { _currentSendHash } }
-        set { sendHashLock.withLock { _currentSendHash = newValue } }
-    }
-
-    // Track connection health
-    private var lastSuccessfulSendTime: Date?
-    private var failedSendCount = 0
-    private var connectionAlertShown = false
-
-    // Manual throttle for updates - using DispatchWorkItem instead of Timer
-    private var throttleWorkItem: DispatchWorkItem?
-    private var pendingThrottledData: Data?
-
-    // Combine subject for 10s throttled Determinations
-    private let determinationSubject = PassthroughSubject<Data, Never>()
 
     // MARK: - Helper: Sending Messages
 
-    /// Sends a message to a given IQApp with optional progress and completion callbacks.
-    /// - Parameters:
-    ///   - msg: The dictionary to send to the watch app.
-    ///   - app: The `IQApp` instance representing the watchface or data field.
-    private func sendMessage(_ msg: Any, to app: IQApp) {
-        // Check if this is the watchface app
-        let watchface = currentWatchface
-        let isWatchfaceApp = app.uuid == watchface.watchfaceUUID
-
-        // Skip sending if data is disabled AND this is the watchface app
-        if !isWatchfaceDataEnabled, isWatchfaceApp {
-            debugGarmin("[\(formatTimeForLog())] Garmin: Watchface data disabled, not sending message to watchface")
-            return
-        }
-
+    private func sendMessage(_ msg: Any, to app: IQApp, appName: String) {
         connectIQ?.sendMessage(
             msg,
             to: app,
-            progress: { _, _ in
-                // Optionally track progress here
-            },
-            completion: { [weak self] result in
-                guard let self = self else { return }
+            progress: { _, _ in },
+            completion: { result in
                 switch result {
                 case .success:
-                    self.failedSendCount = 0
-                    self.lastSuccessfulSendTime = Date()
-                    self.connectionAlertShown = false // Reset alert flag on success
-
-                    // Mark hash as sent only after successful transmission
-                    if let sentHash = self.currentSendHash {
-                        self.lastSentHashLock.lock()
-                        self.lastSentDataHash = sentHash
-                        self.lastSentHashLock.unlock()
-                    }
-
-                    debug(
-                        .watchManager,
-                        "[\(self.formatTimeForLog())] Garmin: Successfully sent message to \(app.uuid!) [Trigger: \(self.currentSendTrigger)]"
-                    )
+                    debug(.watchManager, "Garmin: Successfully sent to \(appName)")
                 default:
-                    self.failedSendCount += 1
-                    debug(
-                        .watchManager,
-                        "[\(self.formatTimeForLog())] Garmin: FAILED to send to \(app.uuid!) [Trigger: \(self.currentSendTrigger)] (Failure #\(self.failedSendCount))"
-                    )
-
-                    // After 3 consecutive failures, show alert (but only once)
-                    if self.failedSendCount >= 3, !self.connectionAlertShown {
-                        self.showConnectionLostAlert()
-                        self.connectionAlertShown = true
-                    }
+                    debug(.watchManager, "Garmin: FAILED to send to \(appName)")
                 }
             }
         )
-    }
-
-    /// Shows an alert when Garmin connection is lost
-    private func showConnectionLostAlert() {
-        let messageCont = MessageContent(
-            content: "Unable to send data to Garmin device.\n\nPlease check:\n• Bluetooth is enabled\n• Watch is in range\n• Watch is powered on\n• Watchface/Datafield is installed",
-            type: .warning,
-            subtype: .misc,
-            title: "Garmin Connection Lost"
-        )
-        router.alertMessage.send(messageCont)
-
-        debugGarmin("[\(formatTimeForLog())] Garmin: Connection lost alert shown to user")
     }
 }
 
@@ -1471,8 +682,6 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable, @unchecked S
 extension BaseGarminManager: IQUIOverrideDelegate, IQDeviceEventDelegate, IQAppMessageDelegate {
     // MARK: - IQUIOverrideDelegate
 
-    /// Called if the Garmin Connect Mobile app is not installed or otherwise not available.
-    /// Typically, you would show an alert or prompt the user to install the app from the store.
     func needsToInstallConnectMobile() {
         debug(.apsManager, "Garmin is not available")
         let messageCont = MessageContent(
@@ -1486,531 +695,57 @@ extension BaseGarminManager: IQUIOverrideDelegate, IQDeviceEventDelegate, IQAppM
 
     // MARK: - IQDeviceEventDelegate
 
-    /// Called whenever the status of a registered Garmin device changes (e.g., connected, not found, etc.).
-    /// - Parameters:
-    ///   - device: The device whose status has changed.
-    ///   - status: The new status for the device.
-    func deviceStatusChanged(_ device: IQDevice, status: IQDeviceStatus) {
-        // Track the current status for connection-aware caching
-        if let deviceUUID = device.uuid {
-            deviceConnectionStates[deviceUUID] = status
-        }
-
+    func deviceStatusChanged(_: IQDevice, status: IQDeviceStatus) {
+        // Always log connection state changes - critical for diagnosing SDK issues
         switch status {
         case .invalidDevice:
-            debugGarmin("[\(formatTimeForLog())] Garmin: invalidDevice (\(device.uuid!))")
+            debug(.watchManager, "Garmin: Device status -> invalidDevice")
         case .bluetoothNotReady:
-            debugGarmin("[\(formatTimeForLog())] Garmin: bluetoothNotReady (\(device.uuid!))")
+            debug(.watchManager, "Garmin: Device status -> bluetoothNotReady")
         case .notFound:
-            debugGarmin("[\(formatTimeForLog())] Garmin: notFound (\(device.uuid!))")
+            debug(.watchManager, "Garmin: Device status -> notFound")
         case .notConnected:
-            debugGarmin("[\(formatTimeForLog())] Garmin: notConnected (\(device.uuid!))")
+            debug(.watchManager, "Garmin: Device status -> notConnected")
         case .connected:
-            debugGarmin("[\(formatTimeForLog())] Garmin: connected (\(device.uuid!))")
+            debug(.watchManager, "Garmin: Device status -> connected")
         @unknown default:
-            debugGarmin("[\(formatTimeForLog())] Garmin: unknown state (\(device.uuid!))")
+            debug(.watchManager, "Garmin: Device status -> unknown(\(status.rawValue))")
         }
     }
 
     // MARK: - IQAppMessageDelegate
 
-    /// Called when a message arrives from a Garmin watch app (watchface or data field).
-    /// If the watch requests a "status" update, we call appropriate setup method
-    /// based on watchface setting and re-send the watch state data.
-    /// - Parameters:
-    ///   - message: The message content from the watch app.
-    ///   - app: The watch app sending the message.
-    /// Handle messages from watch apps
-    /// Always processes datafield messages, checks settings for watchface
     func receivedMessage(_ message: Any, from app: IQApp) {
-        debugGarmin("[\(formatTimeForLog())] Garmin: Received message \(message) from app \(app.uuid!)")
+        let appName = appDisplayName(for: app.uuid!)
+        debugGarmin("Garmin: Received message '\(message)' from \(appName)")
 
-        let validUUIDs = Set([currentWatchface.watchfaceUUID, currentGarminSettings.datafield.datafieldUUID].compactMap { $0 })
-
-        // Must be from a configured app
-        guard validUUIDs.contains(app.uuid!) else {
-            debugGarmin("[\(formatTimeForLog())] ⏭️ Ignoring message from unregistered app: \(app.uuid!)")
+        // If watch requests status update, send current data
+        guard let statusString = message as? String, statusString == "status" else {
             return
         }
 
-        // If from datafield, mark as installed in cache (confirms installation)
-        if app.uuid == currentGarminSettings.datafield.datafieldUUID {
-            updateAppStatusCache(app: app, isInstalled: true)
-            debugGarmin("[\(formatTimeForLog())] Garmin: Datafield confirmed installed via status message")
+        Task {
+            do {
+                let watchState = try await setupGarminWatchState(triggeredBy: "WatchRequest")
+                let watchStateData = try JSONEncoder().encode(watchState)
+                sendWatchStateData(watchStateData)
+            } catch {
+                debug(.watchManager, "Garmin: Cannot encode watch state: \(error)")
+            }
         }
-
-        // All messages are "status" requests - ignore them (timer keeps watchface/datafield alive, no response needed)
-        debugGarmin("[\(formatTimeForLog())] ⏭️ Ignoring status request - apps receive proactive updates")
     }
 }
-
-// MARK: - SettingsObserver
 
 extension BaseGarminManager: SettingsObserver {
-    func settingsDidChange(_ settings: TrioSettings) {
-        debug(.watchManager, "🔔 settingsDidChange triggered")
+    func settingsDidChange(_: TrioSettings) {
+        units = settingsManager.settings.units
 
-        // Check what changed by comparing with stored previous values
-        let watchfaceChanged = previousGarminSettings.watchface != settings.garminSettings.watchface
-        let datafieldChanged = previousGarminSettings.datafield != settings.garminSettings.datafield
-        let dataType1Changed = previousGarminSettings.primaryAttributeChoice != settings.garminSettings.primaryAttributeChoice
-        let dataType2Changed = previousGarminSettings.secondaryAttributeChoice != settings.garminSettings.secondaryAttributeChoice
-        let unitsChanged = units != settings.units
-        let enabledChanged = previousGarminSettings.isWatchfaceDataEnabled != settings.garminSettings.isWatchfaceDataEnabled
-
-        // Debug what changed BEFORE updating stored values
-        if watchfaceChanged {
-            debug(
-                .watchManager,
-                "Garmin: Watchface changed from \(previousGarminSettings.watchface.displayName) to \(settings.garminSettings.watchface.displayName). Re-registering devices only, no data update"
-            )
-        }
-
-        if datafieldChanged {
-            debug(
-                .watchManager,
-                "Garmin: Datafield changed from \(previousGarminSettings.datafield.displayName) to \(settings.garminSettings.datafield.displayName). Re-registering devices only, no data update"
-            )
-        }
-
-        if dataType1Changed {
-            debug(
-                .watchManager,
-                "Garmin: Primary attribute choice changed from \(previousGarminSettings.primaryAttributeChoice.displayName) to \(settings.garminSettings.primaryAttributeChoice.displayName)"
-            )
-        }
-
-        if dataType2Changed {
-            debug(
-                .watchManager,
-                "Garmin: Secondary attribute choice changed from \(previousGarminSettings.secondaryAttributeChoice.displayName) to \(settings.garminSettings.secondaryAttributeChoice.displayName)"
-            )
-        }
-
-        if unitsChanged {
-            debugGarmin("Garmin: Units changed - immediate update required")
-        }
-
-        if enabledChanged {
-            debug(
-                .watchManager,
-                "Garmin: Watchface data enabled changed from \(previousGarminSettings.isWatchfaceDataEnabled) to \(settings.garminSettings.isWatchfaceDataEnabled)"
-            )
-
-            // Re-register devices to add/remove watchface app based on enabled state
+        // Re-register devices to pick up watchface/datafield changes
+        if !devices.isEmpty {
             registerDevices(devices)
-
-            if !settings.garminSettings.isWatchfaceDataEnabled { // ← REVERSED LOGIC
-                debugGarmin("Garmin: Watchface app unregistered, datafield continues")
-            } else {
-                debugGarmin("Garmin: Watchface app re-registered - sending immediate update")
-            }
         }
 
-        // NOW update stored values AFTER logging the changes
-        units = settings.units
-        previousGarminSettings = settings.garminSettings
-
-        // Handle watchface or datafield change - ONLY re-register, NO data send
-        if watchfaceChanged || datafieldChanged {
-            // Clear cached determination data after watchface/datafield change
-            cachedDeterminationData = nil
-            lastWatchfaceChangeTime = Date()
-
-            // Clear hash cache since data format differs between watchfaces
-            hashLock.lock()
-            lastPreparedDataHash = nil
-            lastPreparedWatchState = nil
-            hashLock.unlock()
-
-            debugGarmin("Garmin: Cleared cached determination data due to watchface change")
-
-            registerDevices(devices)
-            debugGarmin("Garmin: Re-registered devices for new watchface UUID")
-            // NO data send here - wait for watch to request or next regular update
-        }
-
-        // Determine which type of update is needed (if any)
-        let needsImmediateUpdate = (
-            unitsChanged ||
-                (enabledChanged && settings.garminSettings.isWatchfaceDataEnabled) // ← REVERSED LOGIC
-        ) &&
-            !watchfaceChanged && !datafieldChanged // Don't send if only watchface or datafield changed
-
-        let needsThrottledUpdate = (dataType1Changed || dataType2Changed) &&
-            !watchfaceChanged && !datafieldChanged // Don't send if only watchface or datafield changed
-
-        // Send immediate update for critical changes
-        if needsImmediateUpdate {
-            Task {
-                // Skip if no apps are installed (based on cache)
-                guard self.areAppsLikelyInstalled() else {
-                    debugGarmin("⏩ Skipping immediate settings update - no apps installed (cached)")
-                    return
-                }
-
-                do {
-                    // Try to use cached determination data first to avoid CoreData staleness
-                    if let cachedData = self.cachedDeterminationData {
-                        self.currentSendTrigger = "Settings-Units/Re-enable"
-
-                        // Cancel any pending throttled send since we're sending immediately
-                        self.throttleWorkItem?.cancel()
-                        self.throttleWorkItem = nil
-                        self.pendingThrottledData = nil
-                        self.throttledUpdatePending = false
-
-                        debugGarmin("Garmin: Using cached determination data for immediate settings update")
-                        self.sendWatchStateDataImmediately(cachedData)
-                        self.lastImmediateSendTime = Date()
-                        debugGarmin("Garmin: Immediate update sent for units/re-enable change (from cache)")
-                    } else {
-                        // Fallback to fresh query if no cache available
-                        let watchState = try await self.setupGarminWatchState(triggeredBy: "Settings-Units/Re-enable")
-                        let watchStateData = try JSONEncoder().encode(watchState)
-                        self.currentSendTrigger = "Settings-Units/Re-enable"
-
-                        // Cancel any pending throttled send since we're sending immediately
-                        self.throttleWorkItem?.cancel()
-                        self.throttleWorkItem = nil
-                        self.pendingThrottledData = nil
-                        self.throttledUpdatePending = false
-
-                        self.sendWatchStateDataImmediately(watchStateData)
-                        self.lastImmediateSendTime = Date()
-                        debugGarmin("Garmin: Immediate update sent for units/re-enable change (fresh query)")
-                    }
-                } catch {
-                    debug(
-                        .watchManager,
-                        "\(DebuggingIdentifiers.failed) Failed to send immediate update after settings change: \(error)"
-                    )
-                }
-            }
-        }
-        // Send throttled update for data type changes
-        else if needsThrottledUpdate {
-            Task {
-                // Skip if no apps are installed (based on cache)
-                guard self.areAppsLikelyInstalled() else {
-                    debugGarmin("⏩ Skipping throttled settings update - no apps installed (cached)")
-                    return
-                }
-
-                // Use cached data if available (display types will be updated at send time)
-                if let cachedData = self.cachedDeterminationData {
-                    self.currentSendTrigger = "Settings-DataType"
-                    self.sendWatchStateDataWithThrottle(cachedData)
-                    debugGarmin("Garmin: Throttled update queued for data type change (10s) - using cached data")
-                } else {
-                    // No cached data - prepare fresh (shouldn't happen often)
-                    do {
-                        let watchState = try await self.setupGarminWatchState(triggeredBy: "Settings-DataType")
-                        let watchStateData = try JSONEncoder().encode(watchState)
-                        self.currentSendTrigger = "Settings-DataType"
-                        self.sendWatchStateDataWithThrottle(watchStateData)
-                        debugGarmin("Garmin: Throttled update queued for data type change (10s) - fresh data")
-                    } catch {
-                        debug(
-                            .watchManager,
-                            "\(DebuggingIdentifiers.failed) Failed to send throttled update after settings change: \(error)"
-                        )
-                    }
-                }
-            }
-        }
+        // Send updated state
+        triggerWatchStateUpdate(triggeredBy: "Settings")
     }
-}
-
-// MARK: - Validation Helpers Extension
-
-extension BaseGarminManager {
-    // MARK: - Glucose Validation
-
-    /// Validates glucose reading and returns the value if valid
-    /// - Parameters:
-    ///   - glucose: GlucoseStored object
-    ///   - maxAgeMinutes: Maximum age in minutes (default: 15)
-    /// - Returns: Valid glucose value (Int16), or nil if invalid
-    private func validateGlucoseReading(
-        _ glucose: GlucoseStored?,
-        maxAgeMinutes: Double = 15
-    ) -> Int16? {
-        guard let glucose = glucose,
-              let glucoseDate = glucose.date
-        else {
-            return nil
-        }
-
-        let age = Date().timeIntervalSince(glucoseDate) / 60
-        guard age <= maxAgeMinutes else {
-            return nil
-        }
-
-        // glucose.glucose is already Int16
-        let glucoseValue = glucose.glucose
-        guard glucoseValue >= 0, glucoseValue <= 500 else {
-            return nil
-        }
-
-        return glucoseValue
-    }
-
-    /// Validates glucose reading with trend information
-    /// - Parameters:
-    ///   - glucose: GlucoseStored object
-    ///   - previousGlucose: Previous GlucoseStored for delta calculation
-    ///   - maxAgeMinutes: Maximum age in minutes (default: 15)
-    /// - Returns: Tuple of (value, delta, direction) if valid, or nil
-    private func validateGlucoseWithTrend(
-        _ glucose: GlucoseStored?,
-        previousGlucose: GlucoseStored?,
-        maxAgeMinutes: Double = 15
-    ) -> (value: Int16, delta: Int16?, direction: String)? {
-        guard let validValue = validateGlucoseReading(glucose, maxAgeMinutes: maxAgeMinutes),
-              let glucose = glucose
-        else {
-            return nil
-        }
-
-        // Calculate delta if previous reading exists
-        let delta: Int16? = {
-            guard let prev = previousGlucose else { return 0 }
-            let deltaValue = glucose.glucose - prev.glucose
-            guard deltaValue >= -100, deltaValue <= 100 else { return nil }
-            return deltaValue
-        }()
-
-        let direction = glucose.direction ?? "--"
-
-        return (value: validValue, delta: delta, direction: direction)
-    }
-
-    // MARK: - Data Freshness Validation
-
-    /// Validates determination data freshness
-    /// - Parameters:
-    ///   - determination: OrefDetermination object
-    ///   - maxAgeMinutes: Maximum age in minutes (default: 15)
-    /// - Returns: True if fresh, false otherwise
-    private func isDeterminationFresh(
-        _ determination: OrefDetermination?,
-        maxAgeMinutes: Double = 15
-    ) -> Bool {
-        guard let determination = determination else { return false }
-
-        // OrefDetermination uses timestamp (not date)
-        guard let timestamp = determination.timestamp else { return false }
-
-        let age = Date().timeIntervalSince(timestamp) / 60
-        return age <= maxAgeMinutes
-    }
-
-    /// Validates timestamp freshness
-    /// - Parameters:
-    ///   - date: Date to validate
-    ///   - maxAgeMinutes: Maximum age in minutes
-    /// - Returns: True if fresh, false otherwise
-    private func isDataFresh(
-        _ date: Date?,
-        maxAgeMinutes: Double
-    ) -> Bool {
-        guard let date = date else {
-            return false
-        }
-
-        let age = Date().timeIntervalSince(date) / 60
-        return age <= maxAgeMinutes
-    }
-
-    // MARK: - App Configuration Validation
-
-    /// Validation result for app configuration
-    private struct AppValidationResult {
-        let shouldProceed: Bool
-        let reason: String
-    }
-
-    /// Validates app installation and configuration status
-    /// - Returns: ValidationResult indicating whether to proceed
-    private func validateAppConfiguration() -> AppValidationResult {
-        let garminSettings = settingsManager.settings.garminSettings
-
-        // Check if datafield is configured (not .none)
-        let hasDatafield = garminSettings.datafield != .none
-
-        // If datafield exists, always proceed (datafield always sends)
-        if hasDatafield {
-            return AppValidationResult(
-                shouldProceed: true,
-                reason: "Datafield configured"
-            )
-        }
-
-        // Only watchface, check if data is enabled
-        if !garminSettings.isWatchfaceDataEnabled {
-            return AppValidationResult(
-                shouldProceed: false,
-                reason: "Watchface data transmission disabled"
-            )
-        }
-
-        return AppValidationResult(
-            shouldProceed: true,
-            reason: "Valid app configuration"
-        )
-    }
-
-    private func shouldSendData() -> Bool {
-        let garminSettings = settingsManager.settings.garminSettings
-
-        // Case 1: Datafield configured - ALWAYS send
-        if garminSettings.datafield != .none {
-            return true
-        }
-
-        // Case 2: Only watchface - check if enabled
-        return garminSettings.isWatchfaceDataEnabled
-    }
-
-    // MARK: - Numeric Value Validation
-
-    /// Validates and formats numeric value for display
-    /// - Parameters:
-    ///   - value: Optional double value
-    ///   - defaultValue: Default value if nil or invalid
-    ///   - decimalPlaces: Number of decimal places (default: 1)
-    /// - Returns: Formatted numeric value
-    private func validateAndFormatNumeric(
-        _ value: Double?,
-        defaultValue: Double = 0.0,
-        decimalPlaces: Int = 1
-    ) -> Double {
-        guard let value = value, value.isFinite else {
-            return defaultValue
-        }
-
-        return value.roundedDouble(toPlaces: decimalPlaces)
-    }
-
-    /// Validates COB value from Int16 (CoreData storage type)
-    /// - Parameter cob: COB value (Int16)
-    /// - Returns: Valid COB value or 0
-    private func validateCOB(_ cob: Int16) -> Double {
-        let cobDouble = Double(cob)
-        guard cobDouble >= 0 else {
-            return 0
-        }
-        return cobDouble
-    }
-
-    /// Validates COB value from Decimal
-    /// - Parameter cob: COB value (Decimal from CoreData)
-    /// - Returns: Valid COB value or 0
-    private func validateCOB(_ cob: Decimal) -> Double {
-        let cobDouble = Double(truncating: cob as NSNumber)
-        guard cobDouble.isFinite, !cobDouble.isNaN, cobDouble >= 0 else {
-            return 0
-        }
-        return cobDouble.roundedDouble(toPlaces: 0)
-    }
-
-    /// Validates IOB value
-    /// - Parameter iob: IOB value (Decimal)
-    /// - Returns: Valid IOB value or 0.0
-    private func validateIOB(_ iob: Decimal) -> Double {
-        let iobDouble = Double(truncating: iob as NSNumber)
-        return validateAndFormatNumeric(iobDouble, defaultValue: 0.0, decimalPlaces: 1)
-    }
-
-    /// Validates sensitivity ratio value
-    /// - Parameter sensRatio: Sensitivity ratio NSNumber
-    /// - Returns: Valid sensitivity ratio or 1.0 (default)
-    private func validateSensRatio(_ sensRatio: NSNumber?) -> Double {
-        guard let sensRatio = sensRatio else { return 1.0 }
-        let sensRatioDouble = Double(truncating: sensRatio as NSNumber)
-        guard sensRatioDouble.isFinite, !sensRatioDouble.isNaN, sensRatioDouble > 0 else {
-            return 1.0
-        }
-        return sensRatioDouble.roundedDouble(toPlaces: 2)
-    }
-
-    /// Validates ISF (insulin sensitivity factor) value
-    /// - Parameter insulinSensitivity: ISF value as NSNumber
-    /// - Returns: Valid ISF value (Int16) or nil
-    private func validateISF(_ insulinSensitivity: NSNumber?) -> Int16? {
-        guard let isf = insulinSensitivity as? Int16 else { return nil }
-        guard isf > 0, isf <= 300 else { return nil }
-        return isf
-    }
-
-    /// Validates eventual BG value
-    /// - Parameter eventualBG: Eventual BG value as NSNumber
-    /// - Returns: Valid eventual BG value (Int16) or nil
-    private func validateEventualBG(_ eventualBG: NSNumber?) -> Int16? {
-        guard let bg = eventualBG as? Int16 else { return nil }
-        guard bg >= 0, bg <= 500 else { return nil }
-        return bg
-    }
-
-    // MARK: - Settings Change Validation
-
-    /// Settings change detection result
-    struct SettingsChange {
-        let watchfaceChanged: Bool
-        let datafieldChanged: Bool
-        let dataType1Changed: Bool
-        let dataType2Changed: Bool
-        let unitsChanged: Bool
-        let enabledChanged: Bool
-    }
-
-    /// Detects which settings have changed
-    /// - Parameter newSettings: New settings to compare against
-    /// - Returns: SettingsChange struct with boolean flags for each change
-    private func detectSettingsChanges(_ newSettings: TrioSettings) -> SettingsChange {
-        let oldSettings = previousGarminSettings
-        let newGarmin = newSettings.garminSettings
-
-        return SettingsChange(
-            watchfaceChanged: oldSettings.watchface != newGarmin.watchface,
-            datafieldChanged: oldSettings.datafield != newGarmin.datafield,
-            dataType1Changed: oldSettings.primaryAttributeChoice != newGarmin.primaryAttributeChoice,
-            dataType2Changed: oldSettings.secondaryAttributeChoice != newGarmin.secondaryAttributeChoice,
-            unitsChanged: units != newSettings.units,
-            enabledChanged: oldSettings.isWatchfaceDataEnabled != newGarmin.isWatchfaceDataEnabled
-        )
-    }
-
-    // MARK: - Cache Validation
-
-    /// Checks if app installation cache is valid
-    /// - Parameter appUUID: UUID of the app to check
-    /// - Returns: Cached status if valid, nil otherwise
-    private func getCachedAppStatus(_ appUUID: String) -> Bool? {
-        appStatusCacheLock.lock()
-        defer { appStatusCacheLock.unlock() }
-
-        guard let cached = appInstallationCache[appUUID] else {
-            return nil
-        }
-
-        let age = Date().timeIntervalSince(cached.lastChecked)
-        guard age < appStatusCacheTimeout else {
-            appInstallationCache.removeValue(forKey: appUUID)
-            return nil
-        }
-
-        return cached.status.shouldSendData
-    }
-
-    /// Updates app installation cache
-    /// - Parameters:
-    ///   - appUUID: UUID of the app
-    ///   - isInstalled: Installation status
-    private func updateAppStatusCache(_ appUUID: String, isInstalled: Bool) {
-        appStatusCacheLock.lock()
-        defer { appStatusCacheLock.unlock() }
-
-        appInstallationCache[appUUID] = (status: isInstalled ? .installed : .notInstalled, lastChecked: Date()) }
 }

--- a/Trio/Sources/Services/WatchManager/GarminManager.swift
+++ b/Trio/Sources/Services/WatchManager/GarminManager.swift
@@ -107,8 +107,8 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
     // MARK: - Glucose/Determination Coordination
 
     /// Delay before sending glucose if determination hasn't arrived (seconds)
-    /// Based on log analysis: avg delay ~5s, max ~24s, >15s occurs <1% of time
-    private let glucoseFallbackDelay: TimeInterval = 20
+    /// Based on log analysis: avg delay ~5s, max ~11s with new timer coordination
+    private let glucoseFallbackDelay: TimeInterval = 10
 
     /// Pending glucose fallback task - cancelled if determination arrives first
     private var pendingGlucoseFallback: DispatchWorkItem?
@@ -255,7 +255,7 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
     }
 
     /// Handles glucose updates with delayed fallback
-    /// Waits up to 20 seconds for determination to arrive before sending glucose-only update
+    /// Waits up to 10 seconds for determination to arrive before sending glucose-only update
     /// This ensures we send complete data when loop is working, but still update watch if loop is slow/failing
     private func handleGlucoseUpdate() {
         guard !devices.isEmpty else { return }
@@ -290,7 +290,7 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
     }
 
     /// Handles IOB updates with delayed fallback
-    /// Also waits up to 20 seconds for determination to arrive, restarting the shared timer
+    /// Also waits up to 10 seconds for determination to arrive, restarting the shared timer
     /// This prevents IOB changes from triggering premature watch updates before determination arrives
     private func handleIOBUpdate() {
         guard !devices.isEmpty else { return }

--- a/Trio/Sources/Services/WatchManager/GarminManager.swift
+++ b/Trio/Sources/Services/WatchManager/GarminManager.swift
@@ -180,11 +180,11 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
             }
             .store(in: &subscriptions)
 
-        // IOB updates - needed for manual boluses which update IOB independently of loop
+        // IOB updates - also wait for determination like glucose does
         iobService.iobPublisher
             .receive(on: DispatchQueue.global(qos: .background))
             .sink { [weak self] _ in
-                self?.triggerWatchStateUpdate(triggeredBy: "IOB")
+                self?.handleIOBUpdate()
             }
             .store(in: &subscriptions)
 
@@ -289,6 +289,41 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
         debugGarmin("Garmin: Glucose received - waiting \(Int(glucoseFallbackDelay))s for determination")
     }
 
+    /// Handles IOB updates with delayed fallback
+    /// Also waits up to 20 seconds for determination to arrive, restarting the shared timer
+    /// This prevents IOB changes from triggering premature watch updates before determination arrives
+    private func handleIOBUpdate() {
+        guard !devices.isEmpty else { return }
+
+        // Cancel any existing fallback timer (restart the 20s window)
+        pendingGlucoseFallback?.cancel()
+
+        // Create new fallback task
+        let fallback = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+
+            Task {
+                do {
+                    self
+                        .debugGarmin(
+                            "Garmin: IOB fallback timer fired (no determination in \(Int(self.glucoseFallbackDelay))s)"
+                        )
+
+                    let watchState = try await self.setupGarminWatchState(triggeredBy: "IOB (fallback)")
+                    let watchStateData = try JSONEncoder().encode(watchState)
+                    self.watchStateSubject.send(watchStateData)
+                } catch {
+                    debug(.watchManager, "Garmin: Error in IOB fallback: \(error)")
+                }
+            }
+        }
+
+        pendingGlucoseFallback = fallback
+        timerQueue.asyncAfter(deadline: .now() + glucoseFallbackDelay, execute: fallback)
+
+        debugGarmin("Garmin: IOB received - waiting \(Int(glucoseFallbackDelay))s for determination")
+    }
+
     /// Triggers watch state preparation and sends to debounce subject
     /// If triggered by Determination, cancels pending glucose fallback timer
     private func triggerWatchStateUpdate(triggeredBy trigger: String) {
@@ -364,6 +399,27 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
         }
     }
 
+    /// Fetches all determinations from the last 30 minutes (no fetch limit).
+    /// Returns them sorted newest first, allowing us to find both enacted and suggested determinations.
+    /// - Returns: An array of `NSManagedObjectID`s for all determinations in the 30-minute window.
+    private func fetchDeterminations30Min() async throws -> [NSManagedObjectID] {
+        let results = try await CoreDataStack.shared.fetchEntitiesAsync(
+            ofType: OrefDetermination.self,
+            onContext: backgroundContext,
+            predicate: NSPredicate.predicateFor30MinAgoForDetermination,
+            key: "deliverAt",
+            ascending: false,
+            fetchLimit: 0 // No limit - get all determinations in 30min window
+        )
+
+        return try await backgroundContext.perform {
+            guard let fetchedResults = results as? [OrefDetermination] else {
+                throw CoreDataError.fetchError(function: #function, file: #file)
+            }
+            return fetchedResults.map(\.objectID)
+        }
+    }
+
     // MARK: - Watch State Setup
 
     /// Builds an array of GarminWatchState objects containing current glucose, trend, loop data, and historical readings.
@@ -384,16 +440,16 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
         let glucoseLimit = needsHistoricalGlucoseData ? 24 : 2
         let glucoseIds = try await fetchGlucose(limit: glucoseLimit)
 
-        let determinationIds = try await determinationStorage.fetchLastDeterminationObjectID(
-            predicate: NSPredicate.enactedDetermination
-        )
+        // Fetch all determinations from last 30 minutes (no limit)
+        // This ensures we get both enacted and suggested determinations
+        let allDeterminationIds = try await fetchDeterminations30Min()
 
         let tempBasalIds = try await fetchTempBasals()
 
         let glucoseObjects: [GlucoseStored] = try await CoreDataStack.shared
             .getNSManagedObject(with: glucoseIds, context: backgroundContext)
-        let determinationObjects: [OrefDetermination] = try await CoreDataStack.shared
-            .getNSManagedObject(with: determinationIds, context: backgroundContext)
+        let allDeterminationObjects: [OrefDetermination] = try await CoreDataStack.shared
+            .getNSManagedObject(with: allDeterminationIds, context: backgroundContext)
         let tempBasalObjects: [PumpEventStored] = try await CoreDataStack.shared
             .getNSManagedObject(with: tempBasalIds, context: backgroundContext)
 
@@ -405,15 +461,22 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
             // IOB with 1 decimal precision
             let iobValue = self.formatIOB(self.iobService.currentIOB ?? Decimal(0))
 
-            // Extract determination data
+            // Find enacted determination for timestamp (when loop actually ran)
+            // If no enacted determination exists in last 30 min, use a synthetic timestamp
+            // of "31 minutes ago" so watchface can distinguish between:
+            //   - nil = no data received yet (watch startup)
+            //   - 31+ min old = loop is stale
+            let enactedDetermination = allDeterminationObjects.first(where: { $0.enacted })
+            let enactedTimestamp: Date = enactedDetermination?.timestamp ?? Date().addingTimeInterval(-31 * 60)
+
+            // Extract data values from most recent determination (enacted or suggested)
+            // Suggested sets provide latest calculations even if loop hasn't run yet
             var cobValue: Double?
             var sensRatioValue: Double?
             var isfValue: Int16?
             var eventualBGValue: Int16?
-            var determinationTimestamp: Date?
 
-            if let latestDetermination = determinationObjects.first {
-                determinationTimestamp = latestDetermination.timestamp
+            if let latestDetermination = allDeterminationObjects.first {
                 cobValue = Double(latestDetermination.cob)
 
                 if let ratio = latestDetermination.sensitivityRatio {
@@ -467,12 +530,10 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
 
                 var watchState = GarminWatchState()
 
-                // Timestamp: Use determination timestamp to indicate loop staleness
-                // If loop hasn't run recently, the old determination timestamp shows data is stale
-                // Fall back to glucose timestamp only if no determination exists
+                // Loop timestamp: Only use enacted determination timestamp (never glucose timestamp)
+                // This shows when the loop actually executed, not when glucose was received
                 if index == 0 {
-                    let timestamp = determinationTimestamp ?? glucose.date
-                    watchState.date = timestamp.map { UInt64($0.timeIntervalSince1970 * 1000) }
+                    watchState.date = UInt64(enactedTimestamp.timeIntervalSince1970 * 1000)
                 } else {
                     watchState.date = glucose.date.map { UInt64($0.timeIntervalSince1970 * 1000) }
                 }
@@ -489,6 +550,10 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
                     } else {
                         watchState.delta = 0
                     }
+
+                    // Glucose timestamp: Used by watchface to determine if glucose is fresh
+                    // Enables green coloring when: enacted loop is 6+ min old but glucose is <10 min old
+                    watchState.glucoseDate = glucose.date.map { UInt64($0.timeIntervalSince1970 * 1000) }
 
                     watchState.units_hint = unitsHint
                     watchState.iob = iobValue

--- a/Trio/Sources/Services/WatchManager/GarminManager.swift
+++ b/Trio/Sources/Services/WatchManager/GarminManager.swift
@@ -582,15 +582,19 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
             let currentHash = watchStates.hashValue
             if currentHash == self.lastPreparedDataHash {
                 if self.debugWatchState {
-                    debug(.watchManager, "Garmin: Skipping - data unchanged (hash: \(currentHash))")
+                    debug(.watchManager, "Garmin: Skipping - data unchanged")
                 }
                 return self.lastPreparedWatchState ?? watchStates
             }
 
             if self.debugWatchState {
+                let iobFormatted = String(format: "%.1f", watchStates.first?.iob ?? 0)
+                let cobFormatted = String(format: "%.0f", watchStates.first?.cob ?? 0)
+                let tbrFormatted = String(format: "%.2f", watchStates.first?.tbr ?? 0)
+                let sensRatioFormatted = String(format: "%.2f", watchStates.first?.sensRatio ?? 0)
                 debug(
                     .watchManager,
-                    "Garmin: Prepared \(watchStates.count) entries - sgv: \(watchStates.first?.sgv ?? 0), iob: \(watchStates.first?.iob ?? 0), cob: \(watchStates.first?.cob ?? 0), tbr: \(watchStates.first?.tbr ?? 0), eventualBG: \(watchStates.first?.eventualBG ?? 0), sensRatio: \(watchStates.first?.sensRatio ?? 0)"
+                    "Garmin: Prepared \(watchStates.count) entries - sgv: \(watchStates.first?.sgv ?? 0), iob: \(iobFormatted), cob: \(cobFormatted), tbr: \(tbrFormatted), eventualBG: \(watchStates.first?.eventualBG ?? 0), sensRatio: \(sensRatioFormatted)"
                 )
             }
 

--- a/Trio/Sources/Services/WatchManager/GarminManager.swift
+++ b/Trio/Sources/Services/WatchManager/GarminManager.swift
@@ -708,6 +708,10 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
     private func registerDevices(_ devices: [IQDevice]) {
         watchApps.removeAll()
 
+        // Reset broadcast hash so newly registered apps receive data
+        // Without this, hash deduplication could skip sending to new apps if data unchanged
+        lastSentDataHash = nil
+
         for device in devices {
             connectIQ?.register(forDeviceEvents: device, delegate: self)
 


### PR DESCRIPTION
I had a lot of checking IOB, Determination and Glucose updates in order to reduce message volume to Garmin devices - many were unnecessary or low yield but added complexity. I simplified that.

It was necessary to make it easier to identify some issues that have come up with Garmin updates starting in the beginning of December. The so far not never logged errors Garmin: Device status -> bluetoothNotReady started creeping up and can lead to stalled Garmin messaging execution, that required a Trio app restart. So with additional logging I hope to get more insights into this.

### Removed Complexity:
- Eliminated complex caching mechanisms (app installation status, watchface change tracking)
- Removed connection state tracking and related caching logic  
- Simplified throttle/debounce implementation
- Removed @unchecked Sendable conformance and NSLock instances
- Cleaned up device connection state tracking

### Simplified State Management:
- More direct dispatch queue usage for timer management
- Streamlined glucose/determination coordination for watch updates
- Documented fallback delay configuration with reasoning
- improved logging for connectIQ states

### Documentation Restoration
- Restored all documentation comments that were present in dev branch
- Added doc strings for the new helper methods (debugGarmin, formatIOB, etc.)

### Simulator Testing Improvements
Enhanced simulator testing workflow:
- Removed auto-creation of simulated devices
- Added manual mock device creation via UI
- Created MockIQDevice class with factory method createSimulated()
- Improved testing workflow to mimic real user experience