### PR TITLE
Enable text selection to copy SHA

### DIFF
--- a/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -100,30 +100,49 @@ extension Settings {
             }
         }
 
+        private func copyVersionInfo(_ text: String) {
+            UIPasteboard.general.string = text
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            withAnimation { showCopiedToast = true }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                withAnimation { showCopiedToast = false }
+            }
+        }
+
         var body: some View {
             List {
                 if searchText.isEmpty {
                     let buildDetails = BuildDetails.shared
 
+                    /// The current development version of the app.
+                    ///
+                    /// Follows a semantic pattern where release versions are like `0.5.0`, and
+                    /// development versions increment with a fourth component (e.g., `0.5.0.1`, `0.5.0.2`)
+                    /// after the base release. For example:
+                    /// - After release `0.5.0` → `0.5.0`
+                    /// - First dev push → `0.5.0.1`
+                    /// - Next dev push → `0.5.0.2`
+                    /// - Next release `0.6.0` → `0.6.0`
+                    /// - Next dev push → `0.6.0.1`
+                    ///
+                    /// If the dev version is unavailable, `"unknown"` is returned.
+                    let devVersion = Bundle.main.appDevVersion ?? "unknown"
+
+                    let buildNumber = Bundle.main.buildVersionNumber ?? String(localized: "Unknown")
+
                     Section(
-                        header: Text("BRANCH: \(buildDetails.branchAndSha)").textCase(nil),
+                        header: HStack(spacing: 4) {
+                            Button {
+                                copyVersionInfo(
+                                    "Trio v\(devVersion) (\(buildNumber)) \(buildDetails.branchAndSha)"
+                                )
+                            } label: {
+                                Image(systemName: "doc.on.doc.fill")
+                            }
+                            .buttonStyle(.plain)
+                            Text("BRANCH: \(buildDetails.branchAndSha)")
+                        }.textCase(nil),
                         content: {
-                            /// The current development version of the app.
-                            ///
-                            /// Follows a semantic pattern where release versions are like `0.5.0`, and
-                            /// development versions increment with a fourth component (e.g., `0.5.0.1`, `0.5.0.2`)
-                            /// after the base release. For example:
-                            /// - After release `0.5.0` → `0.5.0`
-                            /// - First dev push → `0.5.0.1`
-                            /// - Next dev push → `0.5.0.2`
-                            /// - Next release `0.6.0` → `0.6.0`
-                            /// - Next dev push → `0.6.0.1`
-                            ///
-                            /// If the dev version is unavailable, `"unknown"` is returned.
-                            let devVersion = Bundle.main.appDevVersion ?? "unknown"
-
-                            let buildNumber = Bundle.main.buildVersionNumber ?? String(localized: "Unknown")
-
                             NavigationLink(destination: SubmodulesView(buildDetails: buildDetails)) {
                                 HStack {
                                     Image(appIcons.appIcon.rawValue)
@@ -151,16 +170,6 @@ extension Settings {
                                         }
 
                                         versionInfoView
-                                    }
-                                }
-                                .contentShape(Rectangle())
-                                .onLongPressGesture {
-                                    UIPasteboard.general.string =
-                                        "Trio v\(devVersion) (\(buildNumber)) \(buildDetails.branchAndSha)"
-                                    UINotificationFeedbackGenerator().notificationOccurred(.success)
-                                    withAnimation { showCopiedToast = true }
-                                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                                        withAnimation { showCopiedToast = false }
                                     }
                                 }
                             }

--- a/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -3,6 +3,7 @@ import LoopKit
 import LoopKitUI
 import SwiftUI
 import Swinject
+import UIKit
 
 extension Settings {
     struct VersionInfo: Equatable {
@@ -34,6 +35,7 @@ extension Settings {
             isDevUpdateAvailable: false
         )
         @State private var closedLoopDisabled = true
+        @State private var showCopiedToast = false
 
         @Environment(\.colorScheme) var colorScheme
         @EnvironmentObject var appIcons: Icons
@@ -149,6 +151,16 @@ extension Settings {
                                         }
 
                                         versionInfoView
+                                    }
+                                }
+                                .contentShape(Rectangle())
+                                .onLongPressGesture {
+                                    UIPasteboard.general.string =
+                                        "Trio v\(devVersion) (\(buildNumber)) \(buildDetails.branchAndSha)"
+                                    UINotificationFeedbackGenerator().notificationOccurred(.success)
+                                    withAnimation { showCopiedToast = true }
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                                        withAnimation { showCopiedToast = false }
                                     }
                                 }
                             }
@@ -308,6 +320,18 @@ extension Settings {
                             }
                         }
                     ).listRowBackground(Color.chart)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                if showCopiedToast {
+                    Label("Copied", systemImage: "checkmark.circle.fill")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .padding(.bottom, 32)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
             }
             .scrollContentBackground(.hidden).background(appState.trioBackgroundColor(for: colorScheme))

--- a/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
+++ b/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
@@ -32,6 +32,7 @@ struct KeyValueRow: View {
             Text(value)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.trailing)
+                .textSelection(.enabled)
         }
     }
 }

--- a/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
+++ b/Trio/Sources/Modules/Settings/View/Subviews/SubmodulesView.swift
@@ -28,6 +28,7 @@ struct KeyValueRow: View {
         HStack {
             Text(key)
                 .foregroundColor(.primary)
+                .textSelection(.enabled)
             Spacer()
             Text(value)
                 .foregroundColor(.secondary)


### PR DESCRIPTION
resolves #1210 

Allows users to easily copy the SHA of Trio or of a specific submodule.

<img width="333" src="https://github.com/user-attachments/assets/21cd01d0-427d-4f26-8530-70005492248e" />


