### PR TITLE
feat: Add live glucose display to Apple Watch complications

### DIFF
--- a/Trio Watch App Extension/Info.plist
+++ b/Trio Watch App Extension/Info.plist
@@ -4,10 +4,5 @@
 <dict>
 	<key>AppGroupID</key>
 	<string>$(APP_GROUP_ID)</string>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
 </dict>
 </plist>

--- a/Trio Watch App Extension/TrioWatchApp.entitlements
+++ b/Trio Watch App Extension/TrioWatchApp.entitlements
@@ -2,12 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AppGroupID</key>
-	<string>$(APP_GROUP_ID)</string>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(APP_GROUP_ID)</string>
+	</array>
 </dict>
 </plist>

--- a/Trio Watch App Extension/WatchState.swift
+++ b/Trio Watch App Extension/WatchState.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import WatchConnectivity
+import WidgetKit
 
 /// WatchState manages the communication between the Watch app and the iPhone app using WatchConnectivity.
 /// It handles glucose data synchronization and sending treatment requests (bolus, carbs) to the phone.
@@ -573,5 +574,57 @@ import WatchConnectivity
                 self.confirmBolusFaster = booleanValue
             }
         }
+
+        // Persist to App Group for complication access
+        persistToAppGroupForComplication(from: message)
+    }
+
+    // MARK: - Complication Data Persistence
+
+    /// Persists glucose data to Watch-local App Group for complication access.
+    /// This is called after receiving data from the iPhone via WatchConnectivity.
+    /// The complication reads from this same App Group to display glucose data.
+    /// - Parameter message: The WatchState message dictionary containing glucose data
+    private func persistToAppGroupForComplication(from message: [String: Any]) {
+        guard let suiteName = Bundle.main.appGroupSuiteName,
+              let sharedDefaults = UserDefaults(suiteName: suiteName)
+        else {
+            Task {
+                await WatchLogger.shared.log("⌚️ Could not access App Group for complication")
+            }
+            return
+        }
+
+        sharedDefaults.set(currentGlucose, forKey: "currentGlucose")
+        sharedDefaults.set(trend ?? "", forKey: "trend")
+        sharedDefaults.set(delta ?? "--", forKey: "delta")
+        sharedDefaults.set(currentGlucoseColorString, forKey: "currentGlucoseColorString")
+        sharedDefaults.set(iob ?? "", forKey: "iob")
+        sharedDefaults.set(cob ?? "", forKey: "cob")
+        sharedDefaults.set(Date().timeIntervalSince1970, forKey: "date")
+
+        // Store units as string (mg/dL or mmol/L)
+        // The complication will use this to display the correct units
+        if let unitsString = message[WatchMessageKeys.units] as? String {
+            sharedDefaults.set(unitsString, forKey: "units")
+        }
+
+        sharedDefaults.synchronize()
+
+        // Reload complication timeline - this is called FROM the Watch
+        // so it correctly triggers watchOS WidgetKit refresh
+        WidgetCenter.shared.reloadTimelines(ofKind: "TrioWatchComplication")
+
+        Task {
+            await WatchLogger.shared.log("⌚️ Persisted glucose to App Group and triggered complication refresh")
+        }
+    }
+}
+
+// MARK: - Bundle Extension
+
+extension Bundle {
+    var appGroupSuiteName: String? {
+        object(forInfoDictionaryKey: "AppGroupID") as? String
     }
 }

--- a/Trio Watch Complication/TrioWatchComplication.entitlements
+++ b/Trio Watch Complication/TrioWatchComplication.entitlements
@@ -2,12 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AppGroupID</key>
-	<string>$(APP_GROUP_ID)</string>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.widgetkit-extension</string>
-	</dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(APP_GROUP_ID)</string>
+	</array>
 </dict>
 </plist>

