### PR TITLE
Remove no longer used FPU duration setting

### DIFF
--- a/Trio/Resources/json/defaults/freeaps/freeaps_settings.json
+++ b/Trio/Resources/json/defaults/freeaps/freeaps_settings.json
@@ -21,7 +21,6 @@
   "showCarbsRequiredBadge" : true,
   "useFPUconversion" : true,
   "individualAdjustmentFactor" : 0.5,
-  "timeCap" : 8,
   "minuteInterval" : 30,
   "delay" : 60,
   "useAppleHealth" : false,

--- a/Trio/Sources/APS/Storage/CarbsStorage.swift
+++ b/Trio/Sources/APS/Storage/CarbsStorage.swift
@@ -157,7 +157,7 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
 
         let delayMinutes = trioSettings.delay
             .clamp(to: providerSettings.delay)
-        
+
         let spreadInterval = trioSettings.minuteInterval
             .clamp(to: providerSettings.minuteInterval)
 
@@ -166,7 +166,7 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
         let maxEntries = 3
         let maxPerEntry = 33
         let minPerEntry = 10
-        let spacing: TimeInterval = TimeInterval(spreadInterval * 60)
+        let spacing = TimeInterval(spreadInterval * 60)
 
         // kcal -> carb equivalents (kcal/10 * adjustment), rounded down to whole grams
         let kcal = protein * 4 + fat * 9

--- a/Trio/Sources/Models/DecimalPickerSettings.swift
+++ b/Trio/Sources/Models/DecimalPickerSettings.swift
@@ -133,7 +133,6 @@ struct DecimalPickerSettings {
     var updateInterval = PickerSetting(value: 20, step: 5, min: 1, max: 60, type: PickerSetting.PickerSettingType.minute)
     var delay = PickerSetting(value: 60, step: 5, min: 15, max: 120, type: PickerSetting.PickerSettingType.minute)
     var minuteInterval = PickerSetting(value: 30, step: 5, min: 30, max: 60, type: PickerSetting.PickerSettingType.minute)
-    var timeCap = PickerSetting(value: 8, step: 1, min: 5, max: 12, type: PickerSetting.PickerSettingType.hour)
     var hours = PickerSetting(value: 6, step: 0.5, min: 2, max: 24, type: PickerSetting.PickerSettingType.hour)
     var dia = PickerSetting(value: 10, step: 0.5, min: 5, max: 10, type: PickerSetting.PickerSettingType.hour)
     var maxBolus = PickerSetting(value: 10, step: 0.5, min: 0.5, max: 30, type: PickerSetting.PickerSettingType.insulinUnit)

--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -42,7 +42,6 @@ struct TrioSettings: JSON, Equatable {
     var showCarbsRequiredBadge: Bool = true
     var useFPUconversion: Bool = true
     var individualAdjustmentFactor: Decimal = 0.5
-    var timeCap: Decimal = 8
     var minuteInterval: Decimal = 30
     var delay: Decimal = 60
     var useAppleHealth: Bool = false
@@ -166,10 +165,6 @@ extension TrioSettings: Decodable {
 
         if let overrideFactor = try? container.decode(Decimal.self, forKey: .overrideFactor) {
             settings.overrideFactor = overrideFactor
-        }
-
-        if let timeCap = try? container.decode(Decimal.self, forKey: .timeCap) {
-            settings.timeCap = timeCap
         }
 
         if let minuteInterval = try? container.decode(Decimal.self, forKey: .minuteInterval) {

--- a/Trio/Sources/Modules/MealSettings/MealSettingsStateModel.swift
+++ b/Trio/Sources/Modules/MealSettings/MealSettingsStateModel.swift
@@ -8,7 +8,6 @@ extension MealSettings {
         @Published var maxFat: Decimal = 250
         @Published var maxProtein: Decimal = 250
         @Published var individualAdjustmentFactor: Decimal = 0.5
-        @Published var timeCap: Decimal = 8
         @Published var minuteInterval: Decimal = 30
         @Published var delay: Decimal = 60
         @Published var maxMealAbsorptionTime: Decimal = 6
@@ -26,9 +25,6 @@ extension MealSettings {
 
             // "Fat and Protein Delay"
             subscribeSetting(\.delay, on: $delay) { delay = $0 }
-
-            // "Maximum Duration"
-            subscribeSetting(\.timeCap, on: $timeCap) { timeCap = $0 }
 
             // "Spread Interval"
             subscribeSetting(\.minuteInterval, on: $minuteInterval) { minuteInterval = $0 }

--- a/Trio/Sources/Modules/MealSettings/View/MealSettingsRootView.swift
+++ b/Trio/Sources/Modules/MealSettings/View/MealSettingsRootView.swift
@@ -295,35 +295,6 @@ extension MealSettings {
                     )
 
                     SettingInputSection(
-                        decimalValue: $state.timeCap,
-                        booleanValue: $booleanPlaceholder,
-                        shouldDisplayHint: $shouldDisplayHint,
-                        selectedVerboseHint: Binding(
-                            get: { selectedVerboseHint },
-                            set: {
-                                selectedVerboseHint = $0.map { AnyView($0) }
-                                hintLabel = String(localized: "Maximum Duration")
-                            }
-                        ),
-                        units: state.units,
-                        type: .decimal("timeCap"),
-                        label: String(localized: "Maximum Duration"),
-                        miniHint: String(localized: "Set the maximum timeframe to extend FPUs."),
-                        verboseHint:
-                        VStack(alignment: .leading, spacing: 10) {
-                            Text("Default: 8 hours").bold()
-                            Text(
-                                "This sets the maximum length of time that Fat and Protein Carb Equivalents (FPUs) will be extended over from a single Fat and/or Protein bolus calcultor entry."
-                            )
-                            Text(
-                                "It is one factor used in combination with the Fat and Protein Delay, Spread Interval, and Fat and Protein Factor to create the FPU entries."
-                            )
-                            Text("Increasing this setting may result in more FPU entries with smaller carb values.")
-                            Text("Decreasing this setting may result in fewer FPU entries with larger carb values.")
-                        }
-                    )
-
-                    SettingInputSection(
                         decimalValue: $state.minuteInterval,
                         booleanValue: $booleanPlaceholder,
                         shouldDisplayHint: $shouldDisplayHint,

--- a/Trio/Sources/Modules/Onboarding/OnboardingStateModel.swift
+++ b/Trio/Sources/Modules/Onboarding/OnboardingStateModel.swift
@@ -717,7 +717,6 @@ extension Onboarding {
                     .clamp(to: providedSettings.carbsRequiredThreshold)
                 settingsCopy.individualAdjustmentFactor = settingsCopy.individualAdjustmentFactor
                     .clamp(to: providedSettings.individualAdjustmentFactor)
-                settingsCopy.timeCap = settingsCopy.timeCap.clamp(to: providedSettings.timeCap)
                 settingsCopy.minuteInterval = settingsCopy.minuteInterval.clamp(to: providedSettings.minuteInterval)
                 settingsCopy.delay = settingsCopy.delay.clamp(to: providedSettings.delay)
                 settingsCopy.high = settingsCopy.high.clamp(to: providedSettings.high)

--- a/Trio/Sources/Modules/Settings/SettingItems.swift
+++ b/Trio/Sources/Modules/Settings/SettingItems.swift
@@ -195,11 +195,10 @@ enum SettingItems {
                 "Max Meal Absorption Time",
                 "Max Fat",
                 "Max Protein",
-                "Display and Allow Fat and Protein Entries",
+                "Enable Fat and Protein Entries",
                 "Fat and Protein Delay",
-                "Maximum Duration (hours)",
-                "Spread Interval (minutes)",
-                "Fat and Protein Factor",
+                "Spread Interval",
+                "Fat and Protein Percentage",
                 "FPU"
             ],
             path: ["Features", "Meal Settings"]

--- a/Trio/Sources/Modules/SettingsExport/SettingsExportStateModel.swift
+++ b/Trio/Sources/Modules/SettingsExport/SettingsExportStateModel.swift
@@ -704,13 +704,6 @@ extension SettingsExport {
                 addSetting(
                     category: featuresCategory,
                     subcategory: mealSettingsSubcategory,
-                    name: String(localized: "Maximum Duration"),
-                    value: String(describing: trioSettings.timeCap),
-                    unit: String(localized: "hours")
-                )
-                addSetting(
-                    category: featuresCategory,
-                    subcategory: mealSettingsSubcategory,
                     name: String(localized: "Spread Interval"),
                     value: String(describing: trioSettings.minuteInterval),
                     unit: String(localized: "minutes")

--- a/Trio/Sources/Views/SettingInputSection.swift
+++ b/Trio/Sources/Views/SettingInputSection.swift
@@ -99,8 +99,6 @@ struct SettingInputSection<VerboseHint: View>: View {
             return pickerSettingsProvider.settings.individualAdjustmentFactor
         case "delay":
             return pickerSettingsProvider.settings.delay
-        case "timeCap":
-            return pickerSettingsProvider.settings.timeCap
         case "minuteInterval":
             return pickerSettingsProvider.settings.minuteInterval
         case "high":


### PR DESCRIPTION
PR #951 refactored FPU handling and processing for Trio.
This PR removes a setting that is no longer in use as of #951 and fixes the oversight of not having removed it.
