### PR TITLE
Typo

### DIFF
--- a/Trio/Resources/Info.plist
+++ b/Trio/Resources/Info.plist
@@ -74,7 +74,7 @@
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Bluetooth is used to communicate with insulin pump and continuous glucose monitor devices</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay</string>
+	<string>To create events with glucose values, so that they can be viewed on Apple Watch and CarPlay</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Calendar is used to create a new glucose events.</string>
 	<key>NSContactsUsageDescription</key>

--- a/Trio/Resources/Info.plist
+++ b/Trio/Resources/Info.plist
@@ -74,7 +74,7 @@
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Bluetooth is used to communicate with insulin pump and continuous glucose monitor devices</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>To create events with glucose values, so that they can be viewed on Apple Watch and CarPlay</string>
+	<string>To create events with glucose values, so they can be viewed on Apple Watch and CarPlay</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Calendar is used to create new glucose events.</string>
 	<key>NSContactsUsageDescription</key>

--- a/Trio/Resources/Info.plist
+++ b/Trio/Resources/Info.plist
@@ -80,7 +80,7 @@
 	<key>NSContactsUsageDescription</key>
 	<string>Contact is used to create a Apple Watch complication</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>For authorized acces to bolus</string>
+	<string>For authorized access to bolus</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Health App is used to store blood glucose, carbs and insulin</string>
 	<key>NSHealthUpdateUsageDescription</key>

--- a/Trio/Resources/Info.plist
+++ b/Trio/Resources/Info.plist
@@ -107,8 +107,8 @@
 		<string>remote-notification</string>
 		<string>audio</string>
 	</array>
-    <key>UIDesignRequiresCompatibility</key>
-    <true/>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/Trio/Resources/Info.plist
+++ b/Trio/Resources/Info.plist
@@ -76,7 +76,7 @@
 	<key>NSCalendarsFullAccessUsageDescription</key>
 	<string>To create events with glucose values, so that they can be viewed on Apple Watch and CarPlay</string>
 	<key>NSCalendarsUsageDescription</key>
-	<string>Calendar is used to create a new glucose events.</string>
+	<string>Calendar is used to create new glucose events.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Contact is used to create a Apple Watch complication</string>
 	<key>NSFaceIDUsageDescription</key>

--- a/Trio/Resources/InfoPlist.xcstrings
+++ b/Trio/Resources/InfoPlist.xcstrings
@@ -457,6 +457,18 @@
         }
       }
     },
+    "NSCalendarsFullAccessUsageDescription" : {
+      "comment" : "Privacy - Calendars Full Access Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "To create events with glucose values, so that they can be viewed on Apple Watch and CarPlay"
+          }
+        }
+      }
+    },
     "NSCalendarsUsageDescription" : {
       "comment" : "Privacy - Calendars Usage Description",
       "extractionState" : "extracted_with_value",

--- a/Trio/Resources/InfoPlist.xcstrings
+++ b/Trio/Resources/InfoPlist.xcstrings
@@ -473,18 +473,6 @@
       "comment" : "Privacy - Calendars Usage Description",
       "extractionState" : "extracted_with_value",
       "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar is used to create a new glucose events."
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar is used to create a new glucose events."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -500,37 +488,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Calendar is used to create a new glucose events."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar is used to create a new glucose events."
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar is used to create a new glucose events."
+            "value" : "Calendar is used to create new glucose events."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le calendrier est utilisé pour créer un nouvel événement de glycémie."
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar is used to create a new glucose events."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar is used to create a new glucose events."
           }
         },
         "it" : {
@@ -549,24 +513,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Agenda wordt gebruikt om nieuwe glucose gebeurtenissen aan te maken."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar is used to create a new glucose events."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar is used to create a new glucose events."
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar is used to create a new glucose events."
           }
         },
         "ru" : {

--- a/Trio/Resources/InfoPlist.xcstrings
+++ b/Trio/Resources/InfoPlist.xcstrings
@@ -464,7 +464,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "To create events with glucose values, so that they can be viewed on Apple Watch and CarPlay"
+            "value" : "To create events with glucose values, so they can be viewed on Apple Watch and CarPlay"
           }
         }
       }

--- a/Trio/Resources/InfoPlist.xcstrings
+++ b/Trio/Resources/InfoPlist.xcstrings
@@ -616,18 +616,6 @@
       "comment" : "Privacy - Face ID Usage Description",
       "extractionState" : "extracted_with_value",
       "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For authorized acces to bolus"
-          }
-        },
-        "ca" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For authorized acces to bolus"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -643,37 +631,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "For authorized acces to bolus"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For authorized acces to bolus"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For authorized acces to bolus"
+            "value" : "For authorized access to bolus"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pour les accès autorisés au bolus"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For authorized acces to bolus"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For authorized acces to bolus"
           }
         },
         "it" : {
@@ -692,24 +656,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Voor geautoriseerde toegang tot bolus"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For authorized acces to bolus"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For authorized acces to bolus"
-          }
-        },
-        "pt-PT" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For authorized acces to bolus"
           }
         },
         "ru" : {

--- a/TrioTests/GlucoseSmoothingTests.swift
+++ b/TrioTests/GlucoseSmoothingTests.swift
@@ -121,7 +121,7 @@ import Testing
 
     @Test(
         "Exponential smoothing stops at gaps >= 12 minutes and only updates the most recent window"
-    )  func testExponentialSmoothingGapStopsWindow() async throws {
+    ) func testExponentialSmoothingGapStopsWindow() async throws {
         let now = Date()
 
         var dates: [Date] = []


### PR DESCRIPTION
| new | old |
|---|---|
| To create events with glucose values, so they can be viewed on Apple Watch and CarPlay | To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay |
| Calendar is used to create new glucose events. | Calendar is used to create a new glucose events. |
| For authorized access to bolus | For authorized acces to bolus |

Plus a couple Xcode fixems

Thanks @ebouchut for pointing these out.