### PR TITLE
Add CGM status highlight

### DIFF
--- a/Trio/Sources/APS/CGM/AppGroupSource.swift
+++ b/Trio/Sources/APS/CGM/AppGroupSource.swift
@@ -26,6 +26,7 @@ public extension GlucoseTrend {
 
 struct AppGroupSource: GlucoseSource {
     let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
+    let cgmProgressHighlight = CurrentValueSubject<LoopKit.DeviceLifecycleProgress?, Never>(nil)
     var cgmManager: CGMManagerUI?
     var glucoseManager: FetchGlucoseManager?
     let from: String

--- a/Trio/Sources/APS/CGM/AppGroupSource.swift
+++ b/Trio/Sources/APS/CGM/AppGroupSource.swift
@@ -25,6 +25,7 @@ public extension GlucoseTrend {
 }
 
 struct AppGroupSource: GlucoseSource {
+    let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
     var cgmManager: CGMManagerUI?
     var glucoseManager: FetchGlucoseManager?
     let from: String

--- a/Trio/Sources/APS/CGM/GlucoseSimulatorSource.swift
+++ b/Trio/Sources/APS/CGM/GlucoseSimulatorSource.swift
@@ -14,7 +14,13 @@
 
 import Combine
 import Foundation
+import LoopKit
 import LoopKitUI
+
+struct SimProgress: LoopKit.DeviceLifecycleProgress {
+    var percentComplete: Double
+    var progressState: LoopKit.DeviceLifecycleProgressState
+}
 
 // MARK: - Glucose simulator
 
@@ -23,6 +29,7 @@ import LoopKitUI
 /// using different generator strategies.
 final class GlucoseSimulatorSource: GlucoseSource {
     let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
+    let cgmProgressHighlight = CurrentValueSubject<LoopKit.DeviceLifecycleProgress?, Never>(nil)
     var cgmManager: CGMManagerUI?
     var glucoseManager: FetchGlucoseManager?
 
@@ -50,6 +57,11 @@ final class GlucoseSimulatorSource: GlucoseSource {
             }
             lastFetchDate = lastDate
         }
+
+        cgmProgressHighlight.value = SimProgress(
+            percentComplete: 0.85,
+            progressState: .warning
+        )
     }
 
     /// The glucose generator used to create simulated values
@@ -72,6 +84,11 @@ final class GlucoseSimulatorSource: GlucoseSource {
     /// - Parameter timer: Optional dispatch timer (not used in this implementation)
     /// - Returns: A publisher that emits an array of BloodGlucose objects
     func fetch(_: DispatchTimer?) -> AnyPublisher<[BloodGlucose], Never> {
+        cgmProgressHighlight.value = SimProgress(
+            percentComplete: 0.85,
+            progressState: .warning
+        )
+
         guard canGenerateNewValues else {
             return Just([]).eraseToAnyPublisher()
         }

--- a/Trio/Sources/APS/CGM/GlucoseSimulatorSource.swift
+++ b/Trio/Sources/APS/CGM/GlucoseSimulatorSource.swift
@@ -22,6 +22,7 @@ import LoopKitUI
 /// This class implements the GlucoseSource protocol and provides simulated glucose readings
 /// using different generator strategies.
 final class GlucoseSimulatorSource: GlucoseSource {
+    let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
     var cgmManager: CGMManagerUI?
     var glucoseManager: FetchGlucoseManager?
 

--- a/Trio/Sources/APS/CGM/GlucoseSource.swift
+++ b/Trio/Sources/APS/CGM/GlucoseSource.swift
@@ -11,6 +11,7 @@ protocol GlucoseSource: SourceInfoProvider {
     func fetchIfNeeded() -> AnyPublisher<[BloodGlucose], Never>
     var glucoseManager: FetchGlucoseManager? { get set }
     var cgmManager: CGMManagerUI? { get set }
+    var cgmDisplayState: CurrentValueSubject<CgmDisplayState?, Never> { get }
 }
 
 extension GlucoseSource {

--- a/Trio/Sources/APS/CGM/GlucoseSource.swift
+++ b/Trio/Sources/APS/CGM/GlucoseSource.swift
@@ -11,6 +11,7 @@ protocol GlucoseSource: SourceInfoProvider {
     func fetchIfNeeded() -> AnyPublisher<[BloodGlucose], Never>
     var glucoseManager: FetchGlucoseManager? { get set }
     var cgmManager: CGMManagerUI? { get set }
+    var cgmProgressHighlight: CurrentValueSubject<LoopKit.DeviceLifecycleProgress?, Never> { get }
     var cgmDisplayState: CurrentValueSubject<CgmDisplayState?, Never> { get }
 }
 

--- a/Trio/Sources/APS/CGM/PluginSource.swift
+++ b/Trio/Sources/APS/CGM/PluginSource.swift
@@ -11,6 +11,7 @@ final class PluginSource: GlucoseSource {
     private let glucoseStorage: GlucoseStorage!
 
     let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
+    let cgmProgressHighlight = CurrentValueSubject<LoopKit.DeviceLifecycleProgress?, Never>(nil)
     var glucoseManager: FetchGlucoseManager?
 
     var cgmManager: CGMManagerUI? {
@@ -22,6 +23,12 @@ final class PluginSource: GlucoseSource {
                 )
             } else {
                 cgmDisplayState.value = nil
+            }
+
+            if let progress = cgmManager?.cgmLifecycleProgress {
+                cgmProgressHighlight.value = progress
+            } else {
+                cgmProgressHighlight.value = nil
             }
         }
     }
@@ -191,6 +198,12 @@ extension PluginSource: CGMManagerDelegate {
                 )
             } else {
                 cgmDisplayState.value = nil
+            }
+
+            if let progress = self.cgmManager?.cgmLifecycleProgress {
+                cgmProgressHighlight.value = progress
+            } else {
+                cgmProgressHighlight.value = nil
             }
         }
     }

--- a/Trio/Sources/APS/CGM/PluginSource.swift
+++ b/Trio/Sources/APS/CGM/PluginSource.swift
@@ -9,9 +9,22 @@ import LoopKitUI
 final class PluginSource: GlucoseSource {
     private let processQueue = DispatchQueue(label: "CGMPluginSource.processQueue")
     private let glucoseStorage: GlucoseStorage!
+
+    let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
     var glucoseManager: FetchGlucoseManager?
 
-    var cgmManager: CGMManagerUI?
+    var cgmManager: CGMManagerUI? {
+        didSet {
+            if let highlight = cgmManager?.cgmStatusHighlight {
+                cgmDisplayState.value = CgmDisplayState(
+                    localizedMessage: highlight.localizedMessage,
+                    status: CgmDisplayStatus.from(highlight.state)
+                )
+            } else {
+                cgmDisplayState.value = nil
+            }
+        }
+    }
 
     var cgmHasValidSensorSession: Bool = false
 
@@ -170,6 +183,15 @@ extension PluginSource: CGMManagerDelegate {
                 cgmGlucosePluginId: fetchGlucoseManager.settingsManager.settings.cgmPluginIdentifier,
                 newManager: cgmManager as? CGMManagerUI
             )
+
+            if let cgmHightlight = self.cgmManager?.cgmStatusHighlight {
+                cgmDisplayState.value = CgmDisplayState(
+                    localizedMessage: cgmHightlight.localizedMessage,
+                    status: CgmDisplayStatus.from(cgmHightlight.state)
+                )
+            } else {
+                cgmDisplayState.value = nil
+            }
         }
     }
 

--- a/Trio/Sources/APS/DeviceDataManager.swift
+++ b/Trio/Sources/APS/DeviceDataManager.swift
@@ -291,6 +291,7 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
 
     var glucoseManager: FetchGlucoseManager?
     let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
+    let cgmProgressHighlight = CurrentValueSubject<LoopKit.DeviceLifecycleProgress?, Never>(nil)
     var cgmManager: CGMManagerUI?
     var cgmType: CGMType = .enlite
 

--- a/Trio/Sources/APS/DeviceDataManager.swift
+++ b/Trio/Sources/APS/DeviceDataManager.swift
@@ -290,6 +290,7 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
     @Persisted(key: "BaseDeviceDataManager.lastFetchGlucoseDate") private var lastFetchGlucoseDate: Date = .distantPast
 
     var glucoseManager: FetchGlucoseManager?
+    let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
     var cgmManager: CGMManagerUI?
     var cgmType: CGMType = .enlite
 

--- a/Trio/Sources/APS/FetchGlucoseManager.swift
+++ b/Trio/Sources/APS/FetchGlucoseManager.swift
@@ -14,6 +14,7 @@ protocol FetchGlucoseManager: SourceInfoProvider {
     func newGlucoseFromCgmManager(newGlucose: [BloodGlucose])
     var glucoseSource: GlucoseSource? { get }
     var cgmManager: CGMManagerUI? { get }
+    var cgmDisplayState: CurrentValueSubject<CgmDisplayState?, Never> { get }
     var cgmGlucoseSourceType: CGMType { get set }
     var cgmGlucosePluginId: String { get }
     var settingsManager: SettingsManager! { get }
@@ -141,7 +142,20 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
         }
     }
 
-    var glucoseSource: GlucoseSource?
+    let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
+    var glucoseSource: GlucoseSource? {
+        didSet {
+            guard let glucoseSource else {
+                return
+            }
+
+            glucoseSource.cgmDisplayState.receive(on: DispatchQueue.main)
+                .sink { [weak self] state in
+                    self?.cgmDisplayState.value = state
+                }
+                .store(in: &lifetime)
+        }
+    }
 
     func removeCalibrations() {
         calibrationService.removeAllCalibrations()

--- a/Trio/Sources/APS/FetchGlucoseManager.swift
+++ b/Trio/Sources/APS/FetchGlucoseManager.swift
@@ -15,6 +15,7 @@ protocol FetchGlucoseManager: SourceInfoProvider {
     var glucoseSource: GlucoseSource? { get }
     var cgmManager: CGMManagerUI? { get }
     var cgmDisplayState: CurrentValueSubject<CgmDisplayState?, Never> { get }
+    var cgmProgressHighlight: CurrentValueSubject<LoopKit.DeviceLifecycleProgress?, Never> { get }
     var cgmGlucoseSourceType: CGMType { get set }
     var cgmGlucosePluginId: String { get }
     var settingsManager: SettingsManager! { get }
@@ -143,6 +144,7 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
     }
 
     let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
+    let cgmProgressHighlight = CurrentValueSubject<LoopKit.DeviceLifecycleProgress?, Never>(nil)
     var glucoseSource: GlucoseSource? {
         didSet {
             guard let glucoseSource else {
@@ -152,6 +154,12 @@ final class BaseFetchGlucoseManager: FetchGlucoseManager, Injectable {
             glucoseSource.cgmDisplayState.receive(on: DispatchQueue.main)
                 .sink { [weak self] state in
                     self?.cgmDisplayState.value = state
+                }
+                .store(in: &lifetime)
+
+            glucoseSource.cgmProgressHighlight.receive(on: DispatchQueue.main)
+                .sink { [weak self] state in
+                    self?.cgmProgressHighlight.value = state
                 }
                 .store(in: &lifetime)
         }

--- a/Trio/Sources/Modules/CGMSettings/CGMSettingsDataFlow.swift
+++ b/Trio/Sources/Modules/CGMSettings/CGMSettingsDataFlow.swift
@@ -1,5 +1,42 @@
+import LoopKit
+import SwiftUI
+
 enum CGMSettings {
     enum Config {}
+}
+
+struct CgmDisplayState {
+    let localizedMessage: String
+    let status: CgmDisplayStatus
+}
+
+enum CgmDisplayStatus {
+    case normal
+    case warning
+    case critical
+
+    var color: Color {
+        switch self {
+        case .critical:
+            return .critical
+        case .warning:
+            return .warning
+        case .normal:
+            return .loopAccent
+        }
+    }
+
+    static func from(_ state: LoopKit.DeviceStatusHighlightState) -> CgmDisplayStatus {
+        switch state {
+        case .normalCGM,
+             .normalPump:
+            return .normal
+        case .warning:
+            return .warning
+        case .critical:
+            return .critical
+        }
+    }
 }
 
 protocol CGMSettingsProvider: Provider {}

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -101,6 +101,7 @@ extension Home {
         var tempTargetRunStored: [TempTargetRunStored] = []
         var isOverrideCancelled: Bool = false
         var preprocessedData: [(id: UUID, forecast: Forecast, forecastValue: ForecastValue)] = []
+        var cgmHighlight: CgmDisplayState?
         var pumpStatusHighlightMessage: String?
         var pumpStatusBadgeImage: UIImage?
         var pumpStatusBadgeColor: Color?
@@ -378,6 +379,15 @@ extension Home {
                         self.displayPumpStatusBadge()
                         self.setupBatteryArray()
                     }
+                }
+                .store(in: &lifetime)
+
+            fetchGlucoseManager.cgmDisplayState
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] state in
+                    guard let self = self else { return }
+
+                    self.cgmHighlight = state
                 }
                 .store(in: &lifetime)
         }

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -102,6 +102,7 @@ extension Home {
         var isOverrideCancelled: Bool = false
         var preprocessedData: [(id: UUID, forecast: Forecast, forecastValue: ForecastValue)] = []
         var cgmHighlight: CgmDisplayState?
+        var cgmLifetimeProgress: LoopKit.DeviceLifecycleProgress?
         var pumpStatusHighlightMessage: String?
         var pumpStatusBadgeImage: UIImage?
         var pumpStatusBadgeColor: Color?
@@ -388,6 +389,15 @@ extension Home {
                     guard let self = self else { return }
 
                     self.cgmHighlight = state
+                }
+                .store(in: &lifetime)
+
+            fetchGlucoseManager.cgmProgressHighlight
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] state in
+                    guard let self = self else { return }
+
+                    self.cgmLifetimeProgress = state
                 }
                 .store(in: &lifetime)
         }

--- a/Trio/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
@@ -1,4 +1,5 @@
 import CoreData
+import LoopKit
 import SwiftUI
 
 struct CurrentGlucoseView: View {
@@ -11,6 +12,7 @@ struct CurrentGlucoseView: View {
     var currentGlucoseTarget: Decimal
     let glucoseColorScheme: GlucoseColorScheme
     let glucose: [GlucoseStored] // This contains the last two glucose values, no matter if its manual or a cgm reading
+    let progressHightlight: LoopKit.DeviceLifecycleProgress?
     @State private var rotationDegrees: Double = 0.0
     @State private var angularGradient = AngularGradient(colors: [
         Color(red: 0.7215686275, green: 0.3411764706, blue: 1),
@@ -20,6 +22,7 @@ struct CurrentGlucoseView: View {
         Color(red: 0.262745098, green: 0.7333333333, blue: 0.9137254902),
         Color(red: 0.7215686275, green: 0.3411764706, blue: 1)
     ], center: .center, startAngle: .degrees(270), endAngle: .degrees(-90))
+    @State private var showProgress = false
 
     @Environment(\.colorScheme) var colorScheme
 
@@ -80,17 +83,31 @@ struct CurrentGlucoseView: View {
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    HStack {
-                        let minutesAgoString = TimeAgoFormatter.minutesAgo(from: glucose.last?.date)
-                        Group {
-                            Text(minutesAgoString)
-                            Text(delta)
+                    if let progress = progressHightlight, showProgress {
+                        SwiftUI.ProgressView(value: progress.percentComplete)
+                            .frame(width: 75)
+                            .scaleEffect(x: 1, y: 2, anchor: .bottom)
+                            .tint(.orange)
+                            .padding(.top, -10)
+                            .transition(.opacity)
+                    } else {
+                        HStack {
+                            let minutesAgoString = TimeAgoFormatter.minutesAgo(from: glucose.last?.date)
+                            Group {
+                                Text(minutesAgoString)
+                                Text(delta)
+                            }
+                            .font(.callout).fontWeight(.bold)
+                            .foregroundStyle(colorScheme == .dark ? Color.white.opacity(0.9) : Color.secondary)
                         }
-                        .font(.callout).fontWeight(.bold)
-                        .foregroundStyle(colorScheme == .dark ? Color.white.opacity(0.9) : Color.secondary)
+                        .frame(alignment: .top)
+                        .transition(.opacity)
                     }
-                    .frame(alignment: .top)
                 }
+            }
+            .animation(.easeInOut(duration: 0.6), value: showProgress)
+            .onAppear {
+                startLoop()
             }
             .onChange(of: glucose.last?.directionEnum) {
                 withAnimation {
@@ -145,6 +162,14 @@ struct CurrentGlucoseView: View {
         }
         let delta = lastGlucose - secondLastGlucose
         return deltaFormatter.string(from: delta as NSNumber) ?? "--"
+    }
+
+    private func startLoop() {
+        Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { _ in
+            withAnimation {
+                showProgress.toggle()
+            }
+        }
     }
 }
 

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -151,7 +151,8 @@ extension Home {
                 cgmAvailable: state.cgmAvailable,
                 currentGlucoseTarget: state.currentGlucoseTarget,
                 glucoseColorScheme: state.glucoseColorScheme,
-                glucose: state.latestTwoGlucoseValues
+                glucose: state.latestTwoGlucoseValues,
+                progressHightlight: state.cgmLifetimeProgress
             ).scaleEffect(0.9)
                 .onTapGesture {
                     if !state.cgmAvailable {

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -112,6 +112,25 @@ extension Home {
             )
         }
 
+        @ViewBuilder func cgmHighlightView(_ message: String, _ displayState: CgmDisplayStatus) -> some View {
+            HStack {
+                Text(message)
+                    .bold()
+                    .font(.system(size: 14))
+                    .foregroundStyle(displayState.color)
+            }
+            .onTapGesture {
+                state.shouldDisplayCGMSetupSheet.toggle()
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 5)
+            .padding(.horizontal, 10)
+            .overlay(
+                Capsule()
+                    .stroke(displayState.color.opacity(0.4), lineWidth: 2)
+            )
+        }
+
         var cgmSelectionButtons: some View {
             ForEach(cgmOptions, id: \.name) { option in
                 if let cgm = state.listOfCGM.first(where: option.predicate) {
@@ -933,9 +952,11 @@ extension Home {
                 .safeAreaInset(edge: .top, spacing: 0) {
                     if notificationsDisabled {
                         alertSafetyNotificationsView(geo: geo)
-                    }
-                    if let badgeImage = state.pumpStatusBadgeImage, let badgeColor = state.pumpStatusBadgeColor {
+                    } else if let badgeImage = state.pumpStatusBadgeImage, let badgeColor = state.pumpStatusBadgeColor {
                         pumpTimezoneView(badgeImage, badgeColor)
+                            .padding(.horizontal, 20)
+                    } else if let cgmAlert = state.cgmHighlight {
+                        cgmHighlightView(cgmAlert.localizedMessage, cgmAlert.status)
                             .padding(.horizontal, 20)
                     }
                 }

--- a/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
+++ b/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
@@ -1,6 +1,7 @@
 import Combine
 import CoreData
 import Foundation
+import LoopKit
 import LoopKitUI
 import Swinject
 import UIKit
@@ -45,6 +46,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
     private var ping: TimeInterval?
 
     let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
+    let cgmProgressHighlight = CurrentValueSubject<LoopKit.DeviceLifecycleProgress?, Never>(nil)
 
     // Queue where upload pipelines run.
     let uploadPipelineQueue = DispatchQueue(label: "NightscoutManager.uploadPipelines", qos: .utility)

--- a/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
+++ b/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
@@ -44,6 +44,8 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
     private let processQueue = DispatchQueue(label: "BaseNetworkManager.processQueue")
     private var ping: TimeInterval?
 
+    let cgmDisplayState = CurrentValueSubject<CgmDisplayState?, Never>(nil)
+
     // Queue where upload pipelines run.
     let uploadPipelineQueue = DispatchQueue(label: "NightscoutManager.uploadPipelines", qos: .utility)
 


### PR DESCRIPTION
With CGM's like Eversense and Accu Chek, it is important to be aware of any required actions, like calibrations or critical issues. LoopKit provides the `cgmStatusHighlight` for this use case. Currently, only the G7 CGM has implemented this, but I believe this should be implemented in every CGMKit and Trio should show this highlight.

Current proposal (when clicking on the badge the CGM sheet opens, design is copied from the pump timezone warning):

<img width="300" alt="IMG_1385" src="https://github.com/user-attachments/assets/2d9eeb19-6f48-421d-951a-c2aa90a8967c" />
<img width="300" alt="IMG_1386" src="https://github.com/user-attachments/assets/adf4ad76-4927-4840-b843-75e597901ed4" />



If this proposal gets approved, the following items need to be done:
- [ ] Are we cool with the current design?
- [ ] Should we show all highlights or only warning/critical? -> Should we show `Searching for sensor` [link](https://loopkit.github.io/loopdocs/loop-3/add-cgm/#dexcom-g7-or-one)
- [ ] Do we want to show the image?
- [ ] Implement `cgmStatusHighlight` on other CGMKit's, like LibreTransmitter, G6/G7, EversenseKit
