### PR TITLE
Add optional adjustments confirmation

### DIFF
--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -75,6 +75,7 @@ struct TrioSettings: JSON, Equatable, Encodable {
     var smartStackView: LockScreenView = .simple
     var bolusShortcut: BolusShortcutLimit = .notAllowed
     var timeInRangeType: TimeInRangeType = .timeInTightRange
+    var requireAdjustmentsConfirmation: Bool = false
 
     /// Selected Garmin watchface (Trio or SwissAlpine)
     var garminWatchface: GarminWatchface = .trio
@@ -356,6 +357,10 @@ extension TrioSettings: Decodable {
 
         if let timeInRangeType = try? container.decode(TimeInRangeType.self, forKey: .timeInRangeType) {
             settings.timeInRangeType = timeInRangeType
+        }
+
+        if let requireAdjustmentsConfirmation = try? container.decode(Bool.self, forKey: .requireAdjustmentsConfirmation) {
+            settings.requireAdjustmentsConfirmation = requireAdjustmentsConfirmation
         }
 
         if let garminWatchface = try? container.decode(GarminWatchface.self, forKey: .garminWatchface) {

--- a/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel.swift
+++ b/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel.swift
@@ -14,7 +14,7 @@ extension Adjustments {
         @ObservationIgnored @Injected() var nightscoutManager: NightscoutManager!
 
         var requireAdjustmentsConfirmation: Bool = false
-        var shouldDisplayPresetActivateConfirmDialog: Bool = false
+        var shouldDisplayPresetStartConfirmDialog: Bool = false
 
         // MARK: - Override and Temp Target Properties
 

--- a/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel.swift
+++ b/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel.swift
@@ -13,6 +13,9 @@ extension Adjustments {
         @ObservationIgnored @Injected() var overrideStorage: OverrideStorage!
         @ObservationIgnored @Injected() var nightscoutManager: NightscoutManager!
 
+        var requireAdjustmentsConfirmation: Bool = false
+        var shouldDisplayPresetActivateConfirmDialog: Bool = false
+
         // MARK: - Override and Temp Target Properties
 
         var overridePercentage: Double = 100
@@ -162,6 +165,7 @@ extension Adjustments {
                 target: tempTargetTarget,
                 autosensMax: autosensMax
             )
+            requireAdjustmentsConfirmation = settingsManager.settings.requireAdjustmentsConfirmation
             Task {
                 await getCurrentGlucoseTarget()
             }
@@ -256,6 +260,7 @@ extension Adjustments.StateModel: SettingsObserver, PreferencesObserver {
     /// Updates settings when they change.
     func settingsDidChange(_: TrioSettings) {
         units = settingsManager.settings.units
+        requireAdjustmentsConfirmation = settingsManager.settings.requireAdjustmentsConfirmation
         Task {
             await getCurrentGlucoseTarget()
         }

--- a/Trio/Sources/Modules/Adjustments/View/AdjustmentsRootView.swift
+++ b/Trio/Sources/Modules/Adjustments/View/AdjustmentsRootView.swift
@@ -23,6 +23,7 @@ extension Adjustments {
         @State var isEditingTT = false
         @State var showCancelOverrideConfirmDialog = false
         @State var showCancelTempTargetConfirmDialog = false
+        @State var pendingPresetActivation: PendingPresetActivation?
 
         private var shouldDisplayStickyOverrideStopButton: Bool {
             state.isOverrideEnabled && state.activeOverrideName.isNotEmpty
@@ -171,6 +172,23 @@ extension Adjustments {
                 } message: {
                     Text("Stop the Temp Target \"\(state.currentActiveTempTarget?.name ?? "")\"?")
                 }
+                .confirmationDialog(
+                    "Activate Preset",
+                    isPresented: presetActivationConfirmationBinding
+                ) {
+                    Button("Activate") {
+                        if let activation = pendingPresetActivation {
+                            activatePreset(activation)
+                        }
+                    }
+
+                    Button("Cancel", role: .cancel) {
+                        state.shouldDisplayPresetActivateConfirmDialog = false
+                        pendingPresetActivation = nil
+                    }
+                } message: {
+                    Text("Are you sure you want to activate preset \"\(pendingPresetActivation?.name ?? "")\"?")
+                }
             }).background(appState.trioBackgroundColor(for: colorScheme))
         }
 
@@ -287,6 +305,83 @@ extension Adjustments {
                 return "\(minutes)m \(seconds)s"
             } else {
                 return "<1m"
+            }
+        }
+    }
+}
+
+// MARK: Preset Activation Handling
+
+extension Adjustments.RootView: View {
+    enum PendingPresetActivation {
+        case override(objectID: NSManagedObjectID, presetID: String?, name: String)
+        case tempTarget(objectID: NSManagedObjectID, presetID: String?, name: String)
+
+        var name: String {
+            switch self {
+            case let .override(_, _, name),
+                 let .tempTarget(_, _, name):
+                return name
+            }
+        }
+    }
+
+    private var presetActivationConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: {
+                state.requireAdjustmentsConfirmation &&
+                    state.shouldDisplayPresetActivateConfirmDialog &&
+                    pendingPresetActivation != nil
+            },
+            set: { isPresented in
+                if !isPresented {
+                    state.shouldDisplayPresetActivateConfirmDialog = false
+                    pendingPresetActivation = nil
+                }
+            }
+        )
+    }
+
+    func requestPresetActivation(_ activation: PendingPresetActivation) {
+        if state.requireAdjustmentsConfirmation {
+            pendingPresetActivation = activation
+            state.shouldDisplayPresetActivateConfirmDialog = true
+        } else {
+            activatePreset(activation)
+        }
+    }
+
+    func activatePreset(_ activation: PendingPresetActivation) {
+        Task {
+            switch activation {
+            case let .override(objectID, presetID, _):
+                await state.enactOverridePreset(withID: objectID)
+
+                await MainActor.run {
+                    state.hideModal()
+                    selectedOverridePresetID = presetID
+                    showOverrideCheckmark = true
+                    state.shouldDisplayPresetActivateConfirmDialog = false
+                    pendingPresetActivation = nil
+                }
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                    showOverrideCheckmark = false
+                }
+
+            case let .tempTarget(objectID, presetID, _):
+                await state.enactTempTargetPreset(withID: objectID)
+
+                await MainActor.run {
+                    selectedTempTargetPresetID = presetID
+                    showTempTargetCheckmark = true
+                    state.shouldDisplayPresetActivateConfirmDialog = false
+                    pendingPresetActivation = nil
+                }
+
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                    showTempTargetCheckmark = false
+                }
             }
         }
     }

--- a/Trio/Sources/Modules/Adjustments/View/AdjustmentsRootView.swift
+++ b/Trio/Sources/Modules/Adjustments/View/AdjustmentsRootView.swift
@@ -183,11 +183,13 @@ extension Adjustments {
                     }
 
                     Button("Cancel", role: .cancel) {
-                        state.shouldDisplayPresetActivateConfirmDialog = false
+                        state.shouldDisplayPresetStartConfirmDialog = false
                         pendingPresetActivation = nil
                     }
                 } message: {
-                    Text("Are you sure you want to activate preset \"\(pendingPresetActivation?.name ?? "")\"?")
+                    if let activation = pendingPresetActivation {
+                        Text(activation.confirmationMessage)
+                    }
                 }
             }).background(appState.trioBackgroundColor(for: colorScheme))
         }
@@ -324,18 +326,31 @@ extension Adjustments.RootView: View {
                 return name
             }
         }
+
+        var adjustmentType: String {
+            switch self {
+            case .override:
+                return String(localized: "Override")
+            case .tempTarget:
+                return String(localized: "Temp Target")
+            }
+        }
+
+        var confirmationMessage: String {
+            String(localized: "Start the \(adjustmentType) \"\(name)\"?", comment: "Confirmation message for starting a preset")
+        }
     }
 
     private var presetActivationConfirmationBinding: Binding<Bool> {
         Binding(
             get: {
                 state.requireAdjustmentsConfirmation &&
-                    state.shouldDisplayPresetActivateConfirmDialog &&
+                    state.shouldDisplayPresetStartConfirmDialog &&
                     pendingPresetActivation != nil
             },
             set: { isPresented in
                 if !isPresented {
-                    state.shouldDisplayPresetActivateConfirmDialog = false
+                    state.shouldDisplayPresetStartConfirmDialog = false
                     pendingPresetActivation = nil
                 }
             }
@@ -345,7 +360,7 @@ extension Adjustments.RootView: View {
     func requestPresetActivation(_ activation: PendingPresetActivation) {
         if state.requireAdjustmentsConfirmation {
             pendingPresetActivation = activation
-            state.shouldDisplayPresetActivateConfirmDialog = true
+            state.shouldDisplayPresetStartConfirmDialog = true
         } else {
             activatePreset(activation)
         }
@@ -361,7 +376,7 @@ extension Adjustments.RootView: View {
                     state.hideModal()
                     selectedOverridePresetID = presetID
                     showOverrideCheckmark = true
-                    state.shouldDisplayPresetActivateConfirmDialog = false
+                    state.shouldDisplayPresetStartConfirmDialog = false
                     pendingPresetActivation = nil
                 }
 
@@ -375,7 +390,7 @@ extension Adjustments.RootView: View {
                 await MainActor.run {
                     selectedTempTargetPresetID = presetID
                     showTempTargetCheckmark = true
-                    state.shouldDisplayPresetActivateConfirmDialog = false
+                    state.shouldDisplayPresetStartConfirmDialog = false
                     pendingPresetActivation = nil
                 }
 

--- a/Trio/Sources/Modules/Adjustments/View/Overrides/AdjustmentsRootView+Overrides.swift
+++ b/Trio/Sources/Modules/Adjustments/View/Overrides/AdjustmentsRootView+Overrides.swift
@@ -17,7 +17,7 @@ extension Adjustments.RootView {
         Section {
             ForEach(state.overridePresets) { preset in
                 overridesView(for: preset, showCheckMark: showOverrideCheckmark) {
-                    enactOverridePreset(preset)
+                    requestOverridePresetActivation(preset)
                 }
                 .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                     swipeActionsForOverrides(for: preset)
@@ -73,22 +73,17 @@ extension Adjustments.RootView {
         }
     }
 
-    func enactOverridePreset(_ preset: OverrideStored) {
-        Task {
-            let objectID = preset.objectID
-            await state.enactOverridePreset(withID: objectID)
-            state.hideModal()
-            selectedOverridePresetID = preset.id
-            showOverrideCheckmark = true
+    private func requestOverridePresetActivation(_ preset: OverrideStored) {
+        let activation = PendingPresetActivation.override(
+            objectID: preset.objectID,
+            presetID: preset.id,
+            name: preset.name ?? ""
+        )
 
-            // Deactivate checkmark after 3 seconds
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                showOverrideCheckmark = false
-            }
-        }
+        requestPresetActivation(activation)
     }
 
-    func swipeActionsForOverrides(for preset: OverrideStored) -> some View {
+    private func swipeActionsForOverrides(for preset: OverrideStored) -> some View {
         Group {
             Button(role: .none) {
                 selectedOverride = preset

--- a/Trio/Sources/Modules/Adjustments/View/TempTargets/AdjustmentsRootView+TempTargets.swift
+++ b/Trio/Sources/Modules/Adjustments/View/TempTargets/AdjustmentsRootView+TempTargets.swift
@@ -34,7 +34,7 @@ extension Adjustments.RootView {
         Section {
             ForEach(state.tempTargetPresets) { preset in
                 tempTargetView(for: preset, showCheckmark: showTempTargetCheckmark) {
-                    enactTempTargetPreset(preset)
+                    requestTempTargetPresetActivation(preset)
                 }
                 .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                     swipeActionsForTempTargets(for: preset)
@@ -61,17 +61,14 @@ extension Adjustments.RootView {
         }
     }
 
-    private func enactTempTargetPreset(_ preset: TempTargetStored) {
-        Task {
-            let objectID = preset.objectID
-            await state.enactTempTargetPreset(withID: objectID)
-            selectedTempTargetPresetID = preset.id?.uuidString
-            showTempTargetCheckmark = true
+    private func requestTempTargetPresetActivation(_ preset: TempTargetStored) {
+        let activation = PendingPresetActivation.tempTarget(
+            objectID: preset.objectID,
+            presetID: preset.id?.uuidString,
+            name: preset.name ?? ""
+        )
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                showTempTargetCheckmark = false
-            }
-        }
+        requestPresetActivation(activation)
     }
 
     private func swipeActionsForTempTargets(for tempTarget: TempTargetStored) -> some View {

--- a/Trio/Sources/Modules/Settings/SettingItems.swift
+++ b/Trio/Sources/Modules/Settings/SettingItems.swift
@@ -240,7 +240,8 @@ enum SettingItems {
                 "Glucose Color Scheme",
                 "Time in Range Type",
                 "Time in Tight Range (TITR)",
-                "Time in Normoglycemia (TING)"
+                "Time in Normoglycemia (TING)",
+                "Require Adjustments Confirmation"
             ],
             path: ["Features", "User Interface"]
         ),

--- a/Trio/Sources/Modules/SettingsExport/SettingsExportStateModel.swift
+++ b/Trio/Sources/Modules/SettingsExport/SettingsExportStateModel.swift
@@ -809,6 +809,13 @@ extension SettingsExport {
                     name: String(localized: "Time in Range Type"),
                     value: trioSettings.timeInRangeType.rawValue
                 )
+                addSetting(
+                    category: featuresCategory,
+                    subcategory: userInterfaceSubcategory,
+                    name: String(localized: "Require Adjustments Confirmation"),
+                    value: trioSettings
+                        .requireAdjustmentsConfirmation ? String(localized: "Enabled") : String(localized: "Disabled")
+                )
 
                 // Appearance setting from UserDefaults
                 let colorSchemePreference = UserDefaults.standard.string(forKey: "colorSchemePreference") ?? "systemDefault"

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
@@ -14,6 +14,7 @@ extension UserInterfaceSettings {
         @Published var glucoseColorScheme: GlucoseColorScheme = .staticColor
         @Published var eA1cDisplayUnit: EstimatedA1cDisplayUnit = .percent
         @Published var timeInRangeType: TimeInRangeType = .timeInTightRange
+        @Published var requireAdjustmentsConfirmation: Bool = false
 
         var units: GlucoseUnits = .mgdL
 
@@ -44,6 +45,9 @@ extension UserInterfaceSettings {
             subscribeSetting(\.eA1cDisplayUnit, on: $eA1cDisplayUnit) { eA1cDisplayUnit = $0 }
 
             subscribeSetting(\.timeInRangeType, on: $timeInRangeType) { timeInRangeType = $0 }
+
+            subscribeSetting(\.requireAdjustmentsConfirmation, on: $requireAdjustmentsConfirmation) {
+                requireAdjustmentsConfirmation = $0 }
         }
     }
 }

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -561,6 +561,29 @@ extension UserInterfaceSettings {
                     ),
                     headerText: String(localized: "Carbs Required Badge")
                 )
+
+                SettingInputSection(
+                    decimalValue: $decimalPlaceholder,
+                    booleanValue: $state.requireAdjustmentsConfirmation,
+                    shouldDisplayHint: $shouldDisplayHint,
+                    selectedVerboseHint: Binding(
+                        get: { selectedVerboseHint },
+                        set: {
+                            selectedVerboseHint = $0.map { AnyView($0) }
+                            hintLabel = String(localized: "Require Adjustments Confirmation")
+                        }
+                    ),
+                    units: state.units,
+                    type: .boolean,
+                    label: String(localized: "Require Adjustments Confirmation"),
+                    miniHint: String(
+                        localized: "If enabled, a confirmation dialog will be shown when activating adjustment presets."
+                    ),
+                    verboseHint: Text(
+                        "Turning this on will show a confirmation dialog when you activate an Override or Temporary Target preset. This is for users who would like avoid accidentally activating a preset by mistake."
+                    ),
+                    headerText: String(localized: "Adjustments")
+                )
             }
             .listSectionSpacing(sectionSpacing)
             .sheet(isPresented: $shouldDisplayHint) {


### PR DESCRIPTION
* Introduce new setting `requireAdjustmentsConfirmation`
* Refactor adjustments presets activation handling
   * If `requireAdjustmentsConfirmation` is `true` / enabled, show confirmation dialog before firing preset activation workflow
   * If `requireAdjustmentsConfirmation` is `false` / disabled, immediately activate preset (like before)
* Addresses #1110

| New Setting | *New* With Confirmation | Without Confirmation |
|--------|--------|--------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ea645c96-546e-4a07-88ce-382aa3953dc8" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/4b9b0b7f-4664-4295-975e-5728841914ce" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/5db8f364-0880-4f75-96cc-dc64f9dc872e" /> | 