### PR TITLE
Round derived TDD averages in raw algorithm output (#1209)

### DIFF
--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -542,9 +542,12 @@ final class OpenAPS {
                 .reduce(0, +)
 
             let currentTDD = historicalTDDData.last?["total"] as? Decimal ?? 0
-            let averageTDDLastTwoHours = recentTotalTDD / Decimal(recentDataCount)
-            let averageTDDLastTenDays = totalTDD / Decimal(totalDaysCount)
-            let weightedTDD = weightPercentage * averageTDDLastTwoHours + (1 - weightPercentage) * averageTDDLastTenDays
+            // Round derived TDD averages to avoid floating-point artifacts (e.g. ...85000000000001)
+            // leaking into the raw algorithm output. Matches the precision handling in TDDStorage. (#1209)
+            let averageTDDLastTwoHours = (recentTotalTDD / Decimal(recentDataCount)).rounded(toPlaces: 2)
+            let averageTDDLastTenDays = (totalTDD / Decimal(totalDaysCount)).rounded(toPlaces: 2)
+            let weightedTDD = (weightPercentage * averageTDDLastTwoHours + (1 - weightPercentage) * averageTDDLastTenDays)
+                .rounded(toPlaces: 2)
 
             let glucose = try self.fetchGlucose()
 


### PR DESCRIPTION
## Summary
Fixes #1209.

The two-hour, ten-day and weighted TDD averages in `OpenAPS.swift` were computed with raw `Decimal` division/multiplication and passed straight into the oref variables (`average_total_data`, `weightedAverage`, `past2hoursAverage`) without rounding. This surfaced floating-point artifacts such as `…85000000000001` in the raw algorithm output.

## Change
- Round each derived TDD value to 2 decimal places in `OpenAPS.swift`, using the existing `Decimal.rounded(toPlaces:)` helper. This matches the precision handling already applied in `TDDStorage` (which truncates to 3 places).
- `currentTDD` is read from already-stored TDD data, so it is left unchanged.

The change to the value used by dynamic ISF is at most ~0.005 U, i.e. negligible for dosing, while removing the long-decimal artifact from the output.