### PR TITLE
Report adjusted ISF in determination output

### DIFF
--- a/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/DetermineBasalGenerator.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/DetermineBasal/DetermineBasalGenerator.swift
@@ -377,7 +377,7 @@ enum DeterminationGenerator {
             temp: nil,
             bg: currentGlucose,
             reservoir: nil,
-            isf: nil,
+            isf: adjustedSensitivity.jsRounded(),
             timestamp: currentTime,
             tdd: nil,
             current_target: adjustedGlucoseTargets.targetGlucose,


### PR DESCRIPTION
The Swift oref left `isf` as nil in the determination, so the ISF field uploaded to Nightscout came out as 0. This sets it to the adjusted sensitivity, the same value already shown in the reason string.

Dan found the fix, I'm just the secretary.