### PR TITLE
Trio v0.8.2 patch release – sync to dev

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -18,8 +18,8 @@ BUNDLE_IDENTIFIER = org.nightscout.$(DEVELOPMENT_TEAM).trio
 TRIO_APP_GROUP_ID = group.org.nightscout.$(DEVELOPMENT_TEAM).trio.trio-app-group
 
 // The developers set the version numbers, please leave them alone
-APP_VERSION = 0.8.1
-APP_DEV_VERSION = 0.8.1.8
+APP_VERSION = 0.8.2
+APP_DEV_VERSION = 0.8.2
 APP_BUILD_NUMBER = 1
 COPYRIGHT_NOTICE =
 


### PR DESCRIPTION
Sync patch release 0.8.2 back to `dev`.