### PR TITLE
Fix Medtrum Lifetime Display for Main UI

### DIFF
--- a/Trio/Sources/APS/DeviceDataManager.swift
+++ b/Trio/Sources/APS/DeviceDataManager.swift
@@ -126,7 +126,10 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
                     pumpExpiresAtDate.send(endTime)
                 }
                 if let medtrumPump = pumpManager as? MedtrumPumpManager {
-                    guard let endTime = medtrumPump.state.patchExpiresAt else {
+                    // Medtrum's state.patchExpiresAt is actually lifespan + grace
+                    // keeping this in line with omnipod, we will use just the lifetime
+                    // i.e., state.patchGracePeriodFrom
+                    guard let endTime = medtrumPump.state.patchGracePeriodFrom else {
                         pumpExpiresAtDate.send(nil)
                         return
                     }
@@ -534,7 +537,10 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
                 $0.pumpReservoirDidChange(Decimal(medtrumPump.state.reservoir))
             }
 
-            guard let endTime = medtrumPump.state.patchExpiresAt else {
+            // Medtrum's state.patchExpiresAt is actually lifespan + grace
+            // keeping this in line with omnipod, we will use just the lifetime
+            // i.e., state.patchGracePeriodFrom
+            guard let endTime = medtrumPump.state.patchGracePeriodFrom else {
                 pumpExpiresAtDate.send(nil)
                 return
             }


### PR DESCRIPTION
Medtrum's `state.patchExpiresAt` property is actually patch lifespan + grace peroid, see `MedtrumKit > Pumpmanager > MedtrumPumpState #L231`.

Keeping in line with the displayed lifespan in Medtrum's PumpManagerUI and how it's displayed for Omnipod, this PR adjust the expiry time published via DeviceDataManager for UI display to use just the lifespan excluding grace.

| &nbsp; | Before PR | After PR |
|--------|--------|--------|
| Normal Mode |  <img width="389" height="817" alt="image" src="https://github.com/user-attachments/assets/76e07379-c12b-4e03-b754-b15beb568692" /> | <img width="785" height="1600" alt="image" src="https://github.com/user-attachments/assets/30d1e9e3-d8e8-44ee-b0e9-ab6ba56ac407" /> |
| Extended Mode |  <img width="386" height="812" alt="image" src="https://github.com/user-attachments/assets/70a3a82a-6982-444d-ae2c-921baca9ea2d" /> | <img width="784" height="1600" alt="image" src="https://github.com/user-attachments/assets/e8054bcf-a58b-4a94-a1d0-a273c1280e40" /> | 