### PR TITLE
Feature/high percentage override

### DIFF
--- a/Trio/Sources/Modules/Adjustments/View/Overrides/AddOverrideForm.swift
+++ b/Trio/Sources/Modules/Adjustments/View/Overrides/AddOverrideForm.swift
@@ -110,7 +110,7 @@ struct AddOverrideForm: View {
                                 set: { state.overridePercentage = Double($0) }
                             ), label: Text("")
                         ) {
-                            ForEach(Array(stride(from: 40, through: 150, by: percentageStep)), id: \.self) { percent in
+                            ForEach(Array(stride(from: 40, through: 200, by: percentageStep)), id: \.self) { percent in
                                 Text("\(percent) %").tag(percent)
                             }
                         }

--- a/Trio/Sources/Modules/Adjustments/View/Overrides/EditOverrideForm.swift
+++ b/Trio/Sources/Modules/Adjustments/View/Overrides/EditOverrideForm.swift
@@ -172,7 +172,7 @@ struct EditOverrideForm: View {
                             label: Text("")
                         ) {
                             ForEach(
-                                Array(stride(from: 40.0, through: 150.0, by: Double(percentageStep))),
+                                Array(stride(from: 40.0, through: 200.0, by: Double(percentageStep))),
                                 id: \.self
                             ) { percent in
                                 Text("\(Int(percent)) %").tag(percent)


### PR DESCRIPTION
closes https://github.com/nightscout/Trio/issues/1105

Increase max override percentage from 150% to 200%                                                                                        
                                                                                                                                            
  Summary                                                                                                                                   
                                                                                                                                            
  - Raises the upper limit of the Basal Rate Adjustment picker in both Add Override and Edit Override forms from 150% to 200%               
  - No logic changes — only the picker range is extended
                                                                                                                                            
  Motivation                                                                                                                                
                                                                                                                                            
  Some users require basal rate overrides above 150% to manage high insulin resistance periods. The current 150% cap is too restrictive for these cases.                            
                                                                                                                                            
  Changes                                                                                                                                   
  
  - AddOverrideForm.swift: stride(from: 40, through: 150) → through: 200                                                                    
  - EditOverrideForm.swift: stride(from: 40.0, through: 150.0) → through: 200.0
                                              
  Test plan                                                                                                                                 
  
  - Open Add Override — verify picker scrolls up to 200%                                                                                    
  - Open Edit Override on an existing override — verify picker scrolls up to 200%
  - Verify values below 150% still work as before        