### PR TITLE
Fix Apple Health flag by checking for sample type permission

### DIFF
--- a/Trio/Sources/Services/Telemetry/TelemetryClient.swift
+++ b/Trio/Sources/Services/Telemetry/TelemetryClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HealthKit
 import LoopKit
 import Swinject
 import UIKit
@@ -197,9 +198,25 @@ final class TelemetryClient: Injectable {
 
         payload["tidepoolPaired"] = tidepoolManager?.getTidepoolServiceUI() != nil
 
-        let useHealth = settings?.useAppleHealth ?? false
-        let healthAuthorized = healthKitManager?.hasGrantedFullWritePermissions ?? false
-        payload["appleHealthEnabled"] = useHealth && healthAuthorized
+        // Apple Health: report `enabled = true` as soon as *any* per-type write
+        // permission is granted, with the full per-type breakdown in
+        // `appleHealthWrites`.
+        let appleHealthSampleTypes: [(name: String, type: HKObjectType?)] = [
+            ("glucose", AppleHealthConfig.healthBGObject),
+            ("insulin", AppleHealthConfig.healthInsulinObject),
+            ("carbs", AppleHealthConfig.healthCarbObject),
+            ("fat", AppleHealthConfig.healthFatObject),
+            ("protein", AppleHealthConfig.healthProteinObject)
+        ]
+        var writePermissions: [String: Bool] = [:]
+        for (name, type) in appleHealthSampleTypes {
+            let granted = type.flatMap { healthKitManager?.checkWriteToHealthPermissions(objectTypeToHealthStore: $0) } ?? false
+            writePermissions[name] = granted
+        }
+        payload["appleHealthEnabled"] = writePermissions.values.contains(true)
+        if !writePermissions.isEmpty {
+            payload["appleHealthWrites"] = writePermissions
+        }
 
         if let settings = settings {
             payload["closedLoop"] = settings.closedLoop


### PR DESCRIPTION
A tester reported appleHealthEnabled: false despite a working Apple Health integration.

Cause: `hasGrantedFullWritePermissions` required all five Trio-managed sample types (glucose, insulin, carbs, fat, protein) to be authorized.

Changes in `TelemetryClient.buildPayload`: 
- `appleHealthEnabled` → true when any write permission is granted (matches the state-based nightscoutPaired /
  tidepoolPaired pattern already in place).
- New `appleHealthWrites: { glucose, insulin, carbs, fat, protein }`check per-type authorization snapshot. Reuses the existing `checkWriteToHealthPermissions` of HealthKitManager.