### PR TITLE
fix: title on PM & CGM sheets

### DIFF
--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -1005,6 +1005,24 @@ extension Home {
             .navigationBarHidden(true)
             .ignoresSafeArea(.keyboard)
             .blur(radius: state.isLoopStatusPresented ? 3 : 0)
+            .sheet(isPresented: $state.isLoopStatusPresented) {
+                LoopStatusView(state: state)
+            }
+            .sheet(isPresented: $state.isLegendPresented) {
+                ChartLegendView(state: state)
+            }
+            .confirmationDialog("Pump Model", isPresented: $showPumpSelection) {
+                Button("Medtronic") { state.addPump(.minimed) }
+                Button("Omnipod Eros") { state.addPump(.omnipod) }
+                Button("Omnipod DASH") { state.addPump(.omnipodBLE) }
+                Button("Dana(RS/-i)") { state.addPump(.dana) }
+                Button("Pump Simulator") { state.addPump(.simulator) }
+            } message: { Text("Select Pump Model") }
+            .confirmationDialog("CGM Model", isPresented: $showCGMSelection) {
+                cgmSelectionButtons
+            } message: {
+                Text("Select CGM Model")
+            }
         }
 
         @ViewBuilder func tabBar() -> some View {
@@ -1027,21 +1045,6 @@ extension Home {
                     NavigationStack { mainView() }
                         .tabItem { Label("Main", systemImage: "chart.xyaxis.line") }
                         .badge(carbsRequiredBadge).tag(0)
-                        .sheet(isPresented: $state.isLoopStatusPresented) {
-                            LoopStatusView(state: state)
-                        }
-                        .sheet(isPresented: $state.isLegendPresented) {
-                            ChartLegendView(state: state)
-                        }
-                        // PUMP RELATED
-                        .confirmationDialog("Pump Model", isPresented: $showPumpSelection) {
-                            Button("Medtronic") { state.addPump(.minimed) }
-                            Button("Omnipod Eros") { state.addPump(.omnipod) }
-                            Button("Omnipod DASH") { state.addPump(.omnipodBLE) }
-                            Button("Dana(RS/-i)") { state.addPump(.dana) }
-                            Button("Medtrum Nano") { state.addPump(.medtrum) }
-                            Button("Pump Simulator") { state.addPump(.simulator) }
-                        } message: { Text("Select Pump Model") }
                         .sheet(isPresented: $state.shouldDisplayPumpSetupSheet) {
                             if let pumpManager = state.provider.apsManager.pumpManager {
                                 PumpConfig.PumpSettingsView(
@@ -1059,12 +1062,6 @@ extension Home {
                                     setupDelegate: state
                                 )
                             }
-                        }
-                        // CGM RELATED
-                        .confirmationDialog("CGM Model", isPresented: $showCGMSelection) {
-                            cgmSelectionButtons
-                        } message: {
-                            Text("Select CGM Model")
                         }
                         .sheet(isPresented: $state.shouldDisplayCGMSetupSheet) {
                             switch state.cgmCurrent.type {

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -987,24 +987,6 @@ extension Home {
                     }
                 }
             )
-        }
-
-        @ViewBuilder func mainView() -> some View {
-            GeometryReader { geo in
-                mainViewElements(geo)
-            }
-            .onChange(of: state.hours) {
-                highlightButtons()
-            }
-            .onAppear {
-                configureView {
-                    highlightButtons()
-                }
-            }
-            .navigationTitle("Home")
-            .navigationBarHidden(true)
-            .ignoresSafeArea(.keyboard)
-            .blur(radius: state.isLoopStatusPresented ? 3 : 0)
             .sheet(isPresented: $state.isLoopStatusPresented) {
                 LoopStatusView(state: state)
             }
@@ -1080,6 +1062,24 @@ extension Home {
                     }
                 }
             }
+        }
+
+        @ViewBuilder func mainView() -> some View {
+            GeometryReader { geo in
+                mainViewElements(geo)
+            }
+            .onChange(of: state.hours) {
+                highlightButtons()
+            }
+            .onAppear {
+                configureView {
+                    highlightButtons()
+                }
+            }
+            .navigationTitle("Home")
+            .navigationBarHidden(true)
+            .ignoresSafeArea(.keyboard)
+            .blur(radius: state.isLoopStatusPresented ? 3 : 0)
         }
 
         @ViewBuilder func tabBar() -> some View {

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -987,81 +987,6 @@ extension Home {
                     }
                 }
             )
