### PR TITLE
Fix indefinite override not drawn in Live Activity chart

### DIFF
--- a/LiveActivity/Views/LiveActivityChartView.swift
+++ b/LiveActivity/Views/LiveActivityChartView.swift
@@ -113,7 +113,9 @@ struct LiveActivityChartView: View {
         let duration = context.state.detailedViewState.overrideDuration
         let durationAsTimeInterval = TimeInterval((duration as NSDecimalNumber).doubleValue * 60) // return seconds
 
-        let end: Date = start.addingTimeInterval(durationAsTimeInterval)
+        let end: Date = duration == 0
+            ? Date(timeIntervalSinceNow: 7200)
+            : start.addingTimeInterval(durationAsTimeInterval)
         let target = context.state.detailedViewState.overrideTarget
 
         return RuleMark(


### PR DESCRIPTION
When override duration is 0 (indefinite), end date equaled start date, giving the RuleMark zero width and preventing it from rendering. Treat duration == 0 as indefinite and extend the bar to now + 2 hours, matching the chart's x-axis domain.

Fixes #1191