### PR TITLE
Change profile target dynISF condition with HighTTRaisesSensitivity

### DIFF
--- a/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/DynamicISF.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/DynamicISF.swift
@@ -159,7 +159,7 @@ extension Preferences {
 
         // checks for 'exercise mode' like conditions
         if profile.highTemptargetRaisesSensitivity,
-           let profileTarget = profile.profileTarget(trioCustomOrefVariables: trioCustomOrefVariables), profileTarget >= 118
+           let profileTarget = profile.profileTarget(trioCustomOrefVariables: trioCustomOrefVariables), profileTarget >= profile.halfBasalExerciseTarget
         {
             return .off
         }
@@ -167,3 +167,4 @@ extension Preferences {
         return sigmoid ? .sigmoid : .logrithmic
     }
 }
+g

--- a/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/DynamicISF.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/DynamicISF.swift
@@ -157,13 +157,6 @@ extension Preferences {
             return .off
         }
 
-        // checks for 'exercise mode' like conditions
-        if profile.highTemptargetRaisesSensitivity,
-           let profileTarget = profile.profileTarget(trioCustomOrefVariables: trioCustomOrefVariables), profileTarget >= profile.halfBasalExerciseTarget
-        {
-            return .off
-        }
-
         return sigmoid ? .sigmoid : .logrithmic
     }
 }

--- a/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/DynamicISF.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/DynamicISF.swift
@@ -159,7 +159,8 @@ extension Preferences {
 
         // checks for 'exercise mode' like conditions
         if profile.highTemptargetRaisesSensitivity,
-           let profileTarget = profile.profileTarget(trioCustomOrefVariables: trioCustomOrefVariables), profileTarget >= profile.halfBasalExerciseTarget
+           let profileTarget = profile.profileTarget(trioCustomOrefVariables: trioCustomOrefVariables),
+           profileTarget >= profile.halfBasalExerciseTarget
         {
             return .off
         }
@@ -167,4 +168,3 @@ extension Preferences {
         return sigmoid ? .sigmoid : .logrithmic
     }
 }
-g


### PR DESCRIPTION
~~- Before this change, condition checked whether highTTRaisesSens was active AND user's profile target >= 118~~
~~- We received an issue report by a parent whose child runs with profile target set at >118, thus dynISF NEVER activated~~
~~- Change now moves this check condition to a saner target of halfBasalExerciseTarget, to ONLY disable dynISF if the user ACTUALLY sets a TT at a target value >= HBT (which by default is 160)~~

Removes a legacy (pre Trio) dynISF condition that would disable dynISF. 