### PR TITLE
Fix active bolus view being obscured

### DIFF
--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -197,7 +197,7 @@ final class BaseAPSManager: APSManager, Injectable {
             .store(in: &lifetime)
 
         deviceDataManager.suspended
-            .receive(on: processQueue)
+            .receive(on: DispatchQueue.main)
             .sink { suspended in
                 self.isSuspended = suspended
             }

--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -197,7 +197,7 @@ final class BaseAPSManager: APSManager, Injectable {
             .store(in: &lifetime)
 
         deviceDataManager.suspended
-            .receive(on: DispatchQueue.main)
+            .receive(on: processQueue)
             .sink { suspended in
                 self.isSuspended = suspended
             }

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -1003,7 +1003,6 @@ extension Home {
             }
             .navigationTitle("Home")
             .navigationBarHidden(true)
-            .ignoresSafeArea(.keyboard)
             .blur(radius: state.isLoopStatusPresented ? 3 : 0)
             .sheet(isPresented: $state.isLoopStatusPresented) {
                 LoopStatusView(state: state)


### PR DESCRIPTION
Remove .ignoresSafeArea(.keyboard) from HomeRootView which could
intermittently cause the bottom content (active bolus/adjustment
views) to be laid out outside the visible area due to SwiftUI safe
area inset miscalculation.

~~Also, fixed a race condition in APSManager so that isSuspended is
always accessed from the main dispatch queue (it's accessed by the
UI).~~