### PR TITLE
Update telemetry payload: fix buildDate format, add locale/TZ/appName

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -73,6 +73,11 @@ The following information is included in the telemetry payload:
   on/off, Live Activity enabled, calendar integration enabled
 - A rolling 7-day count of how often the app was cold-launched
 - The commit SHAs of pinned submodules (e.g. LoopKit, OmniBLE)
+- The device's system locale (e.g. "en_US") — used to help Trio
+  developers understand which languages to prioritize for translation
+- The device's time zone identifier (e.g. "America/New_York") — used
+  to help Trio developers understand which regions of the world Trio
+  is being used in
 
 The payload sends once every 24 hours while the app is running, plus
 once after a new build is installed. Sending failures simply retry on
@@ -85,7 +90,7 @@ the next launch or scheduler tick — there is no continued retry.
 - Your Nightscout URL or API token
 - Your Tidepool email, password, or session token
 - Remote-command secrets or APNS keys
-- Time zone or location
+- GPS coordinates or any precise location data
 - App logs — log sharing remains a separate, user-initiated flow under Settings
 
 ### Debug Symbols (dSYMs)
@@ -177,4 +182,4 @@ trio.diy.diabetes@gmail.com.
 
 ## Last Updated
 
-May 14, 2025
+May 28, 2026

--- a/Trio/Sources/Services/Telemetry/TelemetryClient.swift
+++ b/Trio/Sources/Services/Telemetry/TelemetryClient.swift
@@ -158,6 +158,12 @@ final class TelemetryClient: Injectable {
         var payload: [String: Any] = [:]
 
         if let v = info["CFBundleShortVersionString"] as? String { payload["appVersion"] = v }
+        // Display name from Info.plist ($(APP_DISPLAY_NAME) in Config.xcconfig,
+        // default "Trio"). Forks typically rebrand by changing that one line,
+        // so this lets dashboards distinguish upstream Trio from forks.
+        let displayName = (info["CFBundleDisplayName"] as? String)
+            ?? (info["CFBundleName"] as? String)
+        payload["appDisplayName"] = displayName ?? "unknown"
         // appDevVersion is Trio's 4-component dev counter (e.g. "0.7.0.14") —
         // the most precise build identifier we have. Always emit, even when
         // the Info.plist key is missing, so dashboards can rely on the field.

--- a/Trio/Sources/Services/Telemetry/TelemetryClient.swift
+++ b/Trio/Sources/Services/Telemetry/TelemetryClient.swift
@@ -39,6 +39,14 @@ final class TelemetryClient: Injectable {
     private static let dailyInterval: TimeInterval = 24 * 60 * 60
     private static let maxPayloadBytes = 4096
 
+    private static let buildDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
     // MARK: Injected services
 
     @Injected() private var apsManager: APSManager!
@@ -157,10 +165,10 @@ final class TelemetryClient: Injectable {
         payload["commitSha"] = bd.trioCommitSHA
         payload["branch"] = bd.trioBranch
 
-        // Date-only prefix of the build-date string. Keeps the field a
-        // low-resolution build identifier, not a precise timestamp.
-        if let raw = bd.buildDateString, raw.count >= 10 {
-            payload["buildDate"] = String(raw.prefix(10))
+        // Date-only (yyyy-MM-dd, UTC) build identifier, parsed from the
+        // "Tue May 26 12:34:56 UTC 2025" form added in BuildDetails.plist.
+        if let date = bd.buildDate() {
+            payload["buildDate"] = Self.buildDateFormatter.string(from: date)
         }
 
         payload["isTestFlight"] = bd.isTestFlightBuild()

--- a/Trio/Sources/Services/Telemetry/TelemetryClient.swift
+++ b/Trio/Sources/Services/Telemetry/TelemetryClient.swift
@@ -21,6 +21,10 @@ final class TelemetryClient: Injectable {
 
     private static let productionBaseURL: URL? = URL(string: "https://telemetry.triodocs.org")
 
+    // MARK: if you fork Trio and keep telemetry enabled, please change the name here
+    // so that we can distinguish forks from mainline Trio builds in our telemetry.
+    private static let telemetryAppName: String = "Trio"
+
     /// Effective base URL: respects the debug override in
     /// `PropertyPersistentFlags.telemetryDebugServerURL`, then falls back to
     /// `productionBaseURL`. Used by both the registration and `/checkin` paths.
@@ -158,12 +162,7 @@ final class TelemetryClient: Injectable {
         var payload: [String: Any] = [:]
 
         if let v = info["CFBundleShortVersionString"] as? String { payload["appVersion"] = v }
-        // Display name from Info.plist ($(APP_DISPLAY_NAME) in Config.xcconfig,
-        // default "Trio"). Forks typically rebrand by changing that one line,
-        // so this lets dashboards distinguish upstream Trio from forks.
-        let displayName = (info["CFBundleDisplayName"] as? String)
-            ?? (info["CFBundleName"] as? String)
-        payload["appDisplayName"] = displayName ?? "unknown"
+        payload["appName"] = telemetryAppName
         // appDevVersion is Trio's 4-component dev counter (e.g. "0.7.0.14") —
         // the most precise build identifier we have. Always emit, even when
         // the Info.plist key is missing, so dashboards can rely on the field.

--- a/Trio/Sources/Services/Telemetry/TelemetryClient.swift
+++ b/Trio/Sources/Services/Telemetry/TelemetryClient.swift
@@ -181,6 +181,8 @@ final class TelemetryClient: Injectable {
         payload["device"] = Self.hardwareIdentifier()
         payload["platform"] = Self.detectPlatform()
         payload["osVersion"] = UIDevice.current.systemVersion
+        payload["locale"] = Locale.current.identifier
+        payload["timeZone"] = TimeZone.current.identifier
 
         // Pump model — omitted entirely when no pump is paired.
         if let pump = apsManager?.pumpManager {

--- a/scripts/capture-build-details.sh
+++ b/scripts/capture-build-details.sh
@@ -16,7 +16,7 @@ fi
 echo "Gathering build details..."
 
 # Capture the current date
-plutil -replace com-trio-build-date -string "$(date -u '+%a %b %e %H:%M:%S UTC %Y')" "${info_plist_path}"
+plutil -replace com-trio-build-date -string "$(LC_ALL=C date -u '+%a %b %e %H:%M:%S UTC %Y')" "${info_plist_path}"
 
 # --- Root repo details ---
 # Retrieve current branch (or tag) and commit SHA.


### PR DESCRIPTION
Fixes a few issues identified with the Trio telemetry payloads:

* On non-English locales, the buildDate was improperly formatted. e.g., a builder on a French language-default OS would emit `lun. mai 2`. Fix: force capture-build-details to POSIX default locale (english).
* Parse the timestamp and emit as YYYY-MM-DD instead of “Tue May 26” format
* Add iOS system locale + timezone to telemetry, with the above bug as motivation for why we should track this. Plus, this will be beneficial for users when managing translations.
* Add appName to telemetry -- hardcoded as "Trio", but can be overridden for forks