### PR TITLE
feature: Hide SMB doses from MainChart

### DIFF
--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -54,6 +54,7 @@ struct TrioSettings: JSON, Equatable {
     var xGridLines: Bool = true
     var yGridLines: Bool = true
     var rulerMarks: Bool = true
+    var showSmbInChart: Bool = true
     var forecastDisplayType: ForecastDisplayType = .cone
     var maxCarbs: Decimal = 250
     var maxFat: Decimal = 250

--- a/Trio/Sources/Modules/Home/HomeStateModel+Setup/PumpHistorySetup.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel+Setup/PumpHistorySetup.swift
@@ -38,6 +38,11 @@ extension Home.StateModel {
     }
 
     @MainActor private func updateInsulinArray(with insulinObjects: [PumpEventStored]) {
+        var insulinObjects = insulinObjects
+        if !showSmb {
+            insulinObjects = insulinObjects.filter({ $0.bolus == nil || $0.bolus?.isSMB != true })
+        }
+
         insulinFromPersistence = insulinObjects
 
         manualTempBasal = apsManager.isManualTempBasal

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -76,6 +76,7 @@ extension Home {
         var displayXgridLines: Bool = false
         var displayYgridLines: Bool = false
         var thresholdLines: Bool = false
+        var showSmb: Bool = true
         var hours: Int16 = 6
         var totalBolus: Decimal = 0
         var isLoopStatusPresented: Bool = false
@@ -404,6 +405,7 @@ extension Home {
             eA1cDisplayUnit = settingsManager.settings.eA1cDisplayUnit
             displayXgridLines = settingsManager.settings.xGridLines
             displayYgridLines = settingsManager.settings.yGridLines
+            showSmb = settingsManager.settings.showSmbInChart
             thresholdLines = settingsManager.settings.rulerMarks
             showCarbsRequiredBadge = settingsManager.settings.showCarbsRequiredBadge
             forecastDisplayType = settingsManager.settings.forecastDisplayType
@@ -668,12 +670,14 @@ extension Home.StateModel:
         displayXgridLines = settingsManager.settings.xGridLines
         displayYgridLines = settingsManager.settings.yGridLines
         thresholdLines = settingsManager.settings.rulerMarks
+        showSmb = settingsManager.settings.showSmbInChart
         showCarbsRequiredBadge = settingsManager.settings.showCarbsRequiredBadge
         forecastDisplayType = settingsManager.settings.forecastDisplayType
         cgmAvailable = (fetchGlucoseManager.cgmGlucoseSourceType != CGMType.none)
         displayPumpStatusHighlightMessage()
         displayPumpStatusBadge()
         setupBatteryArray()
+        setupInsulinArray()
         Task {
             await setupCGMSettings()
         }

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
@@ -7,6 +7,7 @@ extension UserInterfaceSettings {
         @Published var xGridLines = false
         @Published var yGridLines: Bool = false
         @Published var rulerMarks: Bool = true
+        @Published var showSmbInChart: Bool = true
         @Published var forecastDisplayType: ForecastDisplayType = .cone
         @Published var showCarbsRequiredBadge: Bool = true
         @Published var carbsRequiredThreshold: Decimal = 0
@@ -23,6 +24,7 @@ extension UserInterfaceSettings {
             subscribeSetting(\.xGridLines, on: $xGridLines) { xGridLines = $0 }
             subscribeSetting(\.yGridLines, on: $yGridLines) { yGridLines = $0 }
             subscribeSetting(\.rulerMarks, on: $rulerMarks) { rulerMarks = $0 }
+            subscribeSetting(\.showSmbInChart, on: $showSmbInChart) { showSmbInChart = $0 }
 
             subscribeSetting(\.forecastDisplayType, on: $forecastDisplayType) { forecastDisplayType = $0 }
 

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -162,6 +162,7 @@ extension UserInterfaceSettings {
                         VStack {
                             Toggle("Show X-Axis Grid Lines", isOn: $state.xGridLines)
                             Toggle("Show Y-Axis Grid Lines", isOn: $state.yGridLines)
+                            Toggle("Show SMB in Chart", isOn: $state.showSmbInChart)
 
                             HStack(alignment: .center) {
                                 Text(


### PR DESCRIPTION
Based on feedback from a Discord user, I've added a toggle which allows a user to hide SMB doses from the main chart.

This might be a controversial PR, but I wanted to share this feature to see how the rest is feeling about it.

Screenshots:

<img height="500" alt="IMG_1408" src="https://github.com/user-attachments/assets/62a63ac6-f07f-4778-b8c1-050f2e3e4186" />
<img height="500" alt="IMG_1407" src="https://github.com/user-attachments/assets/15b6c2c4-29a1-4a47-a8da-c76aeba3c449" />
