### PR TITLE
Change fetchLimit for glucose oref input to be dynamic based on maxMealAbsorptionTime #920

### DIFF
--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -393,13 +393,20 @@ final class OpenAPS {
         // Perform asynchronous calls in parallel
         async let pumpHistoryObjectIDs = fetchPumpHistoryObjectIDs() ?? []
         async let carbs = fetchAndProcessCarbs(additionalCarbs: simulatedCarbsAmount ?? 0, carbsDate: simulatedCarbsDate)
-        async let glucose = fetchAndProcessGlucose(context: context, shouldSmoothGlucose: shouldSmoothGlucose, fetchLimit: 72)
+
+        var preferences = await storage.retrieveAsync(OpenAPS.Settings.preferences, as: Preferences.self) ?? Preferences()
+        let glucoseFetchLimit = Int((preferences.maxMealAbsorptionTime * 12).rounded(scale: 0, roundingMode: .up))
+        async let glucose = fetchAndProcessGlucose(
+            context: context,
+            shouldSmoothGlucose: shouldSmoothGlucose,
+            fetchLimit: glucoseFetchLimit
+        )
+
         async let prepareTrioCustomOrefVariables = prepareTrioCustomOrefVariables()
         async let profileAsync = loadFileFromStorageAsync(name: Settings.profile)
         async let basalAsync = loadFileFromStorageAsync(name: Settings.basalProfile)
         async let autosenseAsync = loadFileFromStorageAsync(name: Settings.autosense)
         async let reservoirAsync = loadFileFromStorageAsync(name: Monitor.reservoir)
-        async let preferencesAsync = storage.retrieveAsync(OpenAPS.Settings.preferences, as: Preferences.self) ?? Preferences()
         async let hasSufficientTddForDynamic = tddStorage.hasSufficientTDD()
 
         // Await the results of asynchronous tasks
@@ -449,8 +456,6 @@ final class OpenAPS {
         if !simulation {
             storage.save(iob, as: Monitor.iob)
         }
-
-        var preferences = await preferencesAsync
 
         if !hasSufficientTdd, preferences.useNewFormula || (preferences.useNewFormula && preferences.sigmoid) {
             debug(.openAPS, "Insufficient TDD for dynamic formula; disabling for determine basal run.")

--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -99,13 +99,20 @@ final class OpenAPS {
     func fetchAndProcessGlucose(
         context: NSManagedObjectContext,
         shouldSmoothGlucose: Bool,
-        fetchLimit: Int?
+        fetchLimit: Int?,
+        fetchHours: Decimal = 24
     ) async throws -> String {
-        // make it async and await it
+        // Time window from `fetchHours` hours ago up to now. determineBasal feeds
+        // `maxMealAbsorptionTime + 0.5h` (just enough glucose to cover the longest
+        // tracked meal absorption plus a small lead-in); Autosens uses the default
+        // 24h because its sensitivity algorithm needs that full window.
+        let cutoff = Date().addingTimeInterval(-(Double(truncating: fetchHours as NSNumber) * 3600))
+        let timePredicate = NSPredicate(format: "date >= %@", cutoff as NSDate)
+
         let results = try await CoreDataStack.shared.fetchEntitiesAsync(
             ofType: GlucoseStored.self,
             onContext: context,
-            predicate: NSPredicate.predicateForOneDayAgoInMinutes,
+            predicate: timePredicate,
             key: "date",
             ascending: false,
             fetchLimit: fetchLimit,
@@ -395,11 +402,12 @@ final class OpenAPS {
         async let carbs = fetchAndProcessCarbs(additionalCarbs: simulatedCarbsAmount ?? 0, carbsDate: simulatedCarbsDate)
 
         var preferences = await storage.retrieveAsync(OpenAPS.Settings.preferences, as: Preferences.self) ?? Preferences()
-        let glucoseFetchLimit = Int((preferences.maxMealAbsorptionTime * 12).rounded(scale: 0, roundingMode: .up))
+        let glucoseFetchHours = preferences.maxMealAbsorptionTime * 12 + 0.5 // MMAT + half hour buffer
         async let glucose = fetchAndProcessGlucose(
             context: context,
             shouldSmoothGlucose: shouldSmoothGlucose,
-            fetchLimit: glucoseFetchLimit
+            fetchLimit: nil,
+            fetchHours: glucoseFetchHours
         )
 
         async let prepareTrioCustomOrefVariables = prepareTrioCustomOrefVariables()

--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -402,7 +402,7 @@ final class OpenAPS {
         async let carbs = fetchAndProcessCarbs(additionalCarbs: simulatedCarbsAmount ?? 0, carbsDate: simulatedCarbsDate)
 
         var preferences = await storage.retrieveAsync(OpenAPS.Settings.preferences, as: Preferences.self) ?? Preferences()
-        let glucoseFetchHours = preferences.maxMealAbsorptionTime * 12 + 0.5 // MMAT + half hour buffer
+        let glucoseFetchHours = preferences.maxMealAbsorptionTime + 0.5 // MMAT + half hour buffer
         async let glucose = fetchAndProcessGlucose(
             context: context,
             shouldSmoothGlucose: shouldSmoothGlucose,


### PR DESCRIPTION
## Summary
The glucose history fed into the meal/COB algorithm was capped at a fixed fetchLimit: 72 (72 readings × 5 min = 6h).
That constant predates the user-selectable maxMealAbsorptionTime (MMAT) setting, which ranges 4–10h. When MMAT exceeds 6h, the COB calculation considers carb absorption out to MMAT hours but only has 6h of glucose to work with.

The result is the bug reported in #920: mealCOB rises after a carb entry (to an amount larger than the carbs entered)
as larger absorption buckets slide out the back of the 6h window and are replaced by smaller front buckets, then crashes to zero when the meal is evicted at mealTime + MMAT. This drives over-bolusing and hypo risk.

This affects both the JS oref0 path and the native oref-swift port, since the limit is applied upstream in OpenAPS.determineBasal before either path runs.

The fix makes the fetch limit dynamic: ceil(maxMealAbsorptionTime × 12) readings, so the glucose window always covers the full absorption window. Preferences are loaded up front (the existing async load is just hoisted and reused) to derive the limit before the parallel fetches. Tying it to the setting rather than a static cap means it can't silently drift again if the MMAT range changes.

Credit to @robertjwellwood for the diagnosis and simulation in #920.

## To Test

  - Build and run with default MMAT (6h), then verify COB behaves as before
  - Set MMAT to 8–10h, enter a carb dose, and confirm COB decays smoothly toward 0 without rising above the entered amount or cliff-dropping
  - Verify both useSwiftOref on and off produce consistent COB trajectories (so JS-based oref and native Swift port)
  - Confirm glucoseFetchLimit scales as expected (4h→48, 6h→72, 10h→120)