### PR TITLE
Fix empty help sheet on first cold tap

### DIFF
--- a/Trio/Sources/Modules/DynamicSettings/View/DynamicSettingsRootView.swift
+++ b/Trio/Sources/Modules/DynamicSettings/View/DynamicSettingsRootView.swift
@@ -5,12 +5,36 @@ extension DynamicSettings {
     struct RootView: BaseView {
         let resolver: Resolver
         @StateObject var state = StateModel()
-        @State private var shouldDisplayHint: Bool = false
         @State var hintDetent = PresentationDetent.large
-        @State var selectedVerboseHint: AnyView?
-        @State var hintLabel: String?
+        @State private var hintPayload: HintPayload?
         @State private var decimalPlaceholder: Decimal = 0.0
         @State private var booleanPlaceholder: Bool = false
+
+        private struct HintPayload: Identifiable {
+            let id = UUID()
+            let label: String
+            let content: AnyView
+        }
+
+        private var shouldDisplayHintBinding: Binding<Bool> {
+            Binding(
+                get: { hintPayload != nil },
+                set: { newValue in if !newValue { hintPayload = nil } }
+            )
+        }
+
+        private func verboseHintBinding(label: String) -> Binding<(any View)?> {
+            Binding(
+                get: { hintPayload?.content },
+                set: { newView in
+                    if let view = newView {
+                        hintPayload = HintPayload(label: label, content: AnyView(view))
+                    } else {
+                        hintPayload = nil
+                    }
+                }
+            )
+        }
 
         private var conversionFormatter: NumberFormatter {
             let formatter = NumberFormatter()
@@ -76,9 +100,9 @@ extension DynamicSettings {
                                 Spacer()
                                 Button(
                                     action: {
-                                        hintLabel = String(localized: "Dynamic Insulin Sensitivity")
-                                        selectedVerboseHint =
-                                            AnyView(
+                                        hintPayload = HintPayload(
+                                            label: String(localized: "Dynamic Insulin Sensitivity"),
+                                            content: AnyView(
                                                 VStack(alignment: .leading, spacing: 10) {
                                                     Text("Default: Disabled").bold()
                                                     Text(
@@ -124,7 +148,7 @@ extension DynamicSettings {
                                                     }
                                                 }
                                             )
-                                        shouldDisplayHint.toggle()
+                                        )
                                     },
                                     label: {
                                         HStack {
@@ -142,14 +166,8 @@ extension DynamicSettings {
                         SettingInputSection(
                             decimalValue: $state.adjustmentFactor,
                             booleanValue: $booleanPlaceholder,
-                            shouldDisplayHint: $shouldDisplayHint,
-                            selectedVerboseHint: Binding(
-                                get: { selectedVerboseHint },
-                                set: {
-                                    selectedVerboseHint = $0.map { AnyView($0) }
-                                    hintLabel = String(localized: "Adjustment Factor (AF)")
-                                }
-                            ),
+                            shouldDisplayHint: shouldDisplayHintBinding,
+                            selectedVerboseHint: verboseHintBinding(label: String(localized: "Adjustment Factor (AF)")),
                             // TODO?: include conditional links to Desmos logarithmic graphs based on which .glucose setting is used
                             units: state.units,
                             type: .decimal("adjustmentFactor"),
@@ -173,14 +191,8 @@ extension DynamicSettings {
                         SettingInputSection(
                             decimalValue: $state.adjustmentFactorSigmoid,
                             booleanValue: $booleanPlaceholder,
-                            shouldDisplayHint: $shouldDisplayHint,
-                            selectedVerboseHint: Binding(
-                                get: { selectedVerboseHint },
-                                set: {
-                                    selectedVerboseHint = $0.map { AnyView($0) }
-                                    hintLabel = String(localized: "Sigmoid Adjustment Factor")
-                                }
-                            ),
+                            shouldDisplayHint: shouldDisplayHintBinding,
+                            selectedVerboseHint: verboseHintBinding(label: String(localized: "Sigmoid Adjustment Factor")),
                             units: state.units,
                             type: .decimal("adjustmentFactorSigmoid"),
                             label: String(localized: "Sigmoid Adjustment Factor"),
@@ -207,14 +219,8 @@ extension DynamicSettings {
                     SettingInputSection(
                         decimalValue: $state.weightPercentage,
                         booleanValue: $booleanPlaceholder,
-                        shouldDisplayHint: $shouldDisplayHint,
-                        selectedVerboseHint: Binding(
-                            get: { selectedVerboseHint },
-                            set: {
-                                selectedVerboseHint = $0.map { AnyView($0) }
-                                hintLabel = String(localized: "Weighted Average of TDD")
-                            }
-                        ),
+                        shouldDisplayHint: shouldDisplayHintBinding,
+                        selectedVerboseHint: verboseHintBinding(label: String(localized: "Weighted Average of TDD")),
                         units: state.units,
                         type: .decimal("weightPercentage"),
                         label: String(localized: "Weighted Average of TDD"),
@@ -236,14 +242,8 @@ extension DynamicSettings {
                     SettingInputSection(
                         decimalValue: $decimalPlaceholder,
                         booleanValue: $state.tddAdjBasal,
-                        shouldDisplayHint: $shouldDisplayHint,
-                        selectedVerboseHint: Binding(
-                            get: { selectedVerboseHint },
-                            set: {
-                                selectedVerboseHint = $0.map { AnyView($0) }
-                                hintLabel = String(localized: "Adjust Basal")
-                            }
-                        ),
+                        shouldDisplayHint: shouldDisplayHintBinding,
+                        selectedVerboseHint: verboseHintBinding(label: String(localized: "Adjust Basal")),
                         units: state.units,
                         type: .boolean,
                         label: String(localized: "Adjust Basal"),
@@ -264,12 +264,12 @@ extension DynamicSettings {
                 }
             }
             .listSectionSpacing(sectionSpacing)
-            .sheet(isPresented: $shouldDisplayHint) {
+            .sheet(item: $hintPayload) { payload in
                 SettingInputHintView(
                     hintDetent: $hintDetent,
-                    shouldDisplayHint: $shouldDisplayHint,
-                    hintLabel: hintLabel ?? "",
-                    hintText: selectedVerboseHint ?? AnyView(EmptyView()),
+                    shouldDisplayHint: shouldDisplayHintBinding,
+                    hintLabel: payload.label,
+                    hintText: payload.content,
                     sheetTitle: String(localized: "Help", comment: "Help sheet title")
                 )
             }

--- a/Trio/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
+++ b/Trio/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
@@ -7,14 +7,25 @@ extension NightscoutConfig {
         let resolver: Resolver
         let displayClose: Bool
         @StateObject var state = StateModel()
-        @State private var shouldDisplayHint: Bool = false
         @State var hintDetent = PresentationDetent.large
-        @State var selectedVerboseHint: AnyView?
-        @State var hintLabel: String?
+        @State private var hintPayload: HintPayload?
         @State private var decimalPlaceholder: Decimal = 0.0
         @State private var booleanPlaceholder: Bool = false
         @State var backfillAlert: Alert?
         @State var isBackfillAlertPresented = false
+
+        private struct HintPayload: Identifiable {
+            let id = UUID()
+            let label: String
+            let content: AnyView
+        }
+
+        private var shouldDisplayHintBinding: Binding<Bool> {
+            Binding(
+                get: { hintPayload != nil },
+                set: { newValue in if !newValue { hintPayload = nil } }
+            )
+        }
 
         @Environment(\.colorScheme) var colorScheme
         @Environment(AppState.self) var appState
@@ -79,14 +90,14 @@ extension NightscoutConfig {
                                     Spacer()
                                     Button(
                                         action: {
-                                            hintLabel = String(localized: "Backfill Glucose from Nightscout")
-                                            selectedVerboseHint =
-                                                AnyView(
+                                            hintPayload = HintPayload(
+                                                label: String(localized: "Backfill Glucose from Nightscout"),
+                                                content: AnyView(
                                                     Text(
                                                         "This will backfill 24 hours of glucose data from your connected Nightscout URL to Trio"
                                                     )
                                                 )
-                                            shouldDisplayHint.toggle()
+                                            )
                                         },
                                         label: {
                                             HStack {
@@ -104,12 +115,12 @@ extension NightscoutConfig {
                 }
                 .listSectionSpacing(sectionSpacing)
             }
-            .sheet(isPresented: $shouldDisplayHint) {
+            .sheet(item: $hintPayload) { payload in
                 SettingInputHintView(
                     hintDetent: $hintDetent,
-                    shouldDisplayHint: $shouldDisplayHint,
-                    hintLabel: hintLabel ?? "",
-                    hintText: selectedVerboseHint ?? AnyView(EmptyView()),
+                    shouldDisplayHint: shouldDisplayHintBinding,
+                    hintLabel: payload.label,
+                    hintText: payload.content,
                     sheetTitle: String(localized: "Help", comment: "Help sheet title")
                 )
             }


### PR DESCRIPTION
## Summary

Two help (i) buttons rendered a blank Help sheet on the first tap after a cold launch:

- **Settings → Algorithm → Dynamic Settings** → (i) on the "Dynamic Insulin Sensitivity" section header
- **Settings → Nightscout** → (i) next to "Backfill Glucose"

Subsequent taps worked because @State was populated from the prior tap.

## Root cause

The action handlers set three separate `@State` vars (`hintLabel`, `selectedVerboseHint`, `shouldDisplayHint`) and then toggled the sheet. `.sheet(isPresented:)` captured its content closure using a snapshot taken before those writes were observed, leaving both label and body `nil` on the first build. `AnyView`'s lack of stable identity meant subsequent updates didn't propagate into the already-built sheet.

## Fix

Replaces `.sheet(isPresented:)` + the three `@State` vars with `.sheet(item:)` driven by an `Identifiable` `HintPayload` struct. Setting the payload now atomically delivers the data and triggers presentation in a single state write, so the sheet always sees populated values on first render.

For `DynamicSettingsRootView` (which also drives `SettingInputSection` (i) buttons), small `Binding` helpers bridge the existing `SettingInputSection` API to the new payload state without changing that shared view.

## Notes

- The same `@State`-triple pattern exists in ~22 other settings views, but most aren't actually broken — the bug only triggers in views with specific structural conditions (single custom-button (i) sitting alone in its `Section`, with sibling controls bound to dynamic state). Targeted fix here; happy to file a follow-up issue documenting the pattern if useful.