### PR TITLE
Update unit test GitHub workflow

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,6 +1,7 @@
 name: zzz [DO NOT RUN] Automated unit tests
 
 on:
+  workflow_dispatch: # Allow manual running for debugging
   pull_request:
     branches:
       - dev

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,7 +1,7 @@
 name: zzz [DO NOT RUN] Automated unit tests
 
 on:
-  workflow_dispatch: # Allow manual running for debugging
+  workflow_dispatch: # FIXME: Allow manual running for debugging
   pull_request:
     branches:
       - dev
@@ -25,6 +25,7 @@ jobs:
   test:
     name: Run Unit Tests
     runs-on: macos-15
+    # FIXME Change back
     if: github.repository_owner == 'kingst'
 
     steps:
@@ -65,7 +66,7 @@ jobs:
           time xcodebuild build-for-testing \
             -workspace Trio.xcworkspace \
             -scheme "Trio Tests" \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
 
       - name: Check for uncommitted changes
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,7 +1,6 @@
 name: zzz [DO NOT RUN] Automated unit tests
 
 on:
-  workflow_dispatch: # FIXME: Allow manual running for debugging
   pull_request:
     branches:
       - dev
@@ -25,8 +24,7 @@ jobs:
   test:
     name: Run Unit Tests
     runs-on: macos-15
-    # FIXME Change back
-    if: github.repository_owner == 'kingst'
+    if: github.repository_owner == 'nightscout'
 
     steps:
       - name: Select Xcode version

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -109,7 +109,7 @@ jobs:
           time xcodebuild test-without-building \
             -workspace Trio.xcworkspace \
             -scheme "Trio Tests" \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.4' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
             $([ "$ENABLE_PARALLEL_TESTING" = "true" ] && echo "-parallel-testing-enabled YES") \
             2>&1 | tee xcodebuild.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -54,6 +54,9 @@ jobs:
           echo ""
           echo "📂 Contents of .build:"
           ls -lah .build || echo ".build directory not found"
+
+      - name: List available simulators
+        run: xcrun simctl list devices available
 
       - name: Build for testing
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     name: Run Unit Tests
     runs-on: macos-15
-    if: github.repository_owner == 'nightscout'
+    if: github.repository_owner == 'kingst'
 
     steps:
       - name: Select Xcode version

--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -1,3 +1,4 @@
+// REMOVE ME, KICK OFF UNIT TESTS
 import Combine
 import CoreData
 import Foundation

--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -1,4 +1,3 @@
-// REMOVE ME, KICK OFF UNIT TESTS
 import Combine
 import CoreData
 import Foundation


### PR DESCRIPTION
Updates to the unit test workflow so that they run on GitHub. At some point GitHub stopped supporting iPhone 16 with iOS 18.4, so this PR updates our workflow to a new Xcode version and changes the iOS version to the oldest version supported (18.5).

I tested this using my fork of Trio and manual GitHub Actions.