### PR TITLE
Sync delivery limits to pump manager on init

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -585,6 +585,7 @@
 		CEE9A6592BBB418300EB5194 /* CalibrationsDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9A6542BBB418300EB5194 /* CalibrationsDataFlow.swift */; };
 		CEE9A65C2BBB41C800EB5194 /* CalibrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9A65B2BBB41C800EB5194 /* CalibrationService.swift */; };
 		CEE9A65E2BBC9F6500EB5194 /* CalibrationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9A65D2BBC9F6500EB5194 /* CalibrationsTests.swift */; };
+		FEBD275A2930CAD44A346E78 /* DeliveryLimitsSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B081E2D95817EA3CDBC9B79 /* DeliveryLimitsSyncTests.swift */; };
 		CEF1ED6B2D58FB5800FAF41E /* CGMOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF1ED6A2D58FB4600FAF41E /* CGMOptions.swift */; };
 		D6D02515BBFBE64FEBE89856 /* HistoryRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 881E04BA5E0A003DE8E0A9C6 /* HistoryRootView.swift */; };
 		D6DEC113821A7F1056C4AA1E /* NightscoutConfigDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2A13DF0EDEEEDC4106AA2A /* NightscoutConfigDataFlow.swift */; };
@@ -1524,6 +1525,7 @@
 		CEE9A6542BBB418300EB5194 /* CalibrationsDataFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalibrationsDataFlow.swift; sourceTree = "<group>"; };
 		CEE9A65B2BBB41C800EB5194 /* CalibrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibrationService.swift; sourceTree = "<group>"; };
 		CEE9A65D2BBC9F6500EB5194 /* CalibrationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalibrationsTests.swift; sourceTree = "<group>"; };
+		2B081E2D95817EA3CDBC9B79 /* DeliveryLimitsSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryLimitsSyncTests.swift; sourceTree = "<group>"; };
 		CEF1ED6A2D58FB4600FAF41E /* CGMOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGMOptions.swift; sourceTree = "<group>"; };
 		CFCFE0781F9074C2917890E8 /* ManualTempBasalStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManualTempBasalStateModel.swift; sourceTree = "<group>"; };
 		D0BDC6993C1087310EDFC428 /* CarbRatioEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CarbRatioEditorRootView.swift; sourceTree = "<group>"; };
@@ -2870,6 +2872,7 @@
 				BD8FC0552D66187700B95AED /* CoreDataTests */,
 				38FCF3F125E9028E0078B0D1 /* Info.plist */,
 				CEE9A65D2BBC9F6500EB5194 /* CalibrationsTests.swift */,
+				2B081E2D95817EA3CDBC9B79 /* DeliveryLimitsSyncTests.swift */,
 				3BAAE60B2DE776630049589B /* DynamicISFEnableTests.swift */,
 				38FCF3F825E902C20078B0D1 /* FileStorageTests.swift */,
 				3B997DCE2DC00A3A006B6BB2 /* JSONImporterTests.swift */,
@@ -5313,6 +5316,7 @@
 				3B5CD2CE2D4AECD500CE213C /* ProfileBasalTests.swift in Sources */,
 				3B3B4F582E662B1E00B668E3 /* DetermineBasalIobGreaterThanMaxTests.swift in Sources */,
 				CEE9A65E2BBC9F6500EB5194 /* CalibrationsTests.swift in Sources */,
+				FEBD275A2930CAD44A346E78 /* DeliveryLimitsSyncTests.swift in Sources */,
 				3B3B4F562E661FD600B668E3 /* DetermineBasalEventualOrForecastGlucoseLessThanMaxTests.swift in Sources */,
 				3BEF6AB32D97316F0076089D /* MealTotalTests.swift in Sources */,
 				3BEF6AB12D9731660076089D /* MealHistoryTests.swift in Sources */,

--- a/Trio/Sources/APS/DeviceDataManager.swift
+++ b/Trio/Sources/APS/DeviceDataManager.swift
@@ -3,6 +3,7 @@ import Combine
 import CoreData
 import DanaKit
 import Foundation
+import HealthKit
 import LoopKit
 import LoopKitUI
 import MedtrumKit
@@ -90,6 +91,18 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
                 /// copy its rawValue to rawPumpManager which will be saved to persistant storage.
                 rawPumpManager = pumpManager.rawValue
                 UserDefaults.standard.clearLegacyPumpManagerRawValue()
+
+                /// Re-sync delivery limits from the user's settings whenever a pump manager is set.
+                /// A manager restored from persisted state can retain a stale or default limit and
+                /// reject in-range temp basals; keep this ahead of the early returns below.
+                let deliveryLimits = Self.deliveryLimits(from: settingsManager.pumpSettings)
+                processQueue.async {
+                    pumpManager.syncDeliveryLimits(limits: deliveryLimits) { result in
+                        if case let .failure(error) = result {
+                            debug(.deviceManager, "syncDeliveryLimits on pump manager init failed: \(error)")
+                        }
+                    }
+                }
 
                 pumpDisplayState.value = PumpDisplayState(name: pumpManager.localizedTitle, image: pumpManager.smallImage)
                 pumpName.send(pumpManager.localizedTitle)
@@ -282,6 +295,20 @@ final class BaseDeviceDataManager: DeviceDataManager, Injectable {
 
     public func pumpManagerTypeByIdentifier(_ identifier: String) -> PumpManagerUI.Type? {
         staticPumpManagersByIdentifier[identifier]
+    }
+
+    /// Builds pump-manager delivery limits from the user's configured pump settings.
+    static func deliveryLimits(from pumpSettings: PumpSettings) -> DeliveryLimits {
+        DeliveryLimits(
+            maximumBasalRate: HKQuantity(
+                unit: .internationalUnitsPerHour,
+                doubleValue: Double(pumpSettings.maxBasal)
+            ),
+            maximumBolus: HKQuantity(
+                unit: .internationalUnit(),
+                doubleValue: Double(pumpSettings.maxBolus)
+            )
+        )
     }
 
     private func pumpManagerFromRawValue(_ rawValue: [String: Any]) -> PumpManagerUI? {

--- a/TrioTests/DeliveryLimitsSyncTests.swift
+++ b/TrioTests/DeliveryLimitsSyncTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import HealthKit
+import LoopKit
+import Testing
+
+@testable import Trio
+
+/// Covers `BaseDeviceDataManager.deliveryLimits(from:)`: the mapping from the user's configured
+/// pump settings to the delivery limits synced to the pump manager.
+@Suite("Delivery Limits Sync Tests") struct DeliveryLimitsSyncTests {
+    private let basalUnit = HKUnit.internationalUnitsPerHour
+    private let bolusUnit = HKUnit.internationalUnit()
+
+    private func makeSettings(maxBasal: Decimal, maxBolus: Decimal) -> PumpSettings {
+        PumpSettings(insulinActionCurve: 6, maxBolus: maxBolus, maxBasal: maxBasal)
+    }
+
+    @Test("maxBasal maps to maximumBasalRate in U/hr") func testMaxBasalMapping() {
+        let settings = makeSettings(maxBasal: 5.0, maxBolus: 10.0)
+
+        let limits = BaseDeviceDataManager.deliveryLimits(from: settings)
+
+        #expect(limits.maximumBasalRate?.doubleValue(for: basalUnit) == 5.0)
+    }
+
+    @Test("maxBolus maps to maximumBolus in U") func testMaxBolusMapping() {
+        let settings = makeSettings(maxBasal: 5.0, maxBolus: 10.0)
+
+        let limits = BaseDeviceDataManager.deliveryLimits(from: settings)
+
+        #expect(limits.maximumBolus?.doubleValue(for: bolusUnit) == 10.0)
+    }
+
+    /// The derived limit must be the user's configured value, not the `PumpInitialSettings` default.
+    @Test("User-configured limit is preserved, not collapsed to the 2 U/hr default") func testDoesNotFallBackToDefault() {
+        let configuredMaxBasal: Decimal = 3.0
+        let defaultMaxBasal = PumpConfig.PumpInitialSettings.default.maxBasalRateUnitsPerHour
+
+        let settings = makeSettings(maxBasal: configuredMaxBasal, maxBolus: 10.0)
+        let limits = BaseDeviceDataManager.deliveryLimits(from: settings)
+
+        #expect(limits.maximumBasalRate?.doubleValue(for: basalUnit) == Double(configuredMaxBasal))
+        #expect(limits.maximumBasalRate?.doubleValue(for: basalUnit) != defaultMaxBasal)
+    }
+
+    /// The derived limit must be the user's configured value, not the `PumpInitialSettings` default.
+    @Test("User-configured bolus limit is preserved, not collapsed to the default") func testBolusDoesNotFallBackToDefault() {
+        let configuredMaxBolus: Decimal = 25.0
+        let defaultMaxBolus = PumpConfig.PumpInitialSettings.default.maxBolusUnits
+
+        let settings = makeSettings(maxBasal: 3.0, maxBolus: configuredMaxBolus)
+        let limits = BaseDeviceDataManager.deliveryLimits(from: settings)
+
+        #expect(limits.maximumBolus?.doubleValue(for: bolusUnit) == Double(configuredMaxBolus))
+        #expect(limits.maximumBolus?.doubleValue(for: bolusUnit) != defaultMaxBolus)
+    }
+}


### PR DESCRIPTION
When a pump manager is instantiated from persisted raw state rather than through the pump setup flow, it can come up with a stale or default delivery limit from its deserialized state. With pump managers that enforce the limit on temp basals (e.g. OmnipodKit), this silently rejects in-range temp basals and fails the loop.

Re-sync the user's configured max basal/bolus into the pump manager whenever one is set, ahead of the branches that may return early. Add unit tests covering the settings-to-limits derivation, including regression guards that the user's values are not collapsed to the PumpInitialSettings defaults.