### PR TITLE
Change Delete button role to .none

### DIFF
--- a/Trio/Sources/Modules/History/View/HistoryRootView.swift
+++ b/Trio/Sources/Modules/History/View/HistoryRootView.swift
@@ -843,7 +843,7 @@ extension History {
                 Button(
                     "Delete",
                     systemImage: "trash.fill",
-                    role: .destructive,
+                    role: .none,
                     action: {
                         alertCarbEntryToDelete = meal
 


### PR DESCRIPTION
Resolves #1121

#1119 changed the swipe Delete button in the meals history list to use `role: .destructive`, which causes SwiftUI to animate the row away immediately after the action fires — taking the confirmation alert with it before the user can tap "Delete". This PR changes it back to `role: .none` to match the pattern still used by the insulin and glucose swipe actions.