### PR TITLE
Fix ForecastView rendering past forecast points

### DIFF
--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/ForecastView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/ForecastView.swift
@@ -41,7 +41,7 @@ struct ForecastView: ChartContent {
                         Decimal(minForecast[index] + 1)
                         .asMmolL
 
-                    if xValue <= Date(timeIntervalSinceNow: TimeInterval(hours: 2.5)) {
+                    if xValue >= Date(), xValue <= Date(timeIntervalSinceNow: TimeInterval(hours: 2.5)) {
                         AreaMark(
                             x: .value("Time", xValue),
                             // maxValue is already parsed to user units, no need to parse
@@ -57,7 +57,7 @@ struct ForecastView: ChartContent {
                     let yMaxValue = units == .mgdL ? Decimal(maxForecast[index]) : Decimal(maxForecast[index])
                         .asMmolL
 
-                    if xValue <= Date(timeIntervalSinceNow: TimeInterval(hours: 2.5)) {
+                    if xValue >= Date(), xValue <= Date(timeIntervalSinceNow: TimeInterval(hours: 2.5)) {
                         AreaMark(
                             x: .value("Time", xValue),
                             // maxValue is already parsed to user units, no need to parse
@@ -80,7 +80,7 @@ struct ForecastView: ChartContent {
             let displayValue = units == .mmolL ? valueAsDecimal.asMmolL : valueAsDecimal
             let xValue = timeForIndex(forecastValue.index)
 
-            if xValue <= Date(timeIntervalSinceNow: TimeInterval(hours: 2.5)) {
+            if xValue >= Date(), xValue <= Date(timeIntervalSinceNow: TimeInterval(hours: 2.5)) {
                 LineMark(
                     x: .value("Time", xValue),
                     y: .value("Value", displayValue)


### PR DESCRIPTION
## Summary
- ForecastView's `AreaMark` and `LineMark` were rendering for timestamps in the past, causing visual artifacts on the glucose chart
- Added a lower bound check (`xValue >= Date()`) to all three render locations so forecast marks only render for future timestamps
- The existing upper bound check (`xValue <= Date(timeIntervalSinceNow: TimeInterval(hours: 2.5))`) was already in place — this adds the missing lower bound

## Changes
**File:** `Trio/Sources/Modules/Home/View/Chart/ChartElements/ForecastView.swift`

Three identical changes at lines 44, 60, and 83:
```swift
// Before
if xValue <= Date(timeIntervalSinceNow: TimeInterval(hours: 2.5)) {

// After
if xValue >= Date(), xValue <= Date(timeIntervalSinceNow: TimeInterval(hours: 2.5)) {
```

## Test plan
- [ ] Verify forecast cone only renders for future timestamps on the glucose chart
- [ ] Confirm no visual artifacts from past forecast data points
- [ ] Check that the 2.5-hour upper bound still works correctly