### PR TITLE
Use Int instead of String for date in AlgorithmGlucose

### DIFF
--- a/Model/Helper/GlucoseStored+helper.swift
+++ b/Model/Helper/GlucoseStored+helper.swift
@@ -124,42 +124,6 @@ extension NSPredicate {
     }
 }
 
-extension GlucoseStored: Encodable {
-    enum CodingKeys: String, CodingKey {
-        case date
-        case dateString
-        case sgv
-        case glucose
-        case direction
-        case id
-        case type
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-
-        let dateFormatter = ISO8601DateFormatter()
-        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-
-        try container.encode(dateFormatter.string(from: date ?? Date()), forKey: .dateString)
-
-        let dateAsUnixTimestamp = String(format: "%.0f", (date?.timeIntervalSince1970 ?? Date().timeIntervalSince1970) * 1000)
-        try container.encode(dateAsUnixTimestamp, forKey: .date)
-
-        try container.encode(direction, forKey: .direction)
-        try container.encode(id, forKey: .id)
-
-        // TODO: Handle the type of the glucose entry conditionally not hardcoded
-        try container.encode("sgv", forKey: .type)
-
-        if isManual {
-            try container.encode(glucose, forKey: .glucose)
-        } else {
-            try container.encode(glucose, forKey: .sgv)
-        }
-    }
-}
-
 // In order to show the correct direction in the bobble we convert the direction property of the NSManagedObject GlucoseStored back to the Direction type
 extension GlucoseStored {
     var directionEnum: BloodGlucose.Direction? {

--- a/Trio/Sources/Models/AlgorithmGlucose.swift
+++ b/Trio/Sources/Models/AlgorithmGlucose.swift
@@ -68,7 +68,7 @@ struct AlgorithmGlucose: Codable {
 
         try container.encode(dateFormatter.string(from: date ?? Date()), forKey: .dateString)
 
-        let dateAsUnixTimestamp = String(format: "%.0f", (date?.timeIntervalSince1970 ?? Date().timeIntervalSince1970) * 1000)
+        let dateAsUnixTimestamp = Int64((date?.timeIntervalSince1970 ?? Date().timeIntervalSince1970) * 1000)
         try container.encode(dateAsUnixTimestamp, forKey: .date)
 
         try container.encode(direction, forKey: .direction)


### PR DESCRIPTION
This PR fixes an encoding mistake when we convert AlgorithmGlucose to JSON where we use an Int instead of a String to represent the `date` property. It also includes deleting an unused helper function from GlucoseStorage that has the same mistake.

Fixes: https://github.com/nightscout/Trio/issues/1122 and https://github.com/nightscout/Trio/issues/1071