### PR TITLE
Live Activity: Adding glucose forecast

### DIFF
--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -128,7 +128,9 @@ private extension LiveActivityAttributes.ContentState {
             tempTargetTarget: 120,
             widgetItems: LiveActivityAttributes.LiveActivityItem.defaultItems,
             minForecast: [],
-            maxForecast: []
+            maxForecast: [],
+            forecastLines: [],
+            forecastDisplayType: "cone"
         )
 
     // 0 is the widest digit. Use this to get an upper bound on text width.

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -126,7 +126,11 @@ private extension LiveActivityAttributes.ContentState {
             tempTargetDate: Date().addingTimeInterval(-1800),
             tempTargetDuration: 60,
             tempTargetTarget: 120,
-            widgetItems: LiveActivityAttributes.LiveActivityItem.defaultItems
+            widgetItems: LiveActivityAttributes.LiveActivityItem.defaultItems,
+            minForecast: [],
+            maxForecast: [],
+            forecastLines: [],
+            forecastDisplayType: "cone"
         )
 
     // 0 is the widest digit. Use this to get an upper bound on text width.

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -128,9 +128,7 @@ private extension LiveActivityAttributes.ContentState {
             tempTargetTarget: 120,
             widgetItems: LiveActivityAttributes.LiveActivityItem.defaultItems,
             minForecast: [],
-            maxForecast: [],
-            forecastLines: [],
-            forecastDisplayType: "cone"
+            maxForecast: []
         )
 
     // 0 is the widest digit. Use this to get an upper bound on text width.

--- a/LiveActivity/Views/LiveActivityChartView.swift
+++ b/LiveActivity/Views/LiveActivityChartView.swift
@@ -38,7 +38,7 @@ struct LiveActivityChartView: View {
 
         let isOverrideActive = additionalState.isOverrideActive == true
         let isTempTargetActive = additionalState.isTempTargetActive == true
-        let hasForecast = !additionalState.minForecast.isEmpty
+        let hasForecast = !additionalState.minForecast.isEmpty || !additionalState.forecastLines.isEmpty
 
         let calendar = Calendar.current
         let now = Date()
@@ -47,7 +47,11 @@ struct LiveActivityChartView: View {
         let endDate: Date = {
             let baseEnd = calendar.date(byAdding: .minute, value: isWatchOS ? 5 : 0, to: now) ?? now
             guard hasForecast, let anchorDate = state.date else { return baseEnd }
-            let predictionEnd = anchorDate.addingTimeInterval(TimeInterval(additionalState.minForecast.count * 300))
+            let forecastCount = max(
+                additionalState.minForecast.count,
+                additionalState.forecastLines.max(by: { $0.values.count < $1.values.count })?.values.count ?? 0
+            )
+            let predictionEnd = anchorDate.addingTimeInterval(TimeInterval(forecastCount * 300))
             return max(baseEnd, predictionEnd)
         }()
 
@@ -94,7 +98,11 @@ struct LiveActivityChartView: View {
             }
 
             if hasForecast, let anchorDate = state.date {
-                drawForecastCone(anchorDate: anchorDate, isMgdL: isMgdL, maxValue: maxValue)
+                if additionalState.forecastDisplayType == "lines" {
+                    drawForecastLines(anchorDate: anchorDate, isMgdL: isMgdL)
+                } else {
+                    drawForecastCone(anchorDate: anchorDate, isMgdL: isMgdL, maxValue: maxValue)
+                }
             }
 
             drawChart(yAxisRuleMarkMin: yAxisRuleMarkMin, yAxisRuleMarkMax: yAxisRuleMarkMax)
@@ -197,6 +205,34 @@ struct LiveActivityChartView: View {
                 yEnd: .value("Max", coneData[i].yMax)
             )
             .foregroundStyle(Color.blue.opacity(0.5))
+            .interpolationMethod(.linear)
+        }
+    }
+
+    private func drawForecastLines(anchorDate: Date, isMgdL: Bool) -> some ChartContent {
+        let colorMap: [String: Color] = [
+            "iob": Color(red: 0.118, green: 0.588, blue: 0.988),
+            "cob": Color.orange,
+            "uam": Color(red: 0.820, green: 0.169, blue: 0.969),
+            "zt": Color(red: 0.443, green: 0.380, blue: 0.937)
+        ]
+
+        let points: [(series: String, date: Date, value: Decimal)] = additionalState.forecastLines.flatMap { line in
+            line.values.enumerated().map { index, value in
+                let displayValue = isMgdL ? Decimal(value) : Decimal(value).asMmolL
+                return (series: line.type, date: timeForIndex(index, anchorDate: anchorDate), value: displayValue)
+            }
+        }
+
+        return ForEach(Array(points.indices), id: \.self) { i in
+            let point = points[i]
+            LineMark(
+                x: .value("Time", point.date),
+                y: .value("Value", point.value),
+                series: .value("Type", point.series)
+            )
+            .foregroundStyle(colorMap[point.series] ?? Color.gray)
+            .lineStyle(.init(lineWidth: 1.5))
             .interpolationMethod(.linear)
         }
     }

--- a/LiveActivity/Views/LiveActivityChartView.swift
+++ b/LiveActivity/Views/LiveActivityChartView.swift
@@ -22,9 +22,13 @@ struct LiveActivityChartView: View {
 
         let maxThreshhold: Decimal = isWatchOS ? 220 : 300
 
-        // Determine scale
-        let minValue = min(additionalState.chart.min(by: { $0.value < $1.value })?.value ?? 39, 39)
-        let maxValue = max(additionalState.chart.max(by: { $0.value < $1.value })?.value ?? maxThreshhold, maxThreshhold)
+        // Determine scale, accounting for both glucose history and prediction values
+        let chartMin = additionalState.chart.min(by: { $0.value < $1.value })?.value ?? 39
+        let chartMax = additionalState.chart.max(by: { $0.value < $1.value })?.value ?? maxThreshhold
+        let forecastMin = additionalState.minForecast.min().map { Decimal($0) } ?? chartMin
+        let forecastMax = additionalState.maxForecast.max().map { Decimal($0) } ?? chartMax
+        let minValue = min(min(chartMin, forecastMin), 39)
+        let maxValue = max(max(chartMax, forecastMax), maxThreshhold)
 
         let yAxisRuleMarkMin = isMgdL ? state.lowGlucose : state.lowGlucose
             .asMmolL
@@ -34,12 +38,18 @@ struct LiveActivityChartView: View {
 
         let isOverrideActive = additionalState.isOverrideActive == true
         let isTempTargetActive = additionalState.isTempTargetActive == true
+        let hasForecast = !additionalState.minForecast.isEmpty || !additionalState.forecastLines.isEmpty
 
         let calendar = Calendar.current
         let now = Date()
 
         let startDate = calendar.date(byAdding: .hour, value: isWatchOS ? -3 : -6, to: now) ?? now
-        let endDate = calendar.date(byAdding: .minute, value: isWatchOS ? 5 : 0, to: now) ?? now
+        let endDate: Date = {
+            let baseEnd = calendar.date(byAdding: .minute, value: isWatchOS ? 5 : 0, to: now) ?? now
+            guard hasForecast, let anchorDate = state.date else { return baseEnd }
+            let predictionEnd = anchorDate.addingTimeInterval(TimeInterval(150 * 60)) // 2.5h from determination
+            return max(baseEnd, predictionEnd)
+        }()
 
         // TODO: workaround for now: set low value to 55, to have dynamic color shades between 55 and user-set low (approx. 70); same for high glucose
         let hardCodedLow = isMgdL ? Decimal(55) : 55.asMmolL
@@ -81,6 +91,14 @@ struct LiveActivityChartView: View {
 
             if isTempTargetActive {
                 drawActiveTempTarget()
+            }
+
+            if hasForecast, let anchorDate = state.date {
+                if additionalState.forecastDisplayType == "lines" {
+                    drawForecastLines(anchorDate: anchorDate, isMgdL: isMgdL)
+                } else {
+                    drawForecastCone(anchorDate: anchorDate, isMgdL: isMgdL, maxValue: maxValue)
+                }
             }
 
             drawChart(yAxisRuleMarkMin: yAxisRuleMarkMin, yAxisRuleMarkMax: yAxisRuleMarkMax)
@@ -147,6 +165,75 @@ struct LiveActivityChartView: View {
         )
         .foregroundStyle(Color("LoopGreen").opacity(0.6))
         .lineStyle(.init(lineWidth: 8))
+    }
+
+    private func timeForIndex(_ index: Int, anchorDate: Date) -> Date {
+        anchorDate.addingTimeInterval(TimeInterval(index * 300))
+    }
+
+    private func drawForecastCone(anchorDate: Date, isMgdL: Bool, maxValue: Decimal) -> some ChartContent {
+        let minForecast = additionalState.minForecast
+        let maxForecast = additionalState.maxForecast
+        let cappedMax = isMgdL ? maxValue : maxValue.asMmolL
+        let count = min(minForecast.count, maxForecast.count)
+
+        // Pre-compute cone data to avoid conditionals inside the ForEach closure
+        let coneData: [(date: Date, yMin: Decimal, yMax: Decimal)] = (0 ..< count).map { index in
+            let xValue = timeForIndex(index, anchorDate: anchorDate)
+            let delta = minForecast[index] - maxForecast[index]
+            let yMin: Decimal
+            let yMax: Decimal
+            if delta == 0 {
+                let base = isMgdL ? Decimal(minForecast[index]) : Decimal(minForecast[index]).asMmolL
+                yMin = base - 1
+                yMax = base + 1
+            } else {
+                yMin = isMgdL ? Decimal(minForecast[index]) : Decimal(minForecast[index]).asMmolL
+                yMax = isMgdL ? Decimal(maxForecast[index]) : Decimal(maxForecast[index]).asMmolL
+            }
+            return (date: xValue, yMin: min(yMin, cappedMax), yMax: min(yMax, cappedMax))
+        }
+
+        return ForEach(coneData.indices, id: \.self) { i in
+            AreaMark(
+                x: .value("Time", coneData[i].date),
+                yStart: .value("Min", coneData[i].yMin),
+                yEnd: .value("Max", coneData[i].yMax)
+            )
+            .foregroundStyle(Color.blue.opacity(0.5))
+            .interpolationMethod(.catmullRom)
+        }
+    }
+
+    private func drawForecastLines(anchorDate: Date, isMgdL: Bool) -> some ChartContent {
+        // Colors match the main app's chartForegroundStyleScale
+        let colorMap: [String: Color] = [
+            "iob": Color(red: 0.118, green: 0.588, blue: 0.988),
+            "cob": Color.orange,
+            "uam": Color(red: 0.820, green: 0.169, blue: 0.969),
+            "zt": Color(red: 0.443, green: 0.380, blue: 0.937)
+        ]
+
+        // Flatten lines into a single array to avoid nested ForEach in ChartContentBuilder
+        let points: [(series: String, date: Date, value: Decimal)] = additionalState.forecastLines.flatMap { line in
+            line.values.enumerated().map { index, value in
+                let displayValue = isMgdL ? Decimal(value) : Decimal(value).asMmolL
+                return (series: line.type, date: timeForIndex(index, anchorDate: anchorDate), value: displayValue)
+            }
+        }
+
+        let indices = Array(0 ..< points.count)
+        return ForEach(indices, id: \.self) { i in
+            let point = points[i]
+            LineMark(
+                x: .value("Time", point.date),
+                y: .value("Value", point.value),
+                series: .value("Type", point.series)
+            )
+            .foregroundStyle(colorMap[point.series] ?? Color.gray)
+            .lineStyle(.init(lineWidth: 1.5))
+            .interpolationMethod(.catmullRom)
+        }
     }
 
     private func drawChart(yAxisRuleMarkMin _: Decimal, yAxisRuleMarkMax _: Decimal) -> some ChartContent {

--- a/LiveActivity/Views/LiveActivityChartView.swift
+++ b/LiveActivity/Views/LiveActivityChartView.swift
@@ -38,7 +38,7 @@ struct LiveActivityChartView: View {
 
         let isOverrideActive = additionalState.isOverrideActive == true
         let isTempTargetActive = additionalState.isTempTargetActive == true
-        let hasForecast = !additionalState.minForecast.isEmpty || !additionalState.forecastLines.isEmpty
+        let hasForecast = !additionalState.minForecast.isEmpty
 
         let calendar = Calendar.current
         let now = Date()
@@ -47,7 +47,7 @@ struct LiveActivityChartView: View {
         let endDate: Date = {
             let baseEnd = calendar.date(byAdding: .minute, value: isWatchOS ? 5 : 0, to: now) ?? now
             guard hasForecast, let anchorDate = state.date else { return baseEnd }
-            let predictionEnd = anchorDate.addingTimeInterval(TimeInterval(150 * 60)) // 2.5h from determination
+            let predictionEnd = anchorDate.addingTimeInterval(TimeInterval(additionalState.minForecast.count * 300))
             return max(baseEnd, predictionEnd)
         }()
 
@@ -94,11 +94,7 @@ struct LiveActivityChartView: View {
             }
 
             if hasForecast, let anchorDate = state.date {
-                if additionalState.forecastDisplayType == "lines" {
-                    drawForecastLines(anchorDate: anchorDate, isMgdL: isMgdL)
-                } else {
-                    drawForecastCone(anchorDate: anchorDate, isMgdL: isMgdL, maxValue: maxValue)
-                }
+                drawForecastCone(anchorDate: anchorDate, isMgdL: isMgdL, maxValue: maxValue)
             }
 
             drawChart(yAxisRuleMarkMin: yAxisRuleMarkMin, yAxisRuleMarkMax: yAxisRuleMarkMax)
@@ -201,38 +197,7 @@ struct LiveActivityChartView: View {
                 yEnd: .value("Max", coneData[i].yMax)
             )
             .foregroundStyle(Color.blue.opacity(0.5))
-            .interpolationMethod(.catmullRom)
-        }
-    }
-
-    private func drawForecastLines(anchorDate: Date, isMgdL: Bool) -> some ChartContent {
-        // Colors match the main app's chartForegroundStyleScale
-        let colorMap: [String: Color] = [
-            "iob": Color(red: 0.118, green: 0.588, blue: 0.988),
-            "cob": Color.orange,
-            "uam": Color(red: 0.820, green: 0.169, blue: 0.969),
-            "zt": Color(red: 0.443, green: 0.380, blue: 0.937)
-        ]
-
-        // Flatten lines into a single array to avoid nested ForEach in ChartContentBuilder
-        let points: [(series: String, date: Date, value: Decimal)] = additionalState.forecastLines.flatMap { line in
-            line.values.enumerated().map { index, value in
-                let displayValue = isMgdL ? Decimal(value) : Decimal(value).asMmolL
-                return (series: line.type, date: timeForIndex(index, anchorDate: anchorDate), value: displayValue)
-            }
-        }
-
-        let indices = Array(0 ..< points.count)
-        return ForEach(indices, id: \.self) { i in
-            let point = points[i]
-            LineMark(
-                x: .value("Time", point.date),
-                y: .value("Value", point.value),
-                series: .value("Type", point.series)
-            )
-            .foregroundStyle(colorMap[point.series] ?? Color.gray)
-            .lineStyle(.init(lineWidth: 1.5))
-            .interpolationMethod(.catmullRom)
+            .interpolationMethod(.linear)
         }
     }
 

--- a/LiveActivity/Views/LiveActivityChartView.swift
+++ b/LiveActivity/Views/LiveActivityChartView.swift
@@ -31,7 +31,7 @@ struct LiveActivityChartView: View {
         let chartMin = additionalState.chart.min(by: { $0.value < $1.value })?.value ?? 39
         let chartMax = additionalState.chart.max(by: { $0.value < $1.value })?.value ?? maxThreshhold
         let forecastMin = additionalState.minForecast.min().map { Decimal($0) } ?? chartMin
-        let forecastMax = additionalState.maxForecast.max().map { Decimal($0) } ?? chartMax
+        let forecastMax = min(additionalState.maxForecast.max().map { Decimal($0) } ?? chartMax, maxThreshhold)
         let minValue = min(min(chartMin, forecastMin), 39)
         let maxValue = max(max(chartMax, forecastMax), maxThreshhold)
 

--- a/LiveActivity/Views/LiveActivityChartView.swift
+++ b/LiveActivity/Views/LiveActivityChartView.swift
@@ -9,6 +9,11 @@ import Foundation
 import SwiftUI
 import WidgetKit
 
+private enum ForecastDisplayTypeKey {
+    static let lines = "lines"
+    static let cone = "cone"
+}
+
 struct LiveActivityChartView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.isWatchOS) var isWatchOS
@@ -98,7 +103,7 @@ struct LiveActivityChartView: View {
             }
 
             if hasForecast, let anchorDate = state.date {
-                if additionalState.forecastDisplayType == "lines" {
+                if additionalState.forecastDisplayType == ForecastDisplayTypeKey.lines {
                     drawForecastLines(anchorDate: anchorDate, isMgdL: isMgdL)
                 } else {
                     drawForecastCone(anchorDate: anchorDate, isMgdL: isMgdL, maxValue: maxValue)
@@ -213,8 +218,8 @@ struct LiveActivityChartView: View {
         let colorMap: [String: Color] = [
             "iob": Color(red: 0.118, green: 0.588, blue: 0.988),
             "cob": Color.orange,
-            "uam": Color("UAM"),
-            "zt": Color("ZT")
+            "uam": Color(red: 0.820, green: 0.169, blue: 0.969),
+            "zt": Color(red: 0.443, green: 0.380, blue: 0.937)
         ]
 
         let points: [(series: String, date: Date, value: Decimal)] = additionalState.forecastLines.flatMap { line in

--- a/LiveActivity/Views/LiveActivityChartView.swift
+++ b/LiveActivity/Views/LiveActivityChartView.swift
@@ -213,8 +213,8 @@ struct LiveActivityChartView: View {
         let colorMap: [String: Color] = [
             "iob": Color(red: 0.118, green: 0.588, blue: 0.988),
             "cob": Color.orange,
-            "uam": Color(red: 0.820, green: 0.169, blue: 0.969),
-            "zt": Color(red: 0.443, green: 0.380, blue: 0.937)
+            "uam": Color("UAM"),
+            "zt": Color("ZT")
         ]
 
         let points: [(series: String, date: Date, value: Decimal)] = additionalState.forecastLines.flatMap { line in
@@ -224,7 +224,7 @@ struct LiveActivityChartView: View {
             }
         }
 
-        return ForEach(Array(points.indices), id: \.self) { i in
+        return ForEach(0 ..< points.count, id: \.self) { i in
             let point = points[i]
             LineMark(
                 x: .value("Time", point.date),

--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -66,6 +66,7 @@ struct TrioSettings: JSON, Equatable, Encodable {
     var useLiveActivity: Bool = false
     var lockScreenView: LockScreenView = .simple
     var smartStackView: LockScreenView = .simple
+    var displayGlucoseForecasts: Bool = false
     var bolusShortcut: BolusShortcutLimit = .notAllowed
     var timeInRangeType: TimeInRangeType = .timeInTightRange
     var requireAdjustmentsConfirmation: Bool = false
@@ -309,6 +310,10 @@ extension TrioSettings: Decodable {
 
         if let smartStackView = try? container.decode(LockScreenView.self, forKey: .smartStackView) {
             settings.smartStackView = smartStackView
+        }
+
+        if let displayGlucoseForecasts = try? container.decode(Bool.self, forKey: .displayGlucoseForecasts) {
+            settings.displayGlucoseForecasts = displayGlucoseForecasts
         }
 
         if let bolusShortcut = try? container.decode(BolusShortcutLimit.self, forKey: .bolusShortcut) {

--- a/Trio/Sources/Modules/LiveActivitySettings/LiveActivitySettingsStateModel.swift
+++ b/Trio/Sources/Modules/LiveActivitySettings/LiveActivitySettingsStateModel.swift
@@ -9,11 +9,13 @@ extension LiveActivitySettings {
         @Published var useLiveActivity = false
         @Published var lockScreenView: LockScreenView = .simple
         @Published var smartStackView: LockScreenView = .simple
+        @Published var displayGlucoseForecasts = false
         override func subscribe() {
             units = settingsManager.settings.units
             subscribeSetting(\.useLiveActivity, on: $useLiveActivity) { useLiveActivity = $0 }
             subscribeSetting(\.lockScreenView, on: $lockScreenView) { lockScreenView = $0 }
             subscribeSetting(\.smartStackView, on: $smartStackView) { smartStackView = $0 }
+            subscribeSetting(\.displayGlucoseForecasts, on: $displayGlucoseForecasts) { displayGlucoseForecasts = $0 }
         }
     }
 }

--- a/Trio/Sources/Modules/LiveActivitySettings/View/LiveActivitySettingsRootView.swift
+++ b/Trio/Sources/Modules/LiveActivitySettings/View/LiveActivitySettingsRootView.swift
@@ -9,6 +9,7 @@ extension LiveActivitySettings {
 
         @State private var shouldDisplayHintLockScreen: Bool = false
         @State private var shouldDisplayHintSmartStack: Bool = false
+        @State private var shouldDisplayHintGlucoseForecasts: Bool = false
         @State var hintDetent = PresentationDetent.large
         @State var selectedVerboseHint: AnyView?
         @State var hintLabel: String?
@@ -83,6 +84,30 @@ extension LiveActivitySettings {
                     )
 
                     if state.useLiveActivity {
+                        SettingInputSection(
+                            decimalValue: $decimalPlaceholder,
+                            booleanValue: $state.displayGlucoseForecasts,
+                            shouldDisplayHint: $shouldDisplayHintGlucoseForecasts,
+                            selectedVerboseHint: Binding(
+                                get: { selectedVerboseHint },
+                                set: {
+                                    selectedVerboseHint = $0.map { AnyView($0) }
+                                    hintLabel = String(localized: "Display Glucose Forecasts")
+                                }
+                            ),
+                            units: state.units,
+                            type: .boolean,
+                            label: String(localized: "Display Glucose Forecasts"),
+                            miniHint: String(localized: "Display Glucose Forecasts made by the Oref algorithm."),
+                            verboseHint: VStack(alignment: .leading, spacing: 10) {
+                                Text("Default: OFF").bold()
+                                Text(
+                                    "When enabled, the live activity widget on the lock screen will show glucose forecasts. The visual representation will be the same as in the Main view. To change between Cone and Lines, change the setting under Features - User Interface - Forecast Display Type."
+                                )
+                            },
+                            headerText: String(localized: "Display Glucose Forecasts")
+                        )
+
                         Section {
                             VStack {
                                 Picker(
@@ -224,6 +249,15 @@ extension LiveActivitySettings {
                 SettingInputHintView(
                     hintDetent: $hintDetent,
                     shouldDisplayHint: $shouldDisplayHintSmartStack,
+                    hintLabel: hintLabel ?? "",
+                    hintText: selectedVerboseHint ?? AnyView(EmptyView()),
+                    sheetTitle: String(localized: "Help", comment: "Help sheet title")
+                )
+            }
+            .sheet(isPresented: $shouldDisplayHintGlucoseForecasts) {
+                SettingInputHintView(
+                    hintDetent: $hintDetent,
+                    shouldDisplayHint: $shouldDisplayHintGlucoseForecasts,
                     hintLabel: hintLabel ?? "",
                     hintText: selectedVerboseHint ?? AnyView(EmptyView()),
                     sheetTitle: String(localized: "Help", comment: "Help sheet title")

--- a/Trio/Sources/Modules/SettingsExport/SettingsExportStateModel.swift
+++ b/Trio/Sources/Modules/SettingsExport/SettingsExportStateModel.swift
@@ -871,6 +871,12 @@ extension SettingsExport {
                     name: String(localized: "Lock Screen Widget Style"),
                     value: trioSettings.lockScreenView.rawValue
                 )
+                addSetting(
+                    category: notificationsCategory,
+                    subcategory: liveActivitySubcategory,
+                    name: String(localized: "Display Glucose Forecasts"),
+                    value: trioSettings.displayGlucoseForecasts ? String(localized: "Enabled") : String(localized: "Disabled")
+                )
             }
 
             // Services

--- a/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
+++ b/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
@@ -60,14 +60,18 @@ extension LiveActivityManager {
 
             let tddValue = (tddResults.first?["total"] as? NSDecimalNumber)?.decimalValue ?? 0
 
-            // Compute cone bounds from forecast relationships (max 36 values = 3h)
+            // Compute cone bounds and per-type lines from forecast relationships (cap at 24 values = 2h)
             var allForecastValues = [[Int]]()
+            var forecastLines = [(type: String, values: [Int])]()
 
             if let forecasts = determination.forecasts {
                 for forecast in forecasts.sorted(by: { ($0.type ?? "") < ($1.type ?? "") }) {
-                    let values = forecast.forecastValuesArray.prefix(36).map { Int($0.value) }
+                    let values = forecast.forecastValuesArray.prefix(24).map { Int($0.value) }
                     guard !values.isEmpty else { continue }
                     allForecastValues.append(Array(values))
+                    if let type = forecast.type {
+                        forecastLines.append((type: type, values: Array(values)))
+                    }
                 }
             }
 
@@ -87,7 +91,8 @@ extension LiveActivityManager {
                 target: determination.currentTarget?.decimalValue ?? 0,
                 date: determination.deliverAt,
                 minForecast: minForecast,
-                maxForecast: maxForecast
+                maxForecast: maxForecast,
+                forecastLines: forecastLines
             )
         }
     }

--- a/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
+++ b/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
@@ -65,9 +65,14 @@ extension LiveActivityManager {
             var forecastLines = [(type: String, values: [Int])]()
 
             if let forecasts = determination.forecasts {
+                let hasCarbs = forecasts.contains(where: {
+                    ($0.type == "cob" || $0.type == "uam") && !$0.forecastValuesArray.isEmpty
+                })
                 for forecast in forecasts.sorted(by: { ($0.type ?? "") < ($1.type ?? "") }) {
                     let values = forecast.forecastValuesArray.prefix(24).map { Int($0.value) }
                     guard !values.isEmpty else { continue }
+                    // iob is hidden when cob or uam are active (matches phone app behavior)
+                    if forecast.type == "iob", hasCarbs { continue }
                     allForecastValues.append(Array(values))
                     if let type = forecast.type {
                         forecastLines.append((type: type, values: Array(values)))

--- a/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
+++ b/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
@@ -34,7 +34,7 @@ extension LiveActivityManager {
             key: "deliverAt",
             ascending: false,
             fetchLimit: 1,
-            propertiesToFetch: ["cob", "currentTarget", "deliverAt"]
+            relationshipKeyPathsForPrefetching: ["forecasts", "forecasts.forecastValues"]
         )
 
         let tddResults = try await CoreDataStack.shared.fetchEntitiesAsync(
@@ -48,7 +48,9 @@ extension LiveActivityManager {
         )
 
         return try await context.perform {
-            guard let determinationResults = results as? [[String: Any]], let tddResults = tddResults as? [[String: Any]] else {
+            guard let determinationResults = results as? [OrefDetermination],
+                  let tddResults = tddResults as? [[String: Any]]
+            else {
                 throw CoreDataError.fetchError(function: #function, file: #file)
             }
 
@@ -58,11 +60,39 @@ extension LiveActivityManager {
 
             let tddValue = (tddResults.first?["total"] as? NSDecimalNumber)?.decimalValue ?? 0
 
+            // Compute cone bounds and per-type lines from forecast relationships (max 36 values = 3h)
+            var allForecastValues = [[Int]]()
+            var forecastLines = [(type: String, values: [Int])]()
+
+            if let forecasts = determination.forecasts {
+                for forecast in forecasts.sorted(by: { ($0.type ?? "") < ($1.type ?? "") }) {
+                    let values = forecast.forecastValuesArray.prefix(36).map { Int($0.value) }
+                    guard !values.isEmpty else { continue }
+                    allForecastValues.append(Array(values))
+                    if let type = forecast.type {
+                        forecastLines.append((type: type, values: Array(values)))
+                    }
+                }
+            }
+
+            let minCount = allForecastValues.map(\.count).min() ?? 0
+            var minForecast = [Int]()
+            var maxForecast = [Int]()
+
+            for index in 0 ..< minCount {
+                let col = allForecastValues.compactMap { $0.indices.contains(index) ? $0[index] : nil }
+                minForecast.append(col.min() ?? 0)
+                maxForecast.append(col.max() ?? 0)
+            }
+
             return DeterminationData(
-                cob: (determination["cob"] as? Int) ?? 0,
+                cob: Int(determination.cob),
                 tdd: tddValue,
-                target: (determination["currentTarget"] as? NSDecimalNumber)?.decimalValue ?? 0,
-                date: determination["deliverAt"] as? Date ?? nil
+                target: determination.currentTarget?.decimalValue ?? 0,
+                date: determination.deliverAt,
+                minForecast: minForecast,
+                maxForecast: maxForecast,
+                forecastLines: forecastLines
             )
         }
     }

--- a/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
+++ b/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
@@ -60,18 +60,14 @@ extension LiveActivityManager {
 
             let tddValue = (tddResults.first?["total"] as? NSDecimalNumber)?.decimalValue ?? 0
 
-            // Compute cone bounds and per-type lines from forecast relationships (max 36 values = 3h)
+            // Compute cone bounds from forecast relationships (max 36 values = 3h)
             var allForecastValues = [[Int]]()
-            var forecastLines = [(type: String, values: [Int])]()
 
             if let forecasts = determination.forecasts {
                 for forecast in forecasts.sorted(by: { ($0.type ?? "") < ($1.type ?? "") }) {
                     let values = forecast.forecastValuesArray.prefix(36).map { Int($0.value) }
                     guard !values.isEmpty else { continue }
                     allForecastValues.append(Array(values))
-                    if let type = forecast.type {
-                        forecastLines.append((type: type, values: Array(values)))
-                    }
                 }
             }
 
@@ -91,8 +87,7 @@ extension LiveActivityManager {
                 target: determination.currentTarget?.decimalValue ?? 0,
                 date: determination.deliverAt,
                 minForecast: minForecast,
-                maxForecast: maxForecast,
-                forecastLines: forecastLines
+                maxForecast: maxForecast
             )
         }
     }

--- a/Trio/Sources/Services/LiveActivity/Data/DeterminationData.swift
+++ b/Trio/Sources/Services/LiveActivity/Data/DeterminationData.swift
@@ -7,4 +7,5 @@ struct DeterminationData {
     let date: Date?
     let minForecast: [Int]
     let maxForecast: [Int]
+    let forecastLines: [(type: String, values: [Int])]
 }

--- a/Trio/Sources/Services/LiveActivity/Data/DeterminationData.swift
+++ b/Trio/Sources/Services/LiveActivity/Data/DeterminationData.swift
@@ -5,4 +5,7 @@ struct DeterminationData {
     let tdd: Decimal
     let target: Decimal
     let date: Date?
+    let minForecast: [Int]
+    let maxForecast: [Int]
+    let forecastLines: [(type: String, values: [Int])]
 }

--- a/Trio/Sources/Services/LiveActivity/Data/DeterminationData.swift
+++ b/Trio/Sources/Services/LiveActivity/Data/DeterminationData.swift
@@ -7,5 +7,4 @@ struct DeterminationData {
     let date: Date?
     let minForecast: [Int]
     let maxForecast: [Int]
-    let forecastLines: [(type: String, values: [Int])]
 }

--- a/Trio/Sources/Services/LiveActivity/LiveActitiyAttributes.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActitiyAttributes.swift
@@ -51,11 +51,18 @@ struct LiveActivityAttributes: ActivityAttributes {
         let widgetItems: [LiveActivityItem]
         let minForecast: [Int]
         let maxForecast: [Int]
+        let forecastLines: [ForecastLine]
+        let forecastDisplayType: String
     }
 
     struct ChartItem: Codable, Hashable {
         let value: Decimal
         let date: Date
+    }
+
+    struct ForecastLine: Codable, Hashable {
+        let type: String
+        let values: [Int]
     }
 
     let startDate: Date

--- a/Trio/Sources/Services/LiveActivity/LiveActitiyAttributes.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActitiyAttributes.swift
@@ -49,11 +49,20 @@ struct LiveActivityAttributes: ActivityAttributes {
         let tempTargetDuration: Decimal
         let tempTargetTarget: Decimal
         let widgetItems: [LiveActivityItem]
+        let minForecast: [Int]
+        let maxForecast: [Int]
+        let forecastLines: [ForecastLine]
+        let forecastDisplayType: String
     }
 
     struct ChartItem: Codable, Hashable {
         let value: Decimal
         let date: Date
+    }
+
+    struct ForecastLine: Codable, Hashable {
+        let type: String
+        let values: [Int]
     }
 
     let startDate: Date

--- a/Trio/Sources/Services/LiveActivity/LiveActitiyAttributes.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActitiyAttributes.swift
@@ -51,18 +51,11 @@ struct LiveActivityAttributes: ActivityAttributes {
         let widgetItems: [LiveActivityItem]
         let minForecast: [Int]
         let maxForecast: [Int]
-        let forecastLines: [ForecastLine]
-        let forecastDisplayType: String
     }
 
     struct ChartItem: Codable, Hashable {
         let value: Decimal
         let date: Date
-    }
-
-    struct ForecastLine: Codable, Hashable {
-        let type: String
-        let values: [Int]
     }
 
     let startDate: Date

--- a/Trio/Sources/Services/LiveActivity/LiveActivityAttributes+Helper.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActivityAttributes+Helper.swift
@@ -119,8 +119,13 @@ extension LiveActivityAttributes.ContentState {
             tempTargetDuration: tempTarget?.duration ?? 0,
             tempTargetTarget: tempTarget?.target ?? 0,
             widgetItems: widgetItems ?? [], // set empty array here to silence compiler; this can never be nil
-            minForecast: determination?.minForecast ?? [],
-            maxForecast: determination?.maxForecast ?? []
+            minForecast: settings.forecastDisplayType == .cone ? (determination?.minForecast ?? []) : [],
+            maxForecast: settings.forecastDisplayType == .cone ? (determination?.maxForecast ?? []) : [],
+            forecastLines: settings.forecastDisplayType == .lines
+                ? (determination?.forecastLines ?? [])
+                .map { LiveActivityAttributes.ForecastLine(type: $0.type, values: $0.values) }
+                : [],
+            forecastDisplayType: settings.forecastDisplayType.rawValue
         )
 
         self.init(

--- a/Trio/Sources/Services/LiveActivity/LiveActivityAttributes+Helper.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActivityAttributes+Helper.swift
@@ -118,7 +118,13 @@ extension LiveActivityAttributes.ContentState {
             tempTargetDate: tempTarget?.date ?? Date(),
             tempTargetDuration: tempTarget?.duration ?? 0,
             tempTargetTarget: tempTarget?.target ?? 0,
-            widgetItems: widgetItems ?? [] // set empty array here to silence compiler; this can never be nil
+            widgetItems: widgetItems ?? [], // set empty array here to silence compiler; this can never be nil
+            minForecast: determination?.minForecast ?? [],
+            maxForecast: determination?.maxForecast ?? [],
+            forecastLines: (determination?.forecastLines ?? []).map {
+                LiveActivityAttributes.ForecastLine(type: $0.type, values: $0.values)
+            },
+            forecastDisplayType: settings.forecastDisplayType.rawValue
         )
 
         self.init(

--- a/Trio/Sources/Services/LiveActivity/LiveActivityAttributes+Helper.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActivityAttributes+Helper.swift
@@ -119,9 +119,11 @@ extension LiveActivityAttributes.ContentState {
             tempTargetDuration: tempTarget?.duration ?? 0,
             tempTargetTarget: tempTarget?.target ?? 0,
             widgetItems: widgetItems ?? [], // set empty array here to silence compiler; this can never be nil
-            minForecast: settings.forecastDisplayType == .cone ? (determination?.minForecast ?? []) : [],
-            maxForecast: settings.forecastDisplayType == .cone ? (determination?.maxForecast ?? []) : [],
-            forecastLines: settings.forecastDisplayType == .lines
+            minForecast: settings.displayGlucoseForecasts && settings.forecastDisplayType == .cone
+                ? (determination?.minForecast ?? []) : [],
+            maxForecast: settings.displayGlucoseForecasts && settings.forecastDisplayType == .cone
+                ? (determination?.maxForecast ?? []) : [],
+            forecastLines: settings.displayGlucoseForecasts && settings.forecastDisplayType == .lines
                 ? (determination?.forecastLines ?? [])
                 .map { LiveActivityAttributes.ForecastLine(type: $0.type, values: $0.values) }
                 : [],

--- a/Trio/Sources/Services/LiveActivity/LiveActivityAttributes+Helper.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActivityAttributes+Helper.swift
@@ -120,11 +120,7 @@ extension LiveActivityAttributes.ContentState {
             tempTargetTarget: tempTarget?.target ?? 0,
             widgetItems: widgetItems ?? [], // set empty array here to silence compiler; this can never be nil
             minForecast: determination?.minForecast ?? [],
-            maxForecast: determination?.maxForecast ?? [],
-            forecastLines: (determination?.forecastLines ?? []).map {
-                LiveActivityAttributes.ForecastLine(type: $0.type, values: $0.values)
-            },
-            forecastDisplayType: settings.forecastDisplayType.rawValue
+            maxForecast: determination?.maxForecast ?? []
         )
 
         self.init(

--- a/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
@@ -324,7 +324,9 @@ final class LiveActivityData: ObservableObject {
                                 tempTargetTarget: 0,
                                 widgetItems: [],
                                 minForecast: [],
-                                maxForecast: []
+                                maxForecast: [],
+                                forecastLines: [],
+                                forecastDisplayType: ForecastDisplayType.cone.rawValue
                             ),
                             isInitialState: true
                         ),

--- a/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
@@ -322,7 +322,11 @@ final class LiveActivityData: ObservableObject {
                                 tempTargetDate: Date.now,
                                 tempTargetDuration: 0,
                                 tempTargetTarget: 0,
-                                widgetItems: []
+                                widgetItems: [],
+                                minForecast: [],
+                                maxForecast: [],
+                                forecastLines: [],
+                                forecastDisplayType: ForecastDisplayType.cone.rawValue
                             ),
                             isInitialState: true
                         ),

--- a/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
+++ b/Trio/Sources/Services/LiveActivity/LiveActivityManager.swift
@@ -324,9 +324,7 @@ final class LiveActivityData: ObservableObject {
                                 tempTargetTarget: 0,
                                 widgetItems: [],
                                 minForecast: [],
-                                maxForecast: [],
-                                forecastLines: [],
-                                forecastDisplayType: ForecastDisplayType.cone.rawValue
+                                maxForecast: []
                             ),
                             isInitialState: true
                         ),


### PR DESCRIPTION
New feature adding glucose forecast to the Live Activity lock screen widget. 

Quick walkthrough:

- The feature is controlled by a setting under Settings - Notifications - Live Activity
- Default setting is off
- Forecast display type (cone or lines) is controlled by the same setting as the Main chart

| Setting, default is off | Setting explanation | Example with prediction lines | Example with cone |
|--------|--------|--------|--------|
| <img width="563" height="1218" alt="LA_Pred_Setting" src="https://github.com/user-attachments/assets/0ff1ba16-195d-4f3e-838b-ed4fdd5cd987" /> | <img width="563" height="1218" alt="LA_Pred_Setting_Help" src="https://github.com/user-attachments/assets/85d65e98-19a6-4f9b-96ab-40b29a13c4a9" /> | <img width="1125" height="2436" alt="LA_Prediction_Lines_2" src="https://github.com/user-attachments/assets/fdbf2c2c-ab30-4914-b987-477dfc86e8f7" /> | <img width="1125" height="2436" alt="LA_Cone_2" src="https://github.com/user-attachments/assets/4c9f3ed2-cc6e-4709-8535-5979d4921352" /> | 

Runs fine on my test device and on my live device, but needs more testers and a code review.