### PR TITLE
Fix names of settings in search

### DIFF
--- a/Trio/Sources/Modules/Onboarding/View/OnboardingView+AlgorithmUtil.swift
+++ b/Trio/Sources/Modules/Onboarding/View/OnboardingView+AlgorithmUtil.swift
@@ -121,8 +121,8 @@ enum AlgorithmSettingsSubstep: Int, CaseIterable, Identifiable {
         case .maxSMBMinutes: return String(localized: "Max SMB Basal Minutes", comment: "Max SMB Basal Minutes")
         case .maxUAMMinutes: return String(localized: "Max UAM Basal Minutes", comment: "Max UAM Basal Minutes")
         case .maxDeltaGlucoseThreshold: return String(
-                localized: "Max. Allowed Glucose Rise for SMB",
-                comment: "Max. Allowed Glucose Rise for SMB, formerly Max Delta-BG Threshold"
+                localized: "Max Allowed Glucose Rise for SMB",
+                comment: "Max Allowed Glucose Rise for SMB, formerly Max Delta-BG Threshold"
             )
         case .highTempTargetRaisesSensitivity: return String(
                 localized: "High Temp Target Raises Sensitivity",

--- a/Trio/Sources/Modules/SMBSettings/View/SMBSettingsRootView.swift
+++ b/Trio/Sources/Modules/SMBSettings/View/SMBSettingsRootView.swift
@@ -331,16 +331,16 @@ extension SMBSettings {
                         set: {
                             selectedVerboseHint = $0.map { AnyView($0) }
                             hintLabel = String(
-                                localized: "Max. Allowed Glucose Rise for SMB",
-                                comment: "Max. Allowed Glucose Rise for SMB, formerly Max Delta-BG Threshold"
+                                localized: "Max Allowed Glucose Rise for SMB",
+                                comment: "Max Allowed Glucose Rise for SMB, formerly Max Delta-BG Threshold"
                             )
                         }
                     ),
                     units: state.units,
                     type: .decimal("maxDeltaBGthreshold"),
                     label: String(
-                        localized: "Max. Allowed Glucose Rise for SMB",
-                        comment: "Max. Allowed Glucose Rise for SMB, formerly Max Delta-BG Threshold"
+                        localized: "Max Allowed Glucose Rise for SMB",
+                        comment: "Max Allowed Glucose Rise for SMB, formerly Max Delta-BG Threshold"
                     ),
                     miniHint: String(localized: "Disables SMBs if last two glucose values differ by more than this percent."),
                     verboseHint:

--- a/Trio/Sources/Modules/Settings/SettingItems.swift
+++ b/Trio/Sources/Modules/Settings/SettingItems.swift
@@ -114,13 +114,13 @@ enum SettingItems {
                 "Enable SMB With COB",
                 "Enable SMB With Temporary Target",
                 "Enable SMB After Carbs",
-                "Enable SMB With High BG",
-                "High BG Target",
+                "Enable SMB With High Glucose",
+                "High Glucose Target",
                 "Allow SMB With High Temporary Target",
                 "Enable UAM",
                 "Max SMB Basal Minutes",
                 "Max UAM SMB Basal Minutes",
-                "Max Delta-BG Threshold SMB"
+                "Max Allowed Glucose Rise for SMB"
             ],
             path: ["Algorithm", "Super Micro Bolus (SMB)"]
         ),

--- a/Trio/Sources/Modules/SettingsExport/SettingsExportStateModel.swift
+++ b/Trio/Sources/Modules/SettingsExport/SettingsExportStateModel.swift
@@ -396,7 +396,7 @@ extension SettingsExport {
                 addSetting(
                     category: algorithmCategory,
                     subcategory: smbSubcategory,
-                    name: String(localized: "Max. Allowed Glucose Rise for SMB"),
+                    name: String(localized: "Max Allowed Glucose Rise for SMB"),
                     value: String(format: "%.0f", (preferences.maxDeltaBGthreshold as NSDecimalNumber).doubleValue * 100),
                     unit: "%"
                 )


### PR DESCRIPTION
Updates the search feature to match the actual settings' names:

| old | new |
|---|---|
| "Enable SMB With High BG" | "Enable SMB With High Glucose" |
| "High BG Target" | "High Glucose Target" |
| "Max Delta-BG Threshold SMB" | "Max Allowed Glucose Rise for SMB" |

Removes the unnecessary full stop from this setting and copies the old name's l18n
| old | new |
|---|---|
| "Max. Allowed Glucose Rise for SMB" | "Max. Allowed Glucose Rise for SMB" |