-            .sheet(isPresented: $state.isLoopStatusPresented) {
-                LoopStatusView(state: state)
-            }
-            .sheet(isPresented: $state.isLegendPresented) {
-                ChartLegendView(state: state)
-            }
-            // PUMP RELATED
-            .confirmationDialog("Pump Model", isPresented: $showPumpSelection) {
-                Button("Medtronic") { state.addPump(.minimed) }
-                Button("Omnipod Eros") { state.addPump(.omnipod) }
-                Button("Omnipod DASH") { state.addPump(.omnipodBLE) }
-                Button("Dana(RS/-i)") { state.addPump(.dana) }
-                Button("Pump Simulator") { state.addPump(.simulator) }
-            } message: { Text("Select Pump Model") }
-            .sheet(isPresented: $state.shouldDisplayPumpSetupSheet) {
-                if let pumpManager = state.provider.apsManager.pumpManager {
-                    PumpConfig.PumpSettingsView(
-                        pumpManager: pumpManager,
-                        bluetoothManager: state.provider.apsManager.bluetoothManager!,
-                        completionDelegate: state,
-                        setupDelegate: state
-                    )
-                } else {
-                    PumpConfig.PumpSetupView(
-                        pumpType: state.setupPumpType,
-                        pumpInitialSettings: state.pumpInitialSettings,
-                        bluetoothManager: state.provider.apsManager.bluetoothManager!,
-                        completionDelegate: state,
-                        setupDelegate: state
-                    )
-                }
-            }
-            // CGM RELATED
-            .confirmationDialog("CGM Model", isPresented: $showCGMSelection) {
-                cgmSelectionButtons
-            } message: {
-                Text("Select CGM Model")
-            }
-            .sheet(isPresented: $state.shouldDisplayCGMSetupSheet) {
-                switch state.cgmCurrent.type {
-                case .enlite,
-                     .nightscout,
-                     .none,
-                     .simulator,
-                     .xdrip:
-                    CGMSettings.CustomCGMOptionsView(
-                        resolver: self.resolver,
-                        state: state.cgmStateModel,
-                        cgmCurrent: state.cgmCurrent,
-                        deleteCGM: state.deleteCGM
-                    )
-                case .plugin:
-                    if let fetchGlucoseManager = state.fetchGlucoseManager,
-                       let cgmManager = fetchGlucoseManager.cgmManager,
-                       state.cgmCurrent.type == fetchGlucoseManager.cgmGlucoseSourceType,
-                       state.cgmCurrent.id == fetchGlucoseManager.cgmGlucosePluginId
-                    {
-                        CGMSettings.CGMSettingsView(
-                            cgmManager: cgmManager,
-                            bluetoothManager: state.provider.apsManager.bluetoothManager!,
-                            unit: state.settingsManager.settings.units,
-                            completionDelegate: state
-                        )
-                    } else {
-                        CGMSettings.CGMSetupView(
-                            CGMType: state.cgmCurrent,
-                            bluetoothManager: state.provider.apsManager.bluetoothManager!,
-                            unit: state.settingsManager.settings.units,
-                            completionDelegate: state,
-                            setupDelegate: state,
-                            pluginCGMManager: self.state.pluginCGMManager
-                        )
-                    }
-                }
-            }
         }
 
         @ViewBuilder func mainView() -> some View {
@@ -1102,6 +1027,82 @@ extension Home {
                     NavigationStack { mainView() }
                         .tabItem { Label("Main", systemImage: "chart.xyaxis.line") }
                         .badge(carbsRequiredBadge).tag(0)
+                        .sheet(isPresented: $state.isLoopStatusPresented) {
+                            LoopStatusView(state: state)
+                        }
+                        .sheet(isPresented: $state.isLegendPresented) {
+                            ChartLegendView(state: state)
+                        }
+                        // PUMP RELATED
+                        .confirmationDialog("Pump Model", isPresented: $showPumpSelection) {
+                            Button("Medtronic") { state.addPump(.minimed) }
+                            Button("Omnipod Eros") { state.addPump(.omnipod) }
+                            Button("Omnipod DASH") { state.addPump(.omnipodBLE) }
+                            Button("Dana(RS/-i)") { state.addPump(.dana) }
+                            Button("Medtrum Nano") { state.addPump(.medtrum) }
+                            Button("Pump Simulator") { state.addPump(.simulator) }
+                        } message: { Text("Select Pump Model") }
+                        .sheet(isPresented: $state.shouldDisplayPumpSetupSheet) {
+                            if let pumpManager = state.provider.apsManager.pumpManager {
+                                PumpConfig.PumpSettingsView(
+                                    pumpManager: pumpManager,
+                                    bluetoothManager: state.provider.apsManager.bluetoothManager!,
+                                    completionDelegate: state,
+                                    setupDelegate: state
+                                )
+                            } else {
+                                PumpConfig.PumpSetupView(
+                                    pumpType: state.setupPumpType,
+                                    pumpInitialSettings: state.pumpInitialSettings,
+                                    bluetoothManager: state.provider.apsManager.bluetoothManager!,
+                                    completionDelegate: state,
+                                    setupDelegate: state
+                                )
+                            }
+                        }
+                        // CGM RELATED
+                        .confirmationDialog("CGM Model", isPresented: $showCGMSelection) {
+                            cgmSelectionButtons
+                        } message: {
+                            Text("Select CGM Model")
+                        }
+                        .sheet(isPresented: $state.shouldDisplayCGMSetupSheet) {
+                            switch state.cgmCurrent.type {
+                            case .enlite,
+                                 .nightscout,
+                                 .none,
+                                 .simulator,
+                                 .xdrip:
+                                CGMSettings.CustomCGMOptionsView(
+                                    resolver: self.resolver,
+                                    state: state.cgmStateModel,
+                                    cgmCurrent: state.cgmCurrent,
+                                    deleteCGM: state.deleteCGM
+                                )
+                            case .plugin:
+                                if let fetchGlucoseManager = state.fetchGlucoseManager,
+                                   let cgmManager = fetchGlucoseManager.cgmManager,
+                                   state.cgmCurrent.type == fetchGlucoseManager.cgmGlucoseSourceType,
+                                   state.cgmCurrent.id == fetchGlucoseManager.cgmGlucosePluginId
+                                {
+                                    CGMSettings.CGMSettingsView(
+                                        cgmManager: cgmManager,
+                                        bluetoothManager: state.provider.apsManager.bluetoothManager!,
+                                        unit: state.settingsManager.settings.units,
+                                        completionDelegate: state
+                                    )
+                                } else {
+                                    CGMSettings.CGMSetupView(
+                                        CGMType: state.cgmCurrent,
+                                        bluetoothManager: state.provider.apsManager.bluetoothManager!,
+                                        unit: state.settingsManager.settings.units,
+                                        completionDelegate: state,
+                                        setupDelegate: state,
+                                        pluginCGMManager: self.state.pluginCGMManager
+                                    )
+                                }
+                            }
+                        }
 
                     NavigationStack { History.RootView(resolver: resolver) }
                         .tabItem { Label("History", systemImage: historySFSymbol) }.tag(1)


### PR DESCRIPTION
In the recent iOS 26.2 update, we've seen a bug where the title of the PM or CGM isn't shown. More details see: #950.
This PR fixes this:

The issue is related to the GeometryReader. This function is not considered a view by the new iOS 26.2+, which causes the CGM & Pump sheets to be detached from the NavigationStack.

<details><summary><h3>Before video using DanaKit</h3></summary>
<p>

<video src="https://github.com/user-attachments/assets/0f037230-288b-4681-9be0-210f665cc968"></video>

</p>
</details> 

<details><summary><h3>After video using DanaKit</h3></summary>
<p>

<video src="https://github.com/user-attachments/assets/720c1ede-e6e5-4c9e-bfe2-984be5756ee3"></video>

</p>
</details> 