### PR TITLE
Fix help buttons on Dynamic Settings page

### DIFF
--- a/Trio/Sources/Modules/DynamicSettings/View/DynamicSettingsRootView.swift
+++ b/Trio/Sources/Modules/DynamicSettings/View/DynamicSettingsRootView.swift
@@ -19,7 +19,13 @@ extension DynamicSettings {
         private var shouldDisplayHintBinding: Binding<Bool> {
             Binding(
                 get: { hintPayload != nil },
-                set: { newValue in if !newValue { hintPayload = nil } }
+                set: { newValue in
+                    if !newValue {
+                        hintPayload = nil
+                    } else if hintPayload == nil {
+                        hintPayload = HintPayload(label: "", content: AnyView(EmptyView()))
+                    }
+                }
             )
         }
 


### PR DESCRIPTION
The question mark buttons for Adjustment Factor, Weighted Average of TDD, and Adjust Basal on the Dynamic Settings page did nothing when tapped. Only the Dynamic Insulin Sensitivity one worked.

Regression from the cold-tap help-sheet fix. That commit replaced three `@State` vars with a single `HintPayload?` and a derived `shouldDisplayHintBinding`, but the binding's setter only handled `false`. `SettingInputSection` toggles `shouldDisplayHint` from false to true and then assigns the verbose hint based on the new value — since the toggle to `true` was dropped, the next line read `false` and assigned `nil`, so nothing was presented.

Fix lets the setter handle `true` by seeding a placeholder payload. The verbose-hint binding then immediately replaces it with the real label and content on the same action.