### PR TITLE
Fix and improve the Add Carbs shortcut

### DIFF
--- a/Trio/Sources/Shortcuts/Bolus/BolusIntent.swift
+++ b/Trio/Sources/Shortcuts/Bolus/BolusIntent.swift
@@ -3,7 +3,7 @@ import Foundation
 import Intents
 import Swinject
 
-@available(iOS 16.0,*) struct BolusIntent: AppIntent {
+struct BolusIntent: AppIntent {
     // Title of the action in the Shortcuts app
     static var title = LocalizedStringResource("Enact Bolus")
 

--- a/Trio/Sources/Shortcuts/Bolus/BolusIntentRequest.swift
+++ b/Trio/Sources/Shortcuts/Bolus/BolusIntentRequest.swift
@@ -2,7 +2,7 @@ import Combine
 import CoreData
 import Foundation
 
-@available(iOS 16.0,*) final class BolusIntentRequest: BaseIntentsRequest {
+final class BolusIntentRequest: BaseIntentsRequest {
     func bolus(_ bolusAmount: Double) async throws -> String {
         var bolusQuantity: Decimal = 0
         switch settingsManager.settings.bolusShortcut {

--- a/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
+++ b/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
@@ -15,24 +15,24 @@ struct AddCarbPresetIntent: AppIntent {
         description: "Quantity of carbs in g",
         controlStyle: .field,
         inclusiveRange: (lowerBound: 0, upperBound: 300),
-        requestValueDialog: IntentDialog(stringLiteral: String(localized: "How many grams of carbs did you eat?"))
     ) var carbQuantity: Double?
+        requestValueDialog: IntentDialog(stringLiteral: String(localized: "How many grams of carbs?"))
 
     @Parameter(
         title: "Quantity Fat",
         description: "Quantity of fat in g",
         default: 0.0,
         inclusiveRange: (0, 300),
-        requestValueDialog: IntentDialog(stringLiteral: String(localized: "How many grams of fat did you eat?"))
     ) var fatQuantity: Double
+        requestValueDialog: IntentDialog(stringLiteral: String(localized: "How many grams of fat?"))
 
     @Parameter(
         title: "Quantity Protein",
         description: "Quantity of Protein in g",
         default: 0.0,
         inclusiveRange: (0, 300),
-        requestValueDialog: IntentDialog(stringLiteral: String(localized: "How many grams of protein did you eat?"))
     ) var proteinQuantity: Double
+        requestValueDialog: IntentDialog(stringLiteral: String(localized: "How many grams of protein?"))
 
     @Parameter(
         title: "Date",

--- a/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
+++ b/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
@@ -46,7 +46,7 @@ struct AddCarbPresetIntent: AppIntent {
     ) var note: String?
 
     @Parameter(
-        title: "Confirm Before logging",
+        title: "Confirm Before Logging",
         description: "If toggled, you will need to confirm before logging",
         default: true
     ) var confirmBeforeApplying: Bool

--- a/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
+++ b/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
@@ -122,9 +122,19 @@ struct AddCarbPresetIntent: AppIntent {
             }
 
             if confirmBeforeApplying {
+                var confirmationMessage: String
+                confirmationMessage = String(localized: "Add \(quantityCarbs) g carbs")
+                if fatQuantity > 0 {
+                    confirmationMessage = String(localized: "\(confirmationMessage) and \(fatQuantity) g fat")
+                }
+                if proteinQuantity > 0 {
+                    confirmationMessage = String(localized: "\(confirmationMessage) and \(proteinQuantity) g protein")
+                }
+                confirmationMessage = String(localized: "\(confirmationMessage)?")
+
                 try await requestConfirmation(
                     result: .result(
-                        dialog: IntentDialog(stringLiteral: String(localized: "Add \(quantityCarbs) grams of carbs?"))
+                        dialog: IntentDialog(stringLiteral: confirmationMessage)
                     )
                 )
             }

--- a/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
+++ b/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
@@ -14,7 +14,7 @@ struct AddCarbPresetIntent: AppIntent {
         title: "Quantity Carbs",
         description: "Quantity of carbs in g",
         controlStyle: .field,
-        inclusiveRange: (lowerBound: 0, upperBound: 200),
+        inclusiveRange: (lowerBound: 0, upperBound: 300),
         requestValueDialog: IntentDialog(stringLiteral: String(localized: "How many grams of carbs did you eat?"))
     ) var carbQuantity: Double?
 
@@ -22,7 +22,7 @@ struct AddCarbPresetIntent: AppIntent {
         title: "Quantity Fat",
         description: "Quantity of fat in g",
         default: 0.0,
-        inclusiveRange: (0, 200),
+        inclusiveRange: (0, 300),
         requestValueDialog: IntentDialog(stringLiteral: String(localized: "How many grams of fat did you eat?"))
     ) var fatQuantity: Double
 
@@ -30,7 +30,7 @@ struct AddCarbPresetIntent: AppIntent {
         title: "Quantity Protein",
         description: "Quantity of Protein in g",
         default: 0.0,
-        inclusiveRange: (0, 200),
+        inclusiveRange: (0, 300),
         requestValueDialog: IntentDialog(stringLiteral: String(localized: "How many grams of protein did you eat?"))
     ) var proteinQuantity: Double
 

--- a/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
+++ b/Trio/Sources/Shortcuts/Carbs/AddCarbPresetIntent.swift
@@ -3,7 +3,7 @@ import Foundation
 import Intents
 import Swinject
 
-@available(iOS 16.0,*) struct AddCarbPresetIntent: AppIntent {
+struct AddCarbPresetIntent: AppIntent {
     // Title of the action in the Shortcuts app
     static var title: LocalizedStringResource = "Add carbs"
 

--- a/Trio/Sources/Shortcuts/Carbs/CarbPresetIntentRequest.swift
+++ b/Trio/Sources/Shortcuts/Carbs/CarbPresetIntentRequest.swift
@@ -11,7 +11,7 @@ final class CarbPresetIntentRequest: BaseIntentsRequest {
         _ dateDefinedByUser: Bool
     ) async throws -> String {
         guard quantityCarbs >= 0.0 || quantityFat >= 0.0 || quantityProtein >= 0.0 else {
-            return "not adding carbs in Trio"
+            return "Amount must be positive."
         }
 
         let carbs = min(Decimal(quantityCarbs), settingsManager.settings.maxCarbs)

--- a/Trio/Sources/Shortcuts/Carbs/CarbPresetIntentRequest.swift
+++ b/Trio/Sources/Shortcuts/Carbs/CarbPresetIntentRequest.swift
@@ -3,25 +3,23 @@ import Foundation
 
 final class CarbPresetIntentRequest: BaseIntentsRequest {
     func addCarbs(
-        _ quantityCarbs: Double,
-        _ quantityFat: Double,
-        _ quantityProtein: Double,
+        _ quantityCarbs: Int,
+        _ quantityFat: Int,
+        _ quantityProtein: Int,
         _ dateAdded: Date,
         _ note: String?,
         _ dateDefinedByUser: Bool
     ) async throws -> String {
-        guard quantityCarbs >= 0.0 || quantityFat >= 0.0 || quantityProtein >= 0.0 else {
+        guard quantityCarbs >= 0 || quantityFat >= 0 || quantityProtein >= 0 else {
             return "Amount must be positive."
         }
-
-        let carbs = min(Decimal(quantityCarbs), settingsManager.settings.maxCarbs)
 
         try await carbsStorage.storeCarbs(
             [CarbsEntry(
                 id: UUID().uuidString,
                 createdAt: dateAdded,
                 actualDate: dateAdded,
-                carbs: carbs,
+                carbs: Decimal(quantityCarbs),
                 fat: Decimal(quantityFat),
                 protein: Decimal(quantityProtein),
                 note: (note?.isEmpty ?? true) ? "Via Shortcut" : note!,
@@ -31,12 +29,12 @@ final class CarbPresetIntentRequest: BaseIntentsRequest {
             areFetchedFromRemote: false
         )
         var resultDisplay: String
-        resultDisplay = String(localized: "Added \(String(format: "%.0f", Double(carbs))) g carbs")
-        if quantityFat > 0.0 {
-            resultDisplay = String(localized: "\(resultDisplay) and \(String(format: "%.0f", Double(quantityFat))) g fat")
+        resultDisplay = String(localized: "Added \(quantityCarbs) g carbs")
+        if quantityFat > 0 {
+            resultDisplay = String(localized: "\(resultDisplay) and \(quantityFat) g fat")
         }
-        if quantityProtein > 0.0 {
-            resultDisplay = String(localized: "\(resultDisplay) and \(String(format: "%.0f", Double(quantityProtein))) g protein")
+        if quantityProtein > 0 {
+            resultDisplay = String(localized: "\(resultDisplay) and \(quantityProtein) g protein")
         }
         if dateDefinedByUser {
             let dateFormatter = DateFormatter()

--- a/Trio/Sources/Shortcuts/Carbs/CarbPresetIntentRequest.swift
+++ b/Trio/Sources/Shortcuts/Carbs/CarbPresetIntentRequest.swift
@@ -1,7 +1,7 @@
 import CoreData
 import Foundation
 
-@available(iOS 16.0,*) final class CarbPresetIntentRequest: BaseIntentsRequest {
+final class CarbPresetIntentRequest: BaseIntentsRequest {
     func addCarbs(
         _ quantityCarbs: Double,
         _ quantityFat: Double,


### PR DESCRIPTION
Address the following Issues:
* #967 
* #968 

This PR updates the Add Carbs shortcut to use `Int` instead of `Double` for the macronutrients. This addresses both Issues by removing the need for rounding as well as remove the need to format it for a String.

This PR also increases the maximum values of macronutrient entries to 300, which is the top of the range allowed for the Max Carbs/Fat/Protein settings in Trio. The shortcut also now fails with an error message and does not add anything if the users enters over the max amount. This is safer than before this PR where the carb entry is just quietly lowered to the Max Carbs setting and Max Fat/Protein aren't checked at all.

This PR also adds the Fat and Protein entries to the confirmation message.