### PR TITLE
Fix crash from force-unwrap on orphaned PumpEventStored with nil bolus

### DIFF
--- a/Trio/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/Trio/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -291,13 +291,16 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
     }
 
     func determineBolusEventType(for event: PumpEventStored) -> PumpEventStored.EventType {
-        if event.bolus!.isSMB {
+        guard let bolus = event.bolus else {
+            return event.type.flatMap({ PumpEventStored.EventType(rawValue: $0) }) ?? .bolus
+        }
+        if bolus.isSMB {
             return .smb
         }
-        if event.bolus!.isExternal {
+        if bolus.isExternal {
             return .isExternal
         }
-        return PumpEventStored.EventType(rawValue: event.type!) ?? PumpEventStored.EventType.bolus
+        return event.type.flatMap({ PumpEventStored.EventType(rawValue: $0) }) ?? .bolus
     }
 
     func getPumpHistoryNotYetUploadedToNightscout() async throws -> [NightscoutTreatment] {


### PR DESCRIPTION
This commit removes a force-unwrap from our pump event pipeline and replaces it with more idiomatic swift optional handling. The net effect of a pump event of type `bolus` that doesn't have a corresponding `bolus` property is that it'll show up in the history UI as a blank bolus but these events will be filtered out of the pump history before passing them to the algorithm.

Without this fix, when one of these pump events sneaks into an individual's pump history it will cause their app to crash before doing anything, so they have to either wait 24 hours for the pump event to age out or delete trio and start over. With the fix, it will filter these events out in a way that is consistent with the existing code for pump event handling.

To test, I manually deleted the `bolus` property of an existing bolus event in my simulator, confirmed that it crashed and then confirmed that the fix enabled the system to run correctly.