### PR TITLE
Stats: Fix typo and show start of every month in 3M views

### DIFF
--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseSectorChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseSectorChart.swift
@@ -343,7 +343,7 @@ struct GlucoseSectorChart: View {
                         formatPercentage(Decimal(low) / total * 100)
                     ),
                     (
-                        String(localized: "Very Low (<\(Decimal(54).formatted(for: units))"),
+                        String(localized: "Very Low (<\(Decimal(54).formatted(for: units)))"),
                         formatPercentage(Decimal(veryLow) / total * 100)
                     ),
                     (String(localized: "Average"), average.formatted(for: units)),

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/BolusStatsView.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/BolusStatsView.swift
@@ -272,9 +272,9 @@ struct BolusStatsView: View {
                             AxisGridLine()
                         }
                     case .total:
-                        // Only show every other month
+                        // Show start of every month
                         let day = Calendar.current.component(.day, from: date)
-                        if day == 1 && Calendar.current.component(.month, from: date) % 2 == 1 {
+                        if day == 1 {
                             AxisValueLabel(format: StatChartUtils.dateFormat(for: selectedInterval), centered: true)
                                 .font(.footnote)
                             AxisGridLine()

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/TotalDailyDoseChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Insulin/TotalDailyDoseChart.swift
@@ -224,8 +224,8 @@ struct TotalDailyDoseChart: View {
                             AxisGridLine()
                         }
                     case .total:
-                        // Only show every other month
-                        if day == 1 && Calendar.current.component(.month, from: date) % 2 == 1 {
+                        // Show start of every month
+                        if day == 1 {
                             AxisValueLabel(format: StatChartUtils.dateFormat(for: selectedInterval), centered: true)
                                 .font(.footnote)
                             AxisGridLine()

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Meal/MealStatsView.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Meal/MealStatsView.swift
@@ -254,9 +254,9 @@ struct MealStatsView: View {
                             AxisGridLine()
                         }
                     case .total:
-                        // Only show every other month
+                        // Show start of every month
                         let day = Calendar.current.component(.day, from: date)
-                        if day == 1 && Calendar.current.component(.month, from: date) % 2 == 1 {
+                        if day == 1 {
                             AxisValueLabel(format: StatChartUtils.dateFormat(for: selectedInterval), centered: true)
                                 .font(.footnote)
                             AxisGridLine()


### PR DESCRIPTION
Addresses:
- #1032 

Also, in 3M (3 month / quarter) mode, these charts used to only add a vertical hash at the start of every other month (Jan/Mar/May/Jul/Sep/Nov). This PR adds lines for Feb/Apr/Jun/Aug/Oct/Dec as well.

| TDD | Bolus Dist | Meals |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/8c15469d-5e21-4309-8a46-c6cbf8eccd0e" /> | <img src="https://github.com/user-attachments/assets/8460ecf0-5489-4e63-a151-cfb0c19cc610" /> | <img src="https://github.com/user-attachments/assets/30033774-134d-4b47-8c2a-f8103cd7278a" /> |