--- a/Trio Watch Complication/TrioWatchComplication.swift
+++ b/Trio Watch Complication/TrioWatchComplication.swift
@@ -5,30 +5,109 @@ import WidgetKit
 
 struct TrioWatchComplicationEntry: TimelineEntry {
     let date: Date
+    let glucoseValue: String
+    let trend: String
+    let delta: String
+    let glucoseColor: Color
+    let iob: String?
+    let cob: String?
+    let lastUpdateTime: Date?
+    let units: String
+
+    var isStale: Bool {
+        guard let lastUpdate = lastUpdateTime else { return true }
+        return Date().timeIntervalSince(lastUpdate) > 900 // 15 minutes
+    }
 }
 
 // MARK: - Provider
 
 struct TrioWatchComplicationProvider: TimelineProvider {
     func placeholder(in _: Context) -> TrioWatchComplicationEntry {
-        TrioWatchComplicationEntry(date: Date())
+        TrioWatchComplicationEntry(
+            date: Date(),
+            glucoseValue: "120",
+            trend: "→",
+            delta: "+2",
+            glucoseColor: .green,
+            iob: "2.5U",
+            cob: "30g",
+            lastUpdateTime: Date(),
+            units: "mg/dL"
+        )
     }
 
-    func getSnapshot(in _: Context, completion: @escaping (TrioWatchComplicationEntry) -> Void) {
-        let entry = TrioWatchComplicationEntry(date: Date())
+    func getSnapshot(in context: Context, completion: @escaping (TrioWatchComplicationEntry) -> Void) {
+        let entry = loadLatestGlucoseFromAppGroup() ?? placeholder(in: context)
         completion(entry)
     }
 
     func getTimeline(in _: Context, completion: @escaping (Timeline<TrioWatchComplicationEntry>) -> Void) {
-        let entry = TrioWatchComplicationEntry(date: Date())
-        let timeline = Timeline(entries: [entry], policy: .never)
+        let currentEntry = loadLatestGlucoseFromAppGroup() ?? createPlaceholderEntry()
+
+        // Update every 5 minutes to match CGM reading frequency
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 5, to: Date())!
+        let timeline = Timeline(entries: [currentEntry], policy: .after(nextUpdate))
+
         completion(timeline)
+    }
+
+    // MARK: - Data Loading
+
+    private func loadLatestGlucoseFromAppGroup() -> TrioWatchComplicationEntry? {
+        guard let suiteName = Bundle.main.appGroupSuiteName,
+              !suiteName.isEmpty,
+              let sharedDefaults = UserDefaults(suiteName: suiteName)
+        else {
+            return nil
+        }
+
+        // Read glucose data from App Group (written by Watch app after receiving from iPhone)
+        guard let glucoseValue = sharedDefaults.string(forKey: "currentGlucose"),
+              !glucoseValue.isEmpty
+        else {
+            return nil
+        }
+
+        let trend = sharedDefaults.string(forKey: "trend") ?? ""
+        let delta = sharedDefaults.string(forKey: "delta") ?? ""
+        let colorString = sharedDefaults.string(forKey: "currentGlucoseColorString") ?? "#ffffff"
+
+        let glucoseColor = Color(hex: colorString) ?? .white
+        let lastUpdateTimestamp = sharedDefaults.double(forKey: "date")
+        let lastUpdate = lastUpdateTimestamp > 0 ? Date(timeIntervalSince1970: lastUpdateTimestamp) : nil
+
+        return TrioWatchComplicationEntry(
+            date: Date(),
+            glucoseValue: glucoseValue,
+            trend: trend,
+            delta: delta,
+            glucoseColor: glucoseColor,
+            iob: sharedDefaults.string(forKey: "iob"),
+            cob: sharedDefaults.string(forKey: "cob"),
+            lastUpdateTime: lastUpdate,
+            units: sharedDefaults.string(forKey: "units") ?? "mg/dL"
+        )
+    }
+
+    private func createPlaceholderEntry() -> TrioWatchComplicationEntry {
+        TrioWatchComplicationEntry(
+            date: Date(),
+            glucoseValue: "--",
+            trend: "",
+            delta: "",
+            glucoseColor: .gray,
+            iob: nil,
+            cob: nil,
+            lastUpdateTime: nil,
+            units: "mg/dL"
+        )
     }
 }
 
 // MARK: - Views
 
-//// Displayed View Wrapper
+/// Displayed View Wrapper
 struct TrioWatchComplicationEntryView: View {
     @Environment(\.widgetFamily) private var widgetFamily
 
@@ -40,37 +119,140 @@ struct TrioWatchComplicationEntryView: View {
             TrioAccessoryCircularView(entry: entry)
         case .accessoryCorner:
             TrioAccessoryCornerView(entry: entry)
+        case .accessoryRectangular:
+            TrioAccessoryRectangularView(entry: entry)
+        case .accessoryInline:
+            TrioAccessoryInlineView(entry: entry)
         default:
-            Image("ComplicationIcon")
-                .widgetAccentable()
-                .widgetBackground(backgroundView: Color.clear)
+            // Fallback for unsupported families - show glucose text
+            VStack {
+                Text(entry.glucoseValue)
+                    .font(.system(.body, design: .rounded))
+                    .bold()
+                Text(entry.trend)
+                    .font(.caption)
+            }
+            .widgetBackground(backgroundView: Color.clear)
         }
     }
 }
 
-/// Corner Complication
-struct TrioAccessoryCornerView: View {
-    var entry: TrioWatchComplicationProvider.Entry
+/// Circular Complication - Main glucose display
+struct TrioAccessoryCircularView: View {
+    var entry: TrioWatchComplicationEntry
 
     var body: some View {
-        Text("")
-            .widgetCurvesContent()
-            .widgetLabel {
-                Text("Trio")
+        ZStack {
+            AccessoryWidgetBackground()
+
+            VStack(spacing: 1) {
+                // Main glucose value
+                Text(entry.isStale ? "--" : entry.glucoseValue)
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .foregroundStyle(entry.isStale ? .gray : entry.glucoseColor)
+                    .minimumScaleFactor(0.6)
+                    .lineLimit(1)
+
+                // Trend + Delta
+                HStack(spacing: 2) {
+                    Text(entry.trend)
+                        .font(.system(size: 12))
+                        .foregroundStyle(entry.isStale ? .gray : .primary)
+                    Text(entry.delta)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
-            .widgetBackground(backgroundView: Color.clear)
+            .padding(4)
+        }
     }
 }
 
-/// Circular Complication
-struct TrioAccessoryCircularView: View {
-    var entry: TrioWatchComplicationProvider.Entry
+/// Corner Complication - Compact glucose display
+struct TrioAccessoryCornerView: View {
+    var entry: TrioWatchComplicationEntry
 
     var body: some View {
-        Image("ComplicationIcon")
-            .resizable()
-            .widgetAccentable()
-            .widgetBackground(backgroundView: Color.clear)
+        ZStack {
+            AccessoryWidgetBackground()
+
+            HStack(spacing: 3) {
+                // Glucose value
+                Text(entry.isStale ? "--" : entry.glucoseValue)
+                    .font(.system(size: 16, weight: .bold, design: .rounded))
+                    .foregroundStyle(entry.isStale ? .gray : entry.glucoseColor)
+                    .minimumScaleFactor(0.7)
+
+                // Trend arrow
+                Text(entry.trend)
+                    .font(.system(size: 12))
+                    .foregroundStyle(entry.isStale ? .gray : .primary)
+            }
+        }
+        .widgetLabel {
+            Text(entry.delta)
+                .font(.system(size: 10))
+        }
+    }
+}
+
+/// Rectangular Complication - Full info display with IOB/COB
+struct TrioAccessoryRectangularView: View {
+    var entry: TrioWatchComplicationEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            // Top row: Glucose + Trend + Delta
+            HStack(spacing: 4) {
+                Text(entry.isStale ? "--" : entry.glucoseValue)
+                    .font(.system(size: 26, weight: .bold, design: .rounded))
+                    .foregroundStyle(entry.isStale ? .gray : entry.glucoseColor)
+
+                Text(entry.trend)
+                    .font(.system(size: 16))
+                    .foregroundStyle(entry.isStale ? .gray : .primary)
+
+                Text(entry.delta)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+            }
+
+            // Bottom row: IOB + COB
+            HStack(spacing: 12) {
+                if let iob = entry.iob, !entry.isStale {
+                    Text("IOB: \(iob)")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+                if let cob = entry.cob, !entry.isStale {
+                    Text("COB: \(cob)")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+    }
+}
+
+/// Inline Complication - Minimal glucose display
+struct TrioAccessoryInlineView: View {
+    var entry: TrioWatchComplicationEntry
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Text(entry.isStale ? "--" : entry.glucoseValue)
+                .foregroundStyle(entry.isStale ? .gray : entry.glucoseColor)
+            Text(entry.trend)
+                .foregroundStyle(entry.isStale ? .gray : .primary)
+            Text(entry.delta)
+                .foregroundStyle(.secondary)
+        }
+        .font(.system(size: 14, weight: .semibold, design: .rounded))
     }
 }
 
@@ -83,14 +265,18 @@ struct TrioAccessoryCircularView: View {
         StaticConfiguration(kind: kind, provider: TrioWatchComplicationProvider()) { entry in
             TrioWatchComplicationEntryView(entry: entry)
         }
-        .configurationDisplayName("Trio")
-        .description("Displays Trio app icon as complication")
+        .configurationDisplayName("Trio Glucose")
+        .description("Real-time blood glucose monitoring with trend and delta")
         .supportedFamilies([
+            .accessoryCircular,
             .accessoryCorner,
-            .accessoryCircular
+            .accessoryRectangular,
+            .accessoryInline
         ])
     }
 }
+
+// MARK: - Extensions
 
 extension View {
     func widgetBackground(backgroundView: some View) -> some View {
@@ -101,5 +287,36 @@ extension View {
         } else {
             return background(backgroundView)
         }
+    }
+}
+
+extension Color {
+    /// Initialize Color from hex string (supports #RRGGBB and #AARRGGBB formats)
+    init?(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 6: // RGB (no alpha)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            return nil
+        }
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}
+
+extension Bundle {
+    var appGroupSuiteName: String? {
+        object(forInfoDictionaryKey: "AppGroupID") as? String
     }
 }

--- a/Trio Watch Complication/TrioWatchComplication.swift
+++ b/Trio Watch Complication/TrioWatchComplication.swift
@@ -169,31 +169,20 @@ struct TrioAccessoryCircularView: View {
     }
 }
 
-/// Corner Complication - Compact glucose display
+/// Corner Complication - Glucose in corner with trend/delta curving around
 struct TrioAccessoryCornerView: View {
     var entry: TrioWatchComplicationEntry
 
     var body: some View {
-        ZStack {
-            AccessoryWidgetBackground()
-
-            HStack(spacing: 3) {
-                // Glucose value
-                Text(entry.isStale ? "--" : entry.glucoseValue)
-                    .font(.system(size: 16, weight: .bold, design: .rounded))
-                    .foregroundStyle(entry.isStale ? .gray : entry.glucoseColor)
-                    .minimumScaleFactor(0.7)
-
-                // Trend arrow
-                Text(entry.trend)
-                    .font(.system(size: 12))
-                    .foregroundStyle(entry.isStale ? .gray : .primary)
+        // Main content: just the glucose value, large and readable
+        Text(entry.isStale ? "--" : entry.glucoseValue)
+            .font(.system(size: 24, weight: .bold, design: .rounded))
+            .foregroundStyle(entry.isStale ? .gray : entry.glucoseColor)
+            .widgetCurvesContent()
+            .widgetLabel {
+                // Curved label around the corner: trend + delta
+                Text("\(entry.trend) \(entry.delta)")
             }
-        }
-        .widgetLabel {
-            Text(entry.delta)
-                .font(.system(size: 10))
-        }
     }
 }
 

--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -1275,6 +1275,8 @@
 		BDFF7A832D25F97D0016C40C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BDFF7A842D25F97D0016C40C /* TrioMainWatchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrioMainWatchView.swift; sourceTree = "<group>"; };
 		BDFF7A852D25F97D0016C40C /* TrioWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrioWatchApp.swift; sourceTree = "<group>"; };
+		8A868ECC22127EC03F3AA1EF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E37D295C37B7B9823FC34B8D /* TrioWatchApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TrioWatchApp.entitlements; sourceTree = "<group>"; };
 		BDFF7A8A2D25F97D0016C40C /* Unit Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Unit Tests.swift"; sourceTree = "<group>"; };
 		BDFF7A902D25F97D0016C40C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BDFF7A912D25F97D0016C40C /* TrioWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrioWatchApp.swift; sourceTree = "<group>"; };
@@ -3045,6 +3047,8 @@
 				BDFF7A9E2D25FA970016C40C /* Preview Content */,
 				BDFF7A832D25F97D0016C40C /* Assets.xcassets */,
 				BDFF7A852D25F97D0016C40C /* TrioWatchApp.swift */,
+				8A868ECC22127EC03F3AA1EF /* Info.plist */,
+				E37D295C37B7B9823FC34B8D /* TrioWatchApp.entitlements */,
 			);
 			path = "Trio Watch App Extension";
 			sourceTree = "<group>";
@@ -5183,10 +5187,12 @@
 		BD8207D02D2B42E80023339D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_GROUP_ID = "$(TRIO_APP_GROUP_ID)";
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = "Trio Watch Complication/TrioWatchComplication.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(APP_BUILD_NUMBER)";
@@ -5220,10 +5226,12 @@
 		BD8207D12D2B42E80023339D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_GROUP_ID = "$(TRIO_APP_GROUP_ID)";
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = "Trio Watch Complication/TrioWatchComplication.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(APP_BUILD_NUMBER)";
@@ -5256,10 +5264,12 @@
 		BDFF79A12D25AA890016C40C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_GROUP_ID = "$(TRIO_APP_GROUP_ID)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = "Trio Watch App Extension/TrioWatchApp.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(APP_BUILD_NUMBER)";
@@ -5269,6 +5279,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Trio Watch App Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Trio;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "$(BUNDLE_IDENTIFIER)";
@@ -5293,10 +5304,12 @@
 		BDFF79A22D25AA890016C40C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APP_GROUP_ID = "$(TRIO_APP_GROUP_ID)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = "Trio Watch App Extension/TrioWatchApp.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(APP_BUILD_NUMBER)";
@@ -5306,6 +5319,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Trio Watch App Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Trio;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = "$(BUNDLE_IDENTIFIER)";

--- a/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
+++ b/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
@@ -70,12 +70,15 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             .receive(on: DispatchQueue.global(qos: .background))
             .sink { [weak self] _ in
                 guard let self = self else { return }
-                // Skip if no watch is paired or app not installed
-                guard let session = self.session, session.isPaired, session.isReachable,
-                      session.isWatchAppInstalled else { return }
                 Task {
-                    let state = await self.setupWatchState()
-                    await self.sendDataToWatch(state)
+                    // Only send via WatchConnectivity if session is ready
+                    // The Watch App will persist data to its local App Group for the complication
+                    if let session = self.session, session.isPaired, session.isReachable,
+                       session.isWatchAppInstalled
+                    {
+                        let state = await self.setupWatchState()
+                        await self.sendDataToWatch(state)
+                    }
                 }
             }
             .store(in: &subscriptions)


### PR DESCRIPTION
## Summary

Add real-time blood glucose monitoring directly on the Apple Watch face via WidgetKit complications, without requiring the user to open the Watch app.

### Features
- Display current glucose value with color coding (red=low, yellow=high, green=in-range)
- Show trend arrow indicating glucose direction (→, ↑, ↓, ↑↑, ↓↓)
- Show delta (change from previous reading)
- Display IOB/COB in rectangular complication
- 15-minute staleness indicator shows "--" for outdated readings

### Supported Complication Families
| Family | Display |
|--------|---------|
| Circular | Glucose + trend + delta |
| Corner | Compact glucose + trend with delta label |
| Rectangular | Full display with glucose, trend, delta, IOB, COB |
| Inline | Minimal glucose + trend + delta |

## Technical Implementation

**Data Flow:**
```
iPhone App → WatchConnectivity → Watch App → Watch App Group → Complication
                                     ↓
                              WidgetCenter.reload()
```
### Files Changed
- `Trio Watch Complication/TrioWatchComplication.swift` - Complication views and provider
- `Trio Watch Complication/Info.plist` - Added AppGroupID key
- `Trio Watch Complication/TrioWatchComplication.entitlements` - App Group capability
- `Trio Watch App Extension/WatchState.swift` - Added persistence to App Group
- `Trio Watch App Extension/Info.plist` - Added AppGroupID key (new file)
- `Trio Watch App Extension/TrioWatchApp.entitlements` - App Group capability (new file)
- `Trio.xcodeproj/project.pbxproj` - Build settings for both targets
- `Trio/Sources/Services/WatchManager/AppleWatchManager.swift` - Removed broken iPhone-side persistence

## Required Setup

Users must configure App Groups in Apple Developer Portal:
1. Enable **App Groups** capability for Watch App identifier (`*.watchkitapp`)
2. Associate with the existing App Group: `group.org.nightscout.{TEAMID}.trio.trio-app-group`
3. Regenerate certificates and rebuild

## Known Limitations

| Limitation | Impact |
|------------|--------|
| WidgetKit budget ~40-50/day | Complication won't show every 5-min CGM reading |
| WatchConnectivity requires Watch App | User must open Watch App at least once |
| `transferUserInfo` has latency | Updates may be delayed by minutes |
| Background delivery not guaranteed | Complication may show stale data |

**User Experience:** The complication will update when budget allows (~every 30 min average), showing the most recent glucose. Between updates, the timestamp may show data as stale (displays "--").

## Test Plan

- [ ] Build and install on iPhone and Watch
- [ ] Open Watch App at least once to establish WatchConnectivity
- [ ] Add Trio complication to Watch face
- [ ] Verify glucose data appears after CGM reading
- [ ] Verify staleness indicator shows "--" after 15 minutes without update
- [ ] Test all complication families (Circular, Corner, Rectangular, Inline)

## Screenshots
![telegram-cloud-photo-size-1-4900418459536133150-x](https://github.com/user-attachments/assets/523d12ef-6d6e-4fca-9315-9269f591116f)

---