### PR TITLE
Fix basal profile chart not showing active rate at chart's left edge

### DIFF
--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
@@ -177,6 +177,7 @@ extension MainChartView {
         let startOfDay = Calendar.current.startOfDay(for: beginDate)
         let profile = state.basalProfile
         var basalPoints: [BasalProfile] = []
+        var lastEntryBeforeRange: (amount: Double, date: Date)?
 
         // Iterate over the next three days, multiplying the time intervals
         for dayOffset in 0 ..< 3 {
@@ -185,8 +186,12 @@ extension MainChartView {
                 let basalTime = startOfDay.addingTimeInterval(entry.minutes.minutes.timeInterval + dayTimeOffset)
                 let basalTimeInterval = basalTime.timeIntervalSince1970
 
-                // Only append points within the timeBegin and timeEnd range
-                if basalTimeInterval >= timeBegin, basalTimeInterval < timeEnd {
+                if basalTimeInterval < timeBegin {
+                    // Track the last profile entry before the visible range
+                    if lastEntryBeforeRange == nil || basalTime > lastEntryBeforeRange!.date {
+                        lastEntryBeforeRange = (amount: Double(entry.rate), date: basalTime)
+                    }
+                } else if basalTimeInterval < timeEnd {
                     basalPoints.append(BasalProfile(
                         amount: Double(entry.rate),
                         isOverwritten: false,
@@ -194,6 +199,15 @@ extension MainChartView {
                     ))
                 }
             }
+        }
+
+        // Include the active profile entry at timeBegin so the line starts at the chart's left edge
+        if let lastBefore = lastEntryBeforeRange {
+            basalPoints.append(BasalProfile(
+                amount: lastBefore.amount,
+                isOverwritten: false,
+                startDate: beginDate
+            ))
         }
 
         return basalPoints


### PR DESCRIPTION
When the most recent basal rate change occurred before the visible time window, the profile line would only start at the first rate change within the visible range, leaving a gap at the left edge of the chart.

With this PR we track the last profile entry before the visible range and insert it at the chart's begin so the basal profile line always starts from the left edge with the correct active rate.

| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/c6e9d6c0-ea9b-4d41-bab3-d41c4f90e886" alt="Screenshot 1" width="320" /> | <img src="https://github.com/user-attachments/assets/e8aa58d6-d7d6-493e-afd2-e0a36c3d1ac5" alt="Screenshot 2" width="320" /> |