### PR TITLE
Avoid showing zero target/ISF in bolus calculator (#1139)

### DIFF
--- a/Trio/Sources/Modules/Treatments/TreatmentsStateModel.swift
+++ b/Trio/Sources/Modules/Treatments/TreatmentsStateModel.swift
@@ -905,6 +905,14 @@ extension Treatments.StateModel {
 
     private func updateDeterminationsArray(with objects: [OrefDetermination]) {
         Task { @MainActor in
+            // Fall back to the current profile values for target/ISF/carb ratio so the bolus
+            // calculator never shows or divides by 0 when there is no recent determination
+            // (e.g. implicit open loop during sensor warmup or missing readings). These are
+            // overwritten below with the determination's values when one is available. (#1139)
+            target = currentBGTarget
+            isf = currentISF
+            carbRatio = currentCarbRatio
+
             guard let mostRecentDetermination = objects.first else { return }
             determination = objects
 


### PR DESCRIPTION
## Summary
Fixes #1139.

When there was no determination in the last 30 minutes (implicit open loop during sensor warmup or missing readings), `updateDeterminationsArray` returned early and left `target` and `isf` at their initial value of `0`. The bolus calculator then displayed `0` for target and ISF (and could divide by a zero ISF) until a determination arrived "shortly after".

## Change
- Populate `target` / `isf` / `carbRatio` from the currently loaded profile values (`currentBGTarget`, `currentISF`, `currentCarbRatio`) before the early return, so the calculator reflects the active profile instead of `0`.
- When a determination is available, these are immediately overwritten with its values, so normal behavior is unchanged.

Note: the recommended dose itself was already protected — `calculateInsulin` forces the recommendation to 0 when the loop is stale, which is the open-loop case — so this is primarily a display-correctness fix that also avoids a zero-ISF division.