### PR TITLE
Add settingsHighlightScroll modifier to settings sub-screens

### DIFF
--- a/Trio/Sources/Modules/AlgorithmAdvancedSettings/View/AlgorithmAdvancedSettingsRootView.swift
+++ b/Trio/Sources/Modules/AlgorithmAdvancedSettings/View/AlgorithmAdvancedSettingsRootView.swift
@@ -406,6 +406,7 @@ extension AlgorithmAdvancedSettings {
             .onAppear(perform: configureView)
             .navigationTitle("Additionals")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
             .onDisappear {
                 state.saveIfChanged()
             }

--- a/Trio/Sources/Modules/AutosensSettings/View/AutosensSettingsRootView.swift
+++ b/Trio/Sources/Modules/AutosensSettings/View/AutosensSettingsRootView.swift
@@ -230,6 +230,7 @@ extension AutosensSettings {
             .onAppear(perform: configureView)
             .navigationTitle("Autosens")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
     }
 }

--- a/Trio/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
+++ b/Trio/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
@@ -200,6 +200,7 @@ extension BolusCalculatorConfig {
             .onAppear(perform: configureView)
             .navigationBarTitle("Bolus Calculator")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
     }
 }

--- a/Trio/Sources/Modules/CGMSettings/View/CGMRootView.swift
+++ b/Trio/Sources/Modules/CGMSettings/View/CGMRootView.swift
@@ -150,6 +150,7 @@ extension CGMSettings {
                 .scrollContentBackground(.hidden).background(appState.trioBackgroundColor(for: colorScheme))
                 .onAppear(perform: configureView)
                 .navigationTitle("CGM")
+                .settingsHighlightScroll()
                 .navigationBarTitleDisplayMode(.automatic)
                 .navigationBarItems(leading: displayClose ? Button("Close", action: state.hideModal) : nil)
                 .sheet(isPresented: $state.shouldDisplayCGMSetupSheet) {

--- a/Trio/Sources/Modules/CalendarEventSettings/View/CalendarEventSettingsRootView.swift
+++ b/Trio/Sources/Modules/CalendarEventSettings/View/CalendarEventSettingsRootView.swift
@@ -147,6 +147,7 @@ extension CalendarEventSettings {
             .onAppear(perform: configureView)
             .navigationTitle("Calendar Events")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
     }
 }

--- a/Trio/Sources/Modules/GeneralSettings/View/UnitsLimitsSettingsRootView.swift
+++ b/Trio/Sources/Modules/GeneralSettings/View/UnitsLimitsSettingsRootView.swift
@@ -227,6 +227,7 @@ extension UnitsLimitsSettings {
             .onDisappear {
                 state.saveIfChanged()
             }
+            .settingsHighlightScroll()
         }
     }
 }

--- a/Trio/Sources/Modules/GlucoseNotificationSettings/View/GlucoseNotificationSettingsRootView.swift
+++ b/Trio/Sources/Modules/GlucoseNotificationSettings/View/GlucoseNotificationSettingsRootView.swift
@@ -264,6 +264,7 @@ extension GlucoseNotificationSettings {
             .onAppear(perform: configureView)
             .navigationBarTitle("Trio Notifications")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
 
         var lowAndHighGlucoseAlertSection: some View {

--- a/Trio/Sources/Modules/LiveActivitySettings/View/LiveActivitySettingsRootView.swift
+++ b/Trio/Sources/Modules/LiveActivitySettings/View/LiveActivitySettingsRootView.swift
@@ -233,6 +233,7 @@ extension LiveActivitySettings {
             .onAppear(perform: configureView)
             .navigationTitle("Live Activity")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
     }
 }

--- a/Trio/Sources/Modules/MealSettings/View/MealSettingsRootView.swift
+++ b/Trio/Sources/Modules/MealSettings/View/MealSettingsRootView.swift
@@ -371,6 +371,7 @@ extension MealSettings {
             .onAppear(perform: configureView)
             .navigationBarTitle("Meal Settings")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
     }
 }

--- a/Trio/Sources/Modules/NightscoutConfig/View/NightscoutFetchView.swift
+++ b/Trio/Sources/Modules/NightscoutConfig/View/NightscoutFetchView.swift
@@ -52,6 +52,7 @@ struct NightscoutFetchView: View {
         }
         .navigationTitle("Fetch")
         .navigationBarTitleDisplayMode(.automatic)
+        .settingsHighlightScroll()
         .scrollContentBackground(.hidden)
         .background(appState.trioBackgroundColor(for: colorScheme))
     }

--- a/Trio/Sources/Modules/NightscoutConfig/View/NightscoutUploadView.swift
+++ b/Trio/Sources/Modules/NightscoutConfig/View/NightscoutUploadView.swift
@@ -81,6 +81,7 @@ struct NightscoutUploadView: View {
         }
         .navigationTitle("Upload")
         .navigationBarTitleDisplayMode(.automatic)
+        .settingsHighlightScroll()
         .scrollContentBackground(.hidden)
         .background(appState.trioBackgroundColor(for: colorScheme))
     }

--- a/Trio/Sources/Modules/RemoteControlConfig/View/RemoteControlConfig.swift
+++ b/Trio/Sources/Modules/RemoteControlConfig/View/RemoteControlConfig.swift
@@ -101,6 +101,7 @@ extension RemoteControlConfig {
             .onAppear(perform: configureView)
             .navigationTitle("Remote Control")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
     }
 }

--- a/Trio/Sources/Modules/SMBSettings/View/SMBSettingsRootView.swift
+++ b/Trio/Sources/Modules/SMBSettings/View/SMBSettingsRootView.swift
@@ -370,6 +370,7 @@ extension SMBSettings {
             .onAppear(perform: configureView)
             .navigationTitle("SMB Settings")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
     }
 }

--- a/Trio/Sources/Modules/ShortcutsConfig/View/ShortcutsConfigView.swift
+++ b/Trio/Sources/Modules/ShortcutsConfig/View/ShortcutsConfigView.swift
@@ -80,6 +80,7 @@ extension ShortcutsConfig {
             .onAppear(perform: configureView)
             .navigationTitle("Shortcuts")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
     }
 }

--- a/Trio/Sources/Modules/TargetBehavoir/View/TargetBehavoirRootView.swift
+++ b/Trio/Sources/Modules/TargetBehavoir/View/TargetBehavoirRootView.swift
@@ -200,6 +200,7 @@ extension TargetBehavoir {
             }
             .navigationTitle("Target Behavior")
             .navigationBarTitleDisplayMode(.automatic)
+            .settingsHighlightScroll()
         }
 
         private var effectiveLowTTLowersSensBinding: Binding<Bool> {

--- a/Trio/Sources/Modules/WatchConfig/View/WatchConfigAppleWatchView.swift
+++ b/Trio/Sources/Modules/WatchConfig/View/WatchConfigAppleWatchView.swift
@@ -68,6 +68,7 @@ struct WatchConfigAppleWatchView: BaseView {
         }
         .navigationTitle("Apple Watch")
         .navigationBarTitleDisplayMode(.automatic)
+        .settingsHighlightScroll()
         .scrollContentBackground(.hidden)
         .background(appState.trioBackgroundColor(for: colorScheme))
     }


### PR DESCRIPTION
- Adds .settingsHighlightScroll() view modifier to 16 settings sub-screens that were missing it
- This enables the scroll-to and highlight behavior when navigating to a setting from search results