### PR TITLE
Update test device to iPhone 17 iOS 26.2

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -64,7 +64,7 @@ jobs:
           time xcodebuild build-for-testing \
             -workspace Trio.xcworkspace \
             -scheme "Trio Tests" \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' \
 
       - name: Check for uncommitted changes
         run: |
@@ -107,7 +107,7 @@ jobs:
           time xcodebuild test-without-building \
             -workspace Trio.xcworkspace \
             -scheme "Trio Tests" \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' \
+            -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' \
             $([ "$ENABLE_PARALLEL_TESTING" = "true" ] && echo "-parallel-testing-enabled YES") \
             2>&1 | tee xcodebuild.log
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,8 +1,6 @@
 name: zzz [DO NOT RUN] Automated unit tests
 
 on:
-  workflow_dispatch: # Allow manual trigger for debugging
-  
   pull_request:
     branches:
       - dev

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,6 +1,8 @@
 name: zzz [DO NOT RUN] Automated unit tests
 
 on:
+  workflow_dispatch: # Allow manual trigger for debugging
+  
   pull_request:
     branches:
       - dev


### PR DESCRIPTION
#1004 updated all GH action runners but missed to update the command-line passed test device for our CI-run unit tests.

This PR fixes this oversight by bumping the test devices from `iPhone 16, iOS 18.5` to `iPhone 17, iOS 26.2`.

Successfully running test see: https://github.com/dnzxy/Trio/actions/runs/23218784225/job/67486257468
Note: I had to remove the repository owner condition here, to run it in my fork.