### PR TITLE
Use shaded CircleShape

### DIFF
--- a/Trio/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
@@ -176,7 +176,6 @@ struct TrendShape: View {
                     CircleShape(gradient: gradient)
                     TriangleShape(color: color)
                 }.shadow(color: Color.black.opacity(colorScheme == .dark ? 0.75 : 0.33), radius: colorScheme == .dark ? 5 : 3)
-                CircleShape(gradient: gradient)
             }
         }
     }


### PR DESCRIPTION
Noticed ZStack still had an object in it from a commit three days earlier. If this was intended, nvm… 
<img width="1218" height="135" alt="image" src="https://github.com/user-attachments/assets/40054f8d-0116-4d0c-8dfa-6c7a1dd0a792" />
