### PR TITLE
Add context menu to all swipeable list items

### DIFF
--- a/Trio/Sources/Modules/Adjustments/View/Overrides/AdjustmentsRootView+Overrides.swift
+++ b/Trio/Sources/Modules/Adjustments/View/Overrides/AdjustmentsRootView+Overrides.swift
@@ -93,7 +93,7 @@ extension Adjustments.RootView {
 
     func actionButtonsForOverrides(for preset: OverrideStored) -> some View {
         Group {
-            Button(role: .none) {
+            Button(role: .destructive) {
                 selectedOverride = preset
                 isConfirmDeletePresented = true
             } label: {

--- a/Trio/Sources/Modules/Adjustments/View/Overrides/AdjustmentsRootView+Overrides.swift
+++ b/Trio/Sources/Modules/Adjustments/View/Overrides/AdjustmentsRootView+Overrides.swift
@@ -19,8 +19,11 @@ extension Adjustments.RootView {
                 overridesView(for: preset, showCheckMark: showOverrideCheckmark) {
                     enactOverridePreset(preset)
                 }
+                .contextMenu {
+                    actionButtonsForOverrides(for: preset)
+                }
                 .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                    swipeActionsForOverrides(for: preset)
+                    actionButtonsForOverrides(for: preset)
                 }
             }
             .onMove(perform: state.reorderOverride)
@@ -88,7 +91,7 @@ extension Adjustments.RootView {
         }
     }
 
-    func swipeActionsForOverrides(for preset: OverrideStored) -> some View {
+    func actionButtonsForOverrides(for preset: OverrideStored) -> some View {
         Group {
             Button(role: .none) {
                 selectedOverride = preset

--- a/Trio/Sources/Modules/Adjustments/View/TempTargets/AdjustmentsRootView+TempTargets.swift
+++ b/Trio/Sources/Modules/Adjustments/View/TempTargets/AdjustmentsRootView+TempTargets.swift
@@ -21,7 +21,7 @@ extension Adjustments.RootView {
             ForEach(state.scheduledTempTargets) { tempTarget in
                 tempTargetView(for: tempTarget)
                     .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        swipeActionsForTempTargets(for: tempTarget)
+                        actionButtonsForTempTargets(for: tempTarget)
                     }
             }
             .listRowBackground(Color.chart)
@@ -36,8 +36,11 @@ extension Adjustments.RootView {
                 tempTargetView(for: preset, showCheckmark: showTempTargetCheckmark) {
                     enactTempTargetPreset(preset)
                 }
+                .contextMenu {
+                    actionButtonsForTempTargets(for: preset)
+                }
                 .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                    swipeActionsForTempTargets(for: preset)
+                    actionButtonsForTempTargets(for: preset)
                 }
             }
             .onMove(perform: state.reorderTempTargets)
@@ -74,7 +77,7 @@ extension Adjustments.RootView {
         }
     }
 
-    private func swipeActionsForTempTargets(for tempTarget: TempTargetStored) -> some View {
+    private func actionButtonsForTempTargets(for tempTarget: TempTargetStored) -> some View {
         Group {
             Button {
                 Task {

--- a/Trio/Sources/Modules/Adjustments/View/TempTargets/AdjustmentsRootView+TempTargets.swift
+++ b/Trio/Sources/Modules/Adjustments/View/TempTargets/AdjustmentsRootView+TempTargets.swift
@@ -79,7 +79,7 @@ extension Adjustments.RootView {
 
     private func actionButtonsForTempTargets(for tempTarget: TempTargetStored) -> some View {
         Group {
-            Button {
+            Button(role: .destructive) {
                 Task {
                     selectedTempTarget = tempTarget
                     isConfirmDeletePresented = true

--- a/Trio/Sources/Modules/History/View/HistoryRootView.swift
+++ b/Trio/Sources/Modules/History/View/HistoryRootView.swift
@@ -511,7 +511,7 @@ extension History {
                             Button(
                                 "Delete",
                                 systemImage: "trash.fill",
-                                role: .none,
+                                role: .destructive,
                                 action: {
                                     alertGlucoseToDelete = glucose
 
@@ -692,7 +692,7 @@ extension History {
                     Button(
                         "Delete",
                         systemImage: "trash.fill",
-                        role: .none,
+                        role: .destructive,
                         action: {
                             alertTreatmentToDelete = item
                             alertTitle = String(localized: "Delete Insulin?", comment: "Alert title for deleting insulin")
@@ -798,7 +798,7 @@ extension History {
                 Button(
                     "Delete",
                     systemImage: "trash.fill",
-                    role: .none,
+                    role: .destructive,
                     action: {
                         alertCarbEntryToDelete = meal
 
@@ -843,7 +843,7 @@ extension History {
                 Button(
                     "Delete",
                     systemImage: "trash.fill",
-                    role: .none,
+                    role: .destructive,
                     action: {
                         alertCarbEntryToDelete = meal
 

--- a/Trio/Sources/Modules/History/View/HistoryRootView.swift
+++ b/Trio/Sources/Modules/History/View/HistoryRootView.swift
@@ -506,7 +506,27 @@ extension History {
                             Spacer()
 
                             Text(Formatter.dateFormatter.string(from: glucose.date ?? Date()))
-                        }.swipeActions {
+                        }
+                        .contextMenu {
+                            Button(
+                                "Delete",
+                                systemImage: "trash.fill",
+                                role: .none,
+                                action: {
+                                    alertGlucoseToDelete = glucose
+
+                                    let glucoseToDisplay = state.units == .mgdL ? glucose.glucose
+                                        .description : Int(glucose.glucose).formattedAsMmolL
+                                    alertTitle = String(localized: "Delete Glucose?", comment: "Alert title for deleting glucose")
+                                    alertMessage = Formatter.dateFormatter
+                                        .string(from: glucose.date ?? Date()) + ", " + glucoseToDisplay + " " + state.units
+                                        .rawValue
+
+                                    isRemoveHistoryItemAlertPresented = true
+                                }
+                            ).tint(.red)
+                        }
+                        .swipeActions {
                             Button(
                                 "Delete",
                                 systemImage: "trash.fill",
@@ -667,6 +687,34 @@ extension History {
                 Spacer()
                 Text(Formatter.dateFormatter.string(from: item.timestamp ?? Date())).moveDisabled(true)
             }
+            .contextMenu {
+                if item.bolus != nil {
+                    Button(
+                        "Delete",
+                        systemImage: "trash.fill",
+                        role: .none,
+                        action: {
+                            alertTreatmentToDelete = item
+                            alertTitle = String(localized: "Delete Insulin?", comment: "Alert title for deleting insulin")
+                            alertMessage = Formatter.dateFormatter
+                                .string(from: item.timestamp ?? Date()) + ", " +
+                                (Formatter.decimalFormatterWithThreeFractionDigits.string(from: item.bolus?.amount ?? 0) ?? "0") +
+                                String(localized: " U", comment: "Insulin unit")
+
+                            if let bolus = item.bolus {
+                                // Add text snippet, so that alert message is more descriptive for SMBs
+                                alertMessage += bolus.isSMB ? String(
+                                    localized: " SMB",
+                                    comment: "Super Micro Bolus indicator in delete alert"
+                                )
+                                    : ""
+                            }
+
+                            isRemoveHistoryItemAlertPresented = true
+                        }
+                    ).tint(.red)
+                }
+            }
             .swipeActions {
                 if item.bolus != nil {
                     Button(
@@ -745,6 +793,51 @@ extension History {
                         Spacer()
                     }.padding(.top, 5).foregroundColor(.secondary)
                 }
+            }
+            .contextMenu {
+                Button(
+                    "Delete",
+                    systemImage: "trash.fill",
+                    role: .none,
+                    action: {
+                        alertCarbEntryToDelete = meal
+
+                        // meal is carb-only
+                        if meal.fpuID == nil {
+                            alertTitle = String(localized: "Delete Carbs?", comment: "Alert title for deleting carbs")
+                            alertMessage = Formatter.dateFormatter
+                                .string(from: meal.date ?? Date()) + ", " +
+                                (Formatter.decimalFormatterWithTwoFractionDigits.string(for: meal.carbs) ?? "0") +
+                                String(localized: " g", comment: "gram of carbs")
+                        }
+                        // meal is complex-meal or fpu-only
+                        else {
+                            alertTitle = meal.isFPU ? String(
+                                localized: "Delete Carbs Equivalents?",
+                                comment: "Alert title for deleting carb equivalents"
+                            )
+                                : String(localized: "Delete Carbs?", comment: "Alert title for deleting carbs")
+                            alertMessage = String(
+                                localized: "All FPUs and the carbs of the meal will be deleted.",
+                                comment: "Alert message for meal deletion"
+                            )
+                        }
+
+                        isRemoveHistoryItemAlertPresented = true
+                    }
+                ).tint(.red)
+
+                Button(
+                    "Edit",
+                    systemImage: "pencil",
+                    role: .none,
+                    action: {
+                        state.carbEntryToEdit = meal
+                        state.showCarbEntryEditor = true
+                    }
+                )
+                .tint(!state.settingsManager.settings.useFPUconversion && meal.isFPU ? Color(.systemGray4) : Color.blue)
+                .disabled(!state.settingsManager.settings.useFPUconversion && meal.isFPU)
             }
             .swipeActions {
                 Button(

--- a/Trio/Sources/Modules/Onboarding/View/TherapySettingEditorView.swift
+++ b/Trio/Sources/Modules/Onboarding/View/TherapySettingEditorView.swift
@@ -96,6 +96,18 @@ struct TherapySettingEditorView: View {
                                 .transition(.slide)
                             }
                         }
+                        .contextMenu {
+                            if let index = items.firstIndex(where: { $0.id == item.id }), items.count > 1 {
+                                Button(role: .destructive) {
+                                    items.remove(at: index)
+                                    selectedItemID = nil
+                                    validateTherapySettingItems()
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                                .tint(.red)
+                            }
+                        }
                         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                             if let index = items.firstIndex(where: { $0.id == item.id }), items.count > 1 {
                                 Button(role: .destructive) {


### PR DESCRIPTION
## Summary

Adds context menus to list items that previously only exposed actions through swipe gestures, improving action discoverability and accessibility across the app. This makes delete/edit actions available via long press or secondary click in addition to existing swipe actions.

Addresses #1119.

## Changes

- Added context menus for Adjustments
  -  Override presets
  - Temp Target presets
- Added context menus for History items:
  - Glucose entries
  - Insulin/bolus entries
  - Carb and FPU meal entries
- Added context menu delete support to therapy setting rows in onboarding.
- Updated delete buttons to use `.destructive` role for consistent system styling and semantics.

## Screenshots

| Carb Entries | Treatments | Glucose |
|--------|--------|--------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/a70c2dab-7172-44e3-9632-95e4bb7fe463" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/44c73024-10b5-4da8-b0a2-488173635108" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/16b4fe13-06c7-4276-882e-e30fbadbd9ca" /> | 

| Override presets | Temp Target presets | Therapy Item |
|--------|--------|--------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e1addd50-46b5-412c-93c2-0d8263dbdb43" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/a0254417-8aaa-42f3-b795-68de9bda5787" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/c500be0e-0c9c-46e5-a63c-d1dbe99e0c6e" /> | 

### Notes
The placement / alignment of the context menu for therapy items seems odd. However, this is the default render mode for the menu; there's no custom alignment implemented. I'm not sure it's a good addition for therapy items. 