### PR TITLE
Update build to Xcode 26 / macOS 26 runner

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -12,7 +12,7 @@ jobs:
   identifiers:
     name: Add Identifiers
     needs: validate
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       # Checks-out the repo
       - name: Checkout Repo

--- a/.github/workflows/build_trio.yml
+++ b/.github/workflows/build_trio.yml
@@ -165,7 +165,7 @@ jobs:
   build:
     name: Build
     needs: [check_certs, check_status]
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       contents: write
     if:
@@ -175,7 +175,7 @@ jobs:
         (vars.SCHEDULED_SYNC != 'false' && needs.check_status.outputs.NEW_COMMITS == 'true' )
     steps:
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_26.2.app/Contents/Developer"
       
       - name: Checkout Repo for building
         uses: actions/checkout@v4

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -21,7 +21,7 @@ jobs:
   create_certs:
     name: Certificates
     needs: validate
-    runs-on: macos-15
+    runs-on: macos-26
     outputs:
       new_certificate_needed: ${{ steps.set_output.outputs.new_certificate_needed }}
 
@@ -90,7 +90,7 @@ jobs:
   nuke_certs:
       name: Nuke certificates
       needs: [validate, create_certs]
-      runs-on: macos-15
+      runs-on: macos-26
       if: ${{ (needs.create_certs.outputs.new_certificate_needed == 'true' && vars.ENABLE_NUKE_CERTS == 'true') || vars.FORCE_NUKE_CERTS == 'true' }}
       steps:
         - name: Output from step id 'check_certs'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,12 +23,12 @@ on:
 jobs:
   test:
     name: Run Unit Tests
-    runs-on: macos-15
+    runs-on: macos-26
     if: github.repository_owner == 'nightscout'
 
     steps:
       - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -105,7 +105,7 @@ jobs:
   validate-fastlane-secrets:
     name: Fastlane
     needs: [validate-access-token]
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       GH_PAT: ${{ secrets.GH_PAT }}
       GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary
- Updates GitHub Actions build runner from `macos-15` to `macos-26`
- Updates Xcode from 16.4 to 26.2 in both `build_trio.yml` and `unit_tests.yml` (iOS 26 SDK)

Starting April 28, 2026, App Store Connect requires all iOS/iPadOS apps to be built with the iOS 26 SDK (included in Xcode 26+). This was flagged in the latest build delivery (ITMS-90725).

## Test plan
- [x] Trigger a manual build via workflow_dispatch and verify it completes successfully
- [x] Verify the built IPA uploads to TestFlight without SDK version warnings
- [x] Verify unit tests pass on the new runner