### PR TITLE
adds a subtle animation to the bolus progress bar

### DIFF
--- a/Trio/Sources/Views/BolusProgressBar.swift
+++ b/Trio/Sources/Views/BolusProgressBar.swift
@@ -19,6 +19,7 @@ struct BolusProgressBar: View {
                         .mask(alignment: .leading) {
                             RoundedRectangle(cornerRadius: 15)
                                 .frame(width: geo.size.width * CGFloat(progress))
+                                .animation(.easeInOut(duration: 0.25), value: progress)
                         }
                 )
         }


### PR DESCRIPTION

https://github.com/user-attachments/assets/b6d73a2a-90c2-4f59-9cd2-556d1c0a178e
only animated progress bar is in this pr ignore other change viewable at the screen recording