### PR TITLE
Make sure that autosens has a profile to work with

### DIFF
--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -468,14 +468,13 @@ final class BaseAPSManager: APSManager, Injectable {
         do {
             let now = Date()
 
-            // Parallelize the fetches using async let
-            async let currentTemp = fetchCurrentTempBasal(date: now)
-            async let autosenseResult = autosense()
-
-            _ = try await autosenseResult
+            // put profile creation up front since autosens needs it
             try await openAPS.createProfiles(useSwiftOref: settings.useSwiftOref)
+            let currentTemp = try await fetchCurrentTempBasal(date: now)
+            _ = try await autosense()
+
             let determination = try await openAPS.determineBasal(
-                currentTemp: await currentTemp,
+                currentTemp: currentTemp,
                 shouldSmoothGlucose: settingsManager.settings.smoothGlucose,
                 useSwiftOref: settings.useSwiftOref,
                 clock: now


### PR DESCRIPTION
The Swift version of autosens expects to have a profile object, so if
you start with oref-swift from the start the current version will
throw an exception on autosens since there is no profile, and the
algorithm will never make progress.

This change swaps the order of autosens and profile creation. Profile
creation doesn't depend on autosens, so this change is safe and
enables systems set up as oref-swift from the start run.

Note: There was a tiny amount of parallelism in the previous version,
but not enough to justify so I removed it to make the code more
straightforward.

Thanks to @mountrcg for reporting this originally. 
