### PR TITLE
Update actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables

--- a/.github/workflows/auto_version_dev.yml
+++ b/.github/workflows/auto_version_dev.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
          token: ${{ secrets.TRIO_TOKEN_AUTOBUMP }}
 

--- a/.github/workflows/build_trio.yml
+++ b/.github/workflows/build_trio.yml
@@ -90,7 +90,7 @@ jobs:
         if: |
           steps.workflow-permission.outputs.has_permission == 'true' &&
           (vars.SCHEDULED_BUILD != 'false' || vars.SCHEDULED_SYNC != 'false')
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_PAT }}
 
@@ -100,7 +100,7 @@ jobs:
           steps.workflow-permission.outputs.has_permission == 'true' &&
           vars.SCHEDULED_SYNC != 'false' && github.repository_owner != 'nightscout'
         id: sync
-        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.1
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.2
         with:
           target_sync_branch: ${{ env.TARGET_BRANCH }}
           shallow_since: 6 months ago
@@ -178,7 +178,7 @@ jobs:
         run: "sudo xcode-select --switch /Applications/Xcode_26.2.app/Contents/Developer"
       
       - name: Checkout Repo for building
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_PAT }}
           submodules: recursive
@@ -258,7 +258,7 @@ jobs:
       # Upload Build artifacts
       - name: Upload build log, IPA and Symbol artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
@@ -97,7 +97,7 @@ jobs:
           run: echo "new_certificate_needed=${{ needs.create_certs.outputs.new_certificate_needed }}"
 
         - name: Checkout repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Install dependencies
           run: bundle install

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     if: github.repository_owner == 'nightscout'
     steps:
-      - uses: actions/stale@v9.0.0
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
     if: github.repository_owner == 'nightscout'
     steps:
-      - uses: actions/stale@v9.0.0
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 30

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -31,14 +31,14 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           submodules: recursive
 
       - name: Restore cache
         id: cache-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             /Users/runner/Library/Developer/Xcode/DerivedData
@@ -94,7 +94,7 @@ jobs:
           
       - name: Save cache
         if: steps.cache-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             /Users/runner/Library/Developer/Xcode/DerivedData

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -116,7 +116,7 @@ jobs:
       TEAMID: ${{ secrets.TEAMID }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Project Dependencies
         run: bundle install


### PR DESCRIPTION
## Summary
Updates all GitHub Actions to Node.js 24 compatible versions before the GitHub deprecation deadline (June 2, 2026 for Node.js 20).

- `actions/checkout` v4 → v5
- `actions/upload-artifact` v4 → v6
- `actions/cache` v4 → v5
- `actions/stale` v9 → v10
- `aormsby/Fork-Sync-With-Upstream-action` v3.4.1 → v3.4.2

`actions/add-to-project@v1.0.2` left unchanged as no newer version is available.

Successful build: https://github.com/bjorkert/Trio/actions/runs/23501911067