### PR TITLE
Fix crash in TidepoolManager

### DIFF
--- a/Trio/Sources/Services/Network/TidepoolManager.swift
+++ b/Trio/Sources/Services/Network/TidepoolManager.swift
@@ -320,11 +320,12 @@ extension BaseTidepoolManager {
                                     .processTempBasalEvent(event, existingTempBasalEntries: existingTempBasalEntries)
                             )
                     case .bolus:
+                        guard let amount = event.amount else { break }
                         let bolusDoseEntry = DoseEntry(
                             type: .bolus,
                             startDate: event.timestamp,
                             endDate: event.timestamp,
-                            value: Double(event.amount!),
+                            value: Double(amount),
                             unit: .units,
                             deliveredUnits: nil,
                             syncIdentifier: event.id,

--- a/Trio/Sources/Services/Network/TidepoolManager.swift
+++ b/Trio/Sources/Services/Network/TidepoolManager.swift
@@ -320,7 +320,7 @@ extension BaseTidepoolManager {
                                     .processTempBasalEvent(event, existingTempBasalEntries: existingTempBasalEntries)
                             )
                     case .bolus:
-                        guard let amount = event.amount else { break }
+                        guard let amount = event.amount else { return result }
                         let bolusDoseEntry = DoseEntry(
                             type: .bolus,
                             startDate: event.timestamp,


### PR DESCRIPTION
- Fix `EXC_BREAKPOINT (SIGTRAP)` crash in BaseTidepoolManagers `uploadDose(_:)` caused by force-unwrapping `event.amount` on a bolus event where amount is nil
- Replace `event.amount!` with `guard let amount = event.amount else { break }` to safely skip invalid bolus events

 The IPS crash report provided the crash address `0x103356038` with Trio's base address at `0x102e6c000`. Using atos with the dSYM debug symbols from the build artifacts, the crash address was symbolicated to:

  `closure #1 in BaseTidepoolManager.uploadDose(_:) (TidepoolManager.swift:313)`

Line 313 is the start of an `events.reduce` block inside a `backgroundContext.perform` closure. Inspecting the code revealed a force-unwrap `event.amount!` on line 327 for bolus events. Tracing the data flow back to `getPumpHistoryNotYetUploadedToTidepool()` confirmed that amount is set via optional chaining (`event.bolus?.amount as Decimal?`) and can be nil when the CoreData bolus relationship is missing.

Looking at the logs a CoreData batch delete of `BolusStored` entities ran at `18:32:34`, two minutes before the crash at `18:34:33` — This could have been the issue here.

 **Device Logs (crash session 2026-04-10)**

  18:32:34 [CoreData] Successfully deleted BolusStored data related to PumpEventStored older than 90 days ✅
  18:34:21 [DeviceManager] New glucose found → loop cycle starts
  18:34:30 [OpenAPS] determine_basal.js completes → pump events processed
  18:34:31 [Service] HealthKit uploadInsulin running (temp basal entries)
  18:34:33 CRASH → uploadDose() → event.amount! is nil

**Crash Report (symbolicated)**

  Exception Type:  EXC_BREAKPOINT (SIGTRAP)
  Crashed Thread:  4 — Queue: NSManagedObjectContext fetchContext

  Thread 4:
    Frame 0: closure #1 in BaseTidepoolManager.uploadDose(_:) (TidepoolManager.swift:313)
    Frame 1: partial apply for closure #1 in BaseTidepoolManager.uploadDose(_:)
    Frame 2-4: CoreData (NSManagedObjectContext.perform)
    Frame 5-11: libdispatch / libsystem_pthread