### PR TITLE
feature: hide SMB label

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		3BD9687F2D8DDD8800899469 /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3BD9687E2D8DDD8800899469 /* CryptoSwift */; };
 		3BF85FE32E427312000D7351 /* IOBService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF85FE12E427312000D7351 /* IOBService.swift */; };
 		3E28F2AB2EB5337F00FB9EEB /* ConnectIQ in Frameworks */ = {isa = PBXBuildFile; productRef = 3E28F2AA2EB5337F00FB9EEB /* ConnectIQ */; };
+		3E62C7822F54CC1B00433237 /* BolusDisplayThreshold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E62C7812F54CC1600433237 /* BolusDisplayThreshold.swift */; };
 		45252C95D220E796FDB3B022 /* ConfigEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8A87AA037BD079BA3528BA /* ConfigEditorDataFlow.swift */; };
 		45717281F743594AA9D87191 /* ConfigEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920DDB21E5D0EB813197500D /* ConfigEditorRootView.swift */; };
 		491D6FBD2D56741C00C49F67 /* TempTargetStored+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491D6FBC2D56741C00C49F67 /* TempTargetStored+CoreDataProperties.swift */; };
@@ -1090,6 +1091,7 @@
 		3BDEA2DC60EDE0A3CA54DC73 /* TargetsEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorProvider.swift; sourceTree = "<group>"; };
 		3BF768BD6264FF7D71D66767 /* NightscoutConfigProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NightscoutConfigProvider.swift; sourceTree = "<group>"; };
 		3BF85FE12E427312000D7351 /* IOBService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOBService.swift; sourceTree = "<group>"; };
+		3E62C7812F54CC1600433237 /* BolusDisplayThreshold.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusDisplayThreshold.swift; sourceTree = "<group>"; };
 		3F60E97100041040446F44E7 /* PumpConfigStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PumpConfigStateModel.swift; sourceTree = "<group>"; };
 		3F8A87AA037BD079BA3528BA /* ConfigEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorDataFlow.swift; sourceTree = "<group>"; };
 		42369F66CF91F30624C0B3A6 /* BasalProfileEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorProvider.swift; sourceTree = "<group>"; };
@@ -2369,6 +2371,7 @@
 		388E5A5925B6F0250019842D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				3E62C7812F54CC1600433237 /* BolusDisplayThreshold.swift */,
 				DD3D60302F0377350021A33B /* ExportSetting.swift */,
 				DDFF204F2DB2C11900AB8A96 /* WatchStateSnapshot.swift */,
 				DDEBB05B2D89E9050032305D /* TimeInRangeType.swift */,
@@ -4360,6 +4363,7 @@
 				CEE9A6592BBB418300EB5194 /* CalibrationsDataFlow.swift in Sources */,
 				3811DE3525C9D49500A708ED /* HomeRootView.swift in Sources */,
 				38E98A2925F52C9300C0CED0 /* Error+Extensions.swift in Sources */,
+				3E62C7822F54CC1B00433237 /* BolusDisplayThreshold.swift in Sources */,
 				38EA05DA261F6E7C0064E39B /* SimpleLogReporter.swift in Sources */,
 				3811DE6125C9D4D500A708ED /* ViewModifiers.swift in Sources */,
 				3811DEAC25C9D88300A708ED /* NightscoutManager.swift in Sources */,

--- a/Trio/Sources/Models/BolusDisplayThreshold.swift
+++ b/Trio/Sources/Models/BolusDisplayThreshold.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum BolusDisplayThreshold: Decimal, CaseIterable, Encodable, Identifiable {
+    public var id: Decimal { rawValue }
+    case oneUnit = 1
+    case halfUnit = 0.5
+    case pointOneUnit = 0.1
+    case allUnits = 0.01
+
+    var displayName: String {
+        switch self {
+        case .oneUnit:
+            return String(localized: "1U and over")
+        case .halfUnit:
+            return String(localized: "0.5U and over")
+        case .pointOneUnit:
+            return String(localized: "0.1U and over")
+        case .allUnits:
+            return String(localized: "Show all labels")
+        }
+    }
+}

--- a/Trio/Sources/Models/BolusDisplayThreshold.swift
+++ b/Trio/Sources/Models/BolusDisplayThreshold.swift
@@ -16,7 +16,7 @@ enum BolusDisplayThreshold: Decimal, CaseIterable, Encodable, Identifiable {
         case .pointOneUnit:
             return String(localized: "0.1 U and over")
         case .allUnits:
-            return String(localized: "Show All Labels")
+            return String(localized: "All Labels")
         }
     }
 }

--- a/Trio/Sources/Models/BolusDisplayThreshold.swift
+++ b/Trio/Sources/Models/BolusDisplayThreshold.swift
@@ -10,13 +10,13 @@ enum BolusDisplayThreshold: Decimal, CaseIterable, Encodable, Identifiable {
     var displayName: String {
         switch self {
         case .oneUnit:
-            return String(localized: "1U and over")
+            return String(localized: "1 U and over")
         case .halfUnit:
-            return String(localized: "0.5U and over")
+            return String(localized: "0.5 U and over")
         case .pointOneUnit:
-            return String(localized: "0.1U and over")
+            return String(localized: "0.1 U and over")
         case .allUnits:
-            return String(localized: "Show all labels")
+            return String(localized: "Show All Labels")
         }
     }
 }

--- a/Trio/Sources/Models/BolusDisplayThreshold.swift
+++ b/Trio/Sources/Models/BolusDisplayThreshold.swift
@@ -16,7 +16,7 @@ enum BolusDisplayThreshold: Decimal, CaseIterable, Encodable, Identifiable {
         case .pointOneUnit:
             return String(localized: "0.1 U and over")
         case .allUnits:
-            return String(localized: "All Labels")
+            return String(localized: "Show All")
         }
     }
 }

--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -54,7 +54,7 @@ struct TrioSettings: JSON, Equatable {
     var xGridLines: Bool = true
     var yGridLines: Bool = true
     var rulerMarks: Bool = true
-    var showSmbInChart: Bool = true
+    var showSmbLabelInChart: Bool = true
     var forecastDisplayType: ForecastDisplayType = .cone
     var maxCarbs: Decimal = 250
     var maxFat: Decimal = 250

--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -54,6 +54,7 @@ struct TrioSettings: JSON, Equatable {
     var xGridLines: Bool = true
     var yGridLines: Bool = true
     var rulerMarks: Bool = true
+    var showSmbInChart: Bool = true
     var forecastDisplayType: ForecastDisplayType = .cone
     var maxCarbs: Decimal = 250
     var maxFat: Decimal = 250

--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -54,7 +54,7 @@ struct TrioSettings: JSON, Equatable {
     var xGridLines: Bool = true
     var yGridLines: Bool = true
     var rulerMarks: Bool = true
-    var showSmbLabelInChart: Bool = true
+    var bolusDisplayThreshold: BolusDisplayThreshold = .allUnits
     var forecastDisplayType: ForecastDisplayType = .cone
     var maxCarbs: Decimal = 250
     var maxFat: Decimal = 250

--- a/Trio/Sources/Modules/Home/HomeStateModel+Setup/PumpHistorySetup.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel+Setup/PumpHistorySetup.swift
@@ -38,6 +38,11 @@ extension Home.StateModel {
     }
 
     @MainActor private func updateInsulinArray(with insulinObjects: [PumpEventStored]) {
+        var insulinObjects = insulinObjects
+        if !showSmb {
+            insulinObjects = insulinObjects.filter({ $0.bolus == nil || $0.bolus?.isSMB != true })
+        }
+
         insulinFromPersistence = insulinObjects
 
         manualTempBasal = apsManager.isManualTempBasal

--- a/Trio/Sources/Modules/Home/HomeStateModel+Setup/PumpHistorySetup.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel+Setup/PumpHistorySetup.swift
@@ -38,11 +38,6 @@ extension Home.StateModel {
     }
 
     @MainActor private func updateInsulinArray(with insulinObjects: [PumpEventStored]) {
-        var insulinObjects = insulinObjects
-        if !showSmb {
-            insulinObjects = insulinObjects.filter({ $0.bolus == nil || $0.bolus?.isSMB != true })
-        }
-
         insulinFromPersistence = insulinObjects
 
         manualTempBasal = apsManager.isManualTempBasal

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -76,7 +76,7 @@ extension Home {
         var displayXgridLines: Bool = false
         var displayYgridLines: Bool = false
         var thresholdLines: Bool = false
-        var showSmbLabel: Bool = true
+        var bolusDisplayThreshold: BolusDisplayThreshold = .allUnits
         var hours: Int16 = 6
         var totalBolus: Decimal = 0
         var isLoopStatusPresented: Bool = false
@@ -405,7 +405,7 @@ extension Home {
             eA1cDisplayUnit = settingsManager.settings.eA1cDisplayUnit
             displayXgridLines = settingsManager.settings.xGridLines
             displayYgridLines = settingsManager.settings.yGridLines
-            showSmbLabel = settingsManager.settings.showSmbLabelInChart
+            bolusDisplayThreshold = settingsManager.settings.bolusDisplayThreshold
             thresholdLines = settingsManager.settings.rulerMarks
             showCarbsRequiredBadge = settingsManager.settings.showCarbsRequiredBadge
             forecastDisplayType = settingsManager.settings.forecastDisplayType
@@ -670,7 +670,7 @@ extension Home.StateModel:
         displayXgridLines = settingsManager.settings.xGridLines
         displayYgridLines = settingsManager.settings.yGridLines
         thresholdLines = settingsManager.settings.rulerMarks
-        showSmbLabel = settingsManager.settings.showSmbLabelInChart
+        bolusDisplayThreshold = settingsManager.settings.bolusDisplayThreshold
         showCarbsRequiredBadge = settingsManager.settings.showCarbsRequiredBadge
         forecastDisplayType = settingsManager.settings.forecastDisplayType
         cgmAvailable = (fetchGlucoseManager.cgmGlucoseSourceType != CGMType.none)

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -677,7 +677,6 @@ extension Home.StateModel:
         displayPumpStatusHighlightMessage()
         displayPumpStatusBadge()
         setupBatteryArray()
-        setupInsulinArray()
         Task {
             await setupCGMSettings()
         }

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -76,7 +76,7 @@ extension Home {
         var displayXgridLines: Bool = false
         var displayYgridLines: Bool = false
         var thresholdLines: Bool = false
-        var showSmb: Bool = true
+        var showSmbLabel: Bool = true
         var hours: Int16 = 6
         var totalBolus: Decimal = 0
         var isLoopStatusPresented: Bool = false
@@ -405,7 +405,7 @@ extension Home {
             eA1cDisplayUnit = settingsManager.settings.eA1cDisplayUnit
             displayXgridLines = settingsManager.settings.xGridLines
             displayYgridLines = settingsManager.settings.yGridLines
-            showSmb = settingsManager.settings.showSmbInChart
+            showSmbLabel = settingsManager.settings.showSmbLabelInChart
             thresholdLines = settingsManager.settings.rulerMarks
             showCarbsRequiredBadge = settingsManager.settings.showCarbsRequiredBadge
             forecastDisplayType = settingsManager.settings.forecastDisplayType
@@ -670,7 +670,7 @@ extension Home.StateModel:
         displayXgridLines = settingsManager.settings.xGridLines
         displayYgridLines = settingsManager.settings.yGridLines
         thresholdLines = settingsManager.settings.rulerMarks
-        showSmb = settingsManager.settings.showSmbInChart
+        showSmbLabel = settingsManager.settings.showSmbLabelInChart
         showCarbsRequiredBadge = settingsManager.settings.showCarbsRequiredBadge
         forecastDisplayType = settingsManager.settings.forecastDisplayType
         cgmAvailable = (fetchGlucoseManager.cgmGlucoseSourceType != CGMType.none)

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -76,6 +76,7 @@ extension Home {
         var displayXgridLines: Bool = false
         var displayYgridLines: Bool = false
         var thresholdLines: Bool = false
+        var showSmb: Bool = true
         var hours: Int16 = 6
         var totalBolus: Decimal = 0
         var isLoopStatusPresented: Bool = false
@@ -404,6 +405,7 @@ extension Home {
             eA1cDisplayUnit = settingsManager.settings.eA1cDisplayUnit
             displayXgridLines = settingsManager.settings.xGridLines
             displayYgridLines = settingsManager.settings.yGridLines
+            showSmb = settingsManager.settings.showSmbInChart
             thresholdLines = settingsManager.settings.rulerMarks
             showCarbsRequiredBadge = settingsManager.settings.showCarbsRequiredBadge
             forecastDisplayType = settingsManager.settings.forecastDisplayType
@@ -668,12 +670,14 @@ extension Home.StateModel:
         displayXgridLines = settingsManager.settings.xGridLines
         displayYgridLines = settingsManager.settings.yGridLines
         thresholdLines = settingsManager.settings.rulerMarks
+        showSmb = settingsManager.settings.showSmbInChart
         showCarbsRequiredBadge = settingsManager.settings.showCarbsRequiredBadge
         forecastDisplayType = settingsManager.settings.forecastDisplayType
         cgmAvailable = (fetchGlucoseManager.cgmGlucoseSourceType != CGMType.none)
         displayPumpStatusHighlightMessage()
         displayPumpStatusBadge()
         setupBatteryArray()
+        setupInsulinArray()
         Task {
             await setupCGMSettings()
         }

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/InsulinView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/InsulinView.swift
@@ -6,6 +6,7 @@ struct InsulinView: ChartContent {
     let glucoseData: [GlucoseStored]
     let insulinData: [PumpEventStored]
     let units: GlucoseUnits
+    let showSmbLabel: Bool
 
     var body: some ChartContent {
         drawBoluses()
@@ -13,6 +14,7 @@ struct InsulinView: ChartContent {
 
     private func drawBoluses() -> some ChartContent {
         ForEach(insulinData) { insulin in
+            let isSmb = insulin.bolus?.isSMB ?? false
             let amount = insulin.bolus?.amount ?? 0 as NSDecimalNumber
             let bolusDate = insulin.timestamp ?? Date()
 
@@ -32,7 +34,7 @@ struct InsulinView: ChartContent {
                     Image(systemName: "arrowtriangle.down.fill").font(.system(size: size)).foregroundStyle(Color.insulin)
                 }
                 .annotation(position: .top) {
-                    Text(Formatter.bolusFormatter.string(from: amount) ?? "")
+                    Text(!showSmbLabel && isSmb ? "" : Formatter.bolusFormatter.string(from: amount) ?? "")
                         .font(.caption2)
                         .foregroundStyle(Color.primary)
                 }

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/InsulinView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/InsulinView.swift
@@ -6,7 +6,7 @@ struct InsulinView: ChartContent {
     let glucoseData: [GlucoseStored]
     let insulinData: [PumpEventStored]
     let units: GlucoseUnits
-    let showSmbLabel: Bool
+    let bolusDisplayThreshold: BolusDisplayThreshold
 
     var body: some ChartContent {
         drawBoluses()
@@ -14,7 +14,6 @@ struct InsulinView: ChartContent {
 
     private func drawBoluses() -> some ChartContent {
         ForEach(insulinData) { insulin in
-            let isSmb = insulin.bolus?.isSMB ?? false
             let amount = insulin.bolus?.amount ?? 0 as NSDecimalNumber
             let bolusDate = insulin.timestamp ?? Date()
 
@@ -34,9 +33,11 @@ struct InsulinView: ChartContent {
                     Image(systemName: "arrowtriangle.down.fill").font(.system(size: size)).foregroundStyle(Color.insulin)
                 }
                 .annotation(position: .top) {
-                    Text(!showSmbLabel && isSmb ? "" : Formatter.bolusFormatter.string(from: amount) ?? "")
-                        .font(.caption2)
-                        .foregroundStyle(Color.primary)
+                    if bolusDisplayThreshold.rawValue >= amount as Decimal {
+                        Text(Formatter.bolusFormatter.string(from: amount) ?? "")
+                            .font(.caption2)
+                            .foregroundStyle(Color.primary)
+                    }
                 }
             }
         }

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/InsulinView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/InsulinView.swift
@@ -33,7 +33,7 @@ struct InsulinView: ChartContent {
                     Image(systemName: "arrowtriangle.down.fill").font(.system(size: size)).foregroundStyle(Color.insulin)
                 }
                 .annotation(position: .top) {
-                    if bolusDisplayThreshold.rawValue >= amount as Decimal {
+                    if amount as Decimal >= bolusDisplayThreshold.rawValue {
                         Text(Formatter.bolusFormatter.string(from: amount) ?? "")
                             .font(.caption2)
                             .foregroundStyle(Color.primary)

--- a/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -149,7 +149,8 @@ extension MainChartView {
                 InsulinView(
                     glucoseData: state.glucoseFromPersistence,
                     insulinData: state.insulinFromPersistence,
-                    units: state.units
+                    units: state.units,
+                    showSmbLabel: state.showSmbLabel
                 )
 
                 CarbView(

--- a/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -150,7 +150,7 @@ extension MainChartView {
                     glucoseData: state.glucoseFromPersistence,
                     insulinData: state.insulinFromPersistence,
                     units: state.units,
-                    showSmbLabel: state.showSmbLabel
+                    bolusDisplayThreshold: state.bolusDisplayThreshold
                 )
 
                 CarbView(

--- a/Trio/Sources/Modules/Settings/SettingItems.swift
+++ b/Trio/Sources/Modules/Settings/SettingItems.swift
@@ -230,6 +230,7 @@ enum SettingItems {
                 "Show Carbs Required Badge",
                 "Carbs Required Threshold",
                 "Forecast Display Type",
+                "Bolus Display Threshold",
                 "Cone",
                 "Lines",
                 "Dark Mode",

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
@@ -7,7 +7,7 @@ extension UserInterfaceSettings {
         @Published var xGridLines = false
         @Published var yGridLines: Bool = false
         @Published var rulerMarks: Bool = true
-        @Published var showSmbLabelInChart: Bool = true
+        @Published var bolusDisplayThreshold: BolusDisplayThreshold = .allUnits
         @Published var forecastDisplayType: ForecastDisplayType = .cone
         @Published var showCarbsRequiredBadge: Bool = true
         @Published var carbsRequiredThreshold: Decimal = 0
@@ -24,7 +24,7 @@ extension UserInterfaceSettings {
             subscribeSetting(\.xGridLines, on: $xGridLines) { xGridLines = $0 }
             subscribeSetting(\.yGridLines, on: $yGridLines) { yGridLines = $0 }
             subscribeSetting(\.rulerMarks, on: $rulerMarks) { rulerMarks = $0 }
-            subscribeSetting(\.showSmbLabelInChart, on: $showSmbLabelInChart) { showSmbLabelInChart = $0 }
+            subscribeSetting(\.bolusDisplayThreshold, on: $bolusDisplayThreshold) { bolusDisplayThreshold = $0 }
 
             subscribeSetting(\.forecastDisplayType, on: $forecastDisplayType) { forecastDisplayType = $0 }
 

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
@@ -7,7 +7,7 @@ extension UserInterfaceSettings {
         @Published var xGridLines = false
         @Published var yGridLines: Bool = false
         @Published var rulerMarks: Bool = true
-        @Published var showSmbInChart: Bool = true
+        @Published var showSmbLabelInChart: Bool = true
         @Published var forecastDisplayType: ForecastDisplayType = .cone
         @Published var showCarbsRequiredBadge: Bool = true
         @Published var carbsRequiredThreshold: Decimal = 0
@@ -24,7 +24,7 @@ extension UserInterfaceSettings {
             subscribeSetting(\.xGridLines, on: $xGridLines) { xGridLines = $0 }
             subscribeSetting(\.yGridLines, on: $yGridLines) { yGridLines = $0 }
             subscribeSetting(\.rulerMarks, on: $rulerMarks) { rulerMarks = $0 }
-            subscribeSetting(\.showSmbInChart, on: $showSmbInChart) { showSmbInChart = $0 }
+            subscribeSetting(\.showSmbLabelInChart, on: $showSmbLabelInChart) { showSmbLabelInChart = $0 }
 
             subscribeSetting(\.forecastDisplayType, on: $forecastDisplayType) { forecastDisplayType = $0 }
 

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
@@ -7,6 +7,7 @@ extension UserInterfaceSettings {
         @Published var xGridLines = false
         @Published var yGridLines: Bool = false
         @Published var rulerMarks: Bool = true
+        @Published var showSmbInChart: Bool = true
         @Published var forecastDisplayType: ForecastDisplayType = .cone
         @Published var showCarbsRequiredBadge: Bool = true
         @Published var carbsRequiredThreshold: Decimal = 0
@@ -23,6 +24,7 @@ extension UserInterfaceSettings {
             subscribeSetting(\.xGridLines, on: $xGridLines) { xGridLines = $0 }
             subscribeSetting(\.yGridLines, on: $yGridLines) { yGridLines = $0 }
             subscribeSetting(\.rulerMarks, on: $rulerMarks) { rulerMarks = $0 }
+            subscribeSetting(\.showSmbInChart, on: $showSmbInChart) { showSmbInChart = $0 }
 
             subscribeSetting(\.forecastDisplayType, on: $forecastDisplayType) { forecastDisplayType = $0 }
 

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -162,6 +162,7 @@ extension UserInterfaceSettings {
                         VStack {
                             Toggle("Show X-Axis Grid Lines", isOn: $state.xGridLines)
                             Toggle("Show Y-Axis Grid Lines", isOn: $state.yGridLines)
+                            Toggle("Show SMB in Chart", isOn: $state.showSmbInChart)
 
                             HStack(alignment: .center) {
                                 Text(

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -162,7 +162,7 @@ extension UserInterfaceSettings {
                         VStack {
                             Toggle("Show X-Axis Grid Lines", isOn: $state.xGridLines)
                             Toggle("Show Y-Axis Grid Lines", isOn: $state.yGridLines)
-                            Toggle("Show SMB in Chart", isOn: $state.showSmbInChart)
+                            Toggle("Show SMB label in Chart", isOn: $state.showSmbLabelInChart)
 
                             HStack(alignment: .center) {
                                 Text(

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -212,11 +212,13 @@ extension UserInterfaceSettings {
                             Spacer()
                             Button(
                                 action: {
-                                    hintLabel = String(localized: "Glucose Color Scheme")
+                                    hintLabel = String(localized: "Bolus Display Threshold")
                                     selectedVerboseHint =
                                         AnyView(
-                                            VStack(alignment: .leading, spacing: 10) {
-                                                Text("TODO: Helper text")
+                                            VStack(alignment: .leading) {
+                                                Text(
+                                                    "Choose whether to display the amount above every bolus indicator or just for a bigger bolus amount"
+                                                )
                                             }
                                         )
                                     shouldDisplayHint.toggle()

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -162,7 +162,6 @@ extension UserInterfaceSettings {
                         VStack {
                             Toggle("Show X-Axis Grid Lines", isOn: $state.xGridLines)
                             Toggle("Show Y-Axis Grid Lines", isOn: $state.yGridLines)
-                            Toggle("Show SMB label in Chart", isOn: $state.showSmbLabelInChart)
 
                             HStack(alignment: .center) {
                                 Text(
@@ -191,6 +190,46 @@ extension UserInterfaceSettings {
                         }.padding(.vertical)
                     }
                 ).listRowBackground(Color.chart)
+
+                Section {
+                    VStack {
+                        Picker(
+                            selection: $state.bolusDisplayThreshold,
+                            label: Text("Bolus Display Threshold")
+                        ) {
+                            ForEach(BolusDisplayThreshold.allCases) { selection in
+                                Text(selection.displayName).tag(selection)
+                            }
+                        }.padding(.top)
+
+                        HStack(alignment: .center) {
+                            Text(
+                                "Choose to hide small bolus amounts. See hint for more details."
+                            )
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                            .lineLimit(nil)
+                            Spacer()
+                            Button(
+                                action: {
+                                    hintLabel = String(localized: "Glucose Color Scheme")
+                                    selectedVerboseHint =
+                                        AnyView(
+                                            VStack(alignment: .leading, spacing: 10) {
+                                                Text("TODO: Helper text")
+                                            }
+                                        )
+                                    shouldDisplayHint.toggle()
+                                },
+                                label: {
+                                    HStack {
+                                        Image(systemName: "questionmark.circle")
+                                    }
+                                }
+                            ).buttonStyle(BorderlessButtonStyle())
+                        }.padding(.top)
+                    }.padding(.bottom)
+                }.listRowBackground(Color.chart)
 
                 SettingInputSection(
                     decimalValue: $decimalPlaceholder,

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -217,7 +217,7 @@ extension UserInterfaceSettings {
                                         AnyView(
                                             VStack(alignment: .leading) {
                                                 Text(
-                                                    "Choose whether to display the amount above every bolus indicator or just for a bigger bolus amount"
+                                                    "This setting controls which bolus amount labels are shown on Trio’s main chart. Boluses appear as blue upside-down triangles, with a number showing the amount. Depending on the option you choose, only boluses at or above that amount will show a label. For example, if you choose ‘0.5 U and over’, only boluses of 0.5 U or more will show a label."
                                                 )
                                             }
                                         )

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -191,48 +191,6 @@ extension UserInterfaceSettings {
                     }
                 ).listRowBackground(Color.chart)
 
-                Section {
-                    VStack {
-                        Picker(
-                            selection: $state.bolusDisplayThreshold,
-                            label: Text("Bolus Display Threshold")
-                        ) {
-                            ForEach(BolusDisplayThreshold.allCases) { selection in
-                                Text(selection.displayName).tag(selection)
-                            }
-                        }.padding(.top)
-
-                        HStack(alignment: .center) {
-                            Text(
-                                "Choose to hide small bolus amounts. See hint for more details."
-                            )
-                            .font(.footnote)
-                            .foregroundColor(.secondary)
-                            .lineLimit(nil)
-                            Spacer()
-                            Button(
-                                action: {
-                                    hintLabel = String(localized: "Bolus Display Threshold")
-                                    selectedVerboseHint =
-                                        AnyView(
-                                            VStack(alignment: .leading) {
-                                                Text(
-                                                    "This setting controls which bolus amount labels are shown on Trio’s main chart. Boluses appear as blue upside-down triangles, with a number showing the amount. Depending on the option you choose, only boluses at or above that amount will show a label. For example, if you choose ‘0.5 U and over’, only boluses of 0.5 U or more will show a label."
-                                                )
-                                            }
-                                        )
-                                    shouldDisplayHint.toggle()
-                                },
-                                label: {
-                                    HStack {
-                                        Image(systemName: "questionmark.circle")
-                                    }
-                                }
-                            ).buttonStyle(BorderlessButtonStyle())
-                        }.padding(.top)
-                    }.padding(.bottom)
-                }.listRowBackground(Color.chart)
-
                 SettingInputSection(
                     decimalValue: $decimalPlaceholder,
                     booleanValue: $state.rulerMarks,
@@ -404,6 +362,48 @@ extension UserInterfaceSettings {
                                                         "Uses the IOB, COB, UAM, and ZT forecast lines from OpenAPS. This option provides a more detailed view of the algorithm's forecast, but may be more confusing for some users."
                                                     )
                                                 }
+                                            }
+                                        )
+                                    shouldDisplayHint.toggle()
+                                },
+                                label: {
+                                    HStack {
+                                        Image(systemName: "questionmark.circle")
+                                    }
+                                }
+                            ).buttonStyle(BorderlessButtonStyle())
+                        }.padding(.top)
+                    }.padding(.bottom)
+                }.listRowBackground(Color.chart)
+
+                Section {
+                    VStack {
+                        Picker(
+                            selection: $state.bolusDisplayThreshold,
+                            label: Text("Bolus Display Threshold")
+                        ) {
+                            ForEach(BolusDisplayThreshold.allCases) { selection in
+                                Text(selection.displayName).tag(selection)
+                            }
+                        }.padding(.top)
+
+                        HStack(alignment: .center) {
+                            Text(
+                                "Choose to hide small bolus amounts. See hint for more details."
+                            )
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                            .lineLimit(nil)
+                            Spacer()
+                            Button(
+                                action: {
+                                    hintLabel = String(localized: "Bolus Display Threshold")
+                                    selectedVerboseHint =
+                                        AnyView(
+                                            VStack(alignment: .leading) {
+                                                Text(
+                                                    "This setting controls which bolus amount labels are shown on Trio’s main chart. Boluses appear as blue upside-down triangles, with a number showing the amount. Depending on the option you choose, only boluses at or above that amount will show a label. For example, if you choose ‘0.5 U and over’, only boluses of 0.5 U or more will show a label."
+                                                )
                                             }
                                         )
                                     shouldDisplayHint.toggle()


### PR DESCRIPTION
To allow user to clean up the main chart, I believe it is good to give users an extra option to hide the amount label above the SMB's.

Screenshots:

<img height="700" alt="IMG_1411" src="https://github.com/user-attachments/assets/eecaf12d-59a4-4353-a2f9-b7e665045a4d" />
<img height="700" alt="IMG_1410" src="https://github.com/user-attachments/assets/30840fd1-7cac-4fe0-a4d2-e5810e0dc4c6" />
