### PR TITLE
Refresh stale persistent history token for CoreData

### DIFF
--- a/Model/CoreDataStack.swift
+++ b/Model/CoreDataStack.swift
@@ -113,8 +113,28 @@ class CoreDataStack: ObservableObject {
     func fetchPersistentHistory() async {
         do {
             try await fetchPersistentHistoryTransactionsAndChanges()
+        } catch let error as NSError where error.code == NSPersistentHistoryTokenExpiredError {
+            debug(.coreData, "Persistent history token expired; clearing token and replaying available history.")
+            await recoverFromExpiredHistoryToken()
         } catch {
             debug(.coreData, "\(error)")
+        }
+    }
+
+    /// Recovers the change-merge pipeline after the persistent history token expires.
+    private func recoverFromExpiredHistoryToken() async {
+        lastToken = nil
+        do {
+            try await fetchPersistentHistoryTransactionsAndChanges()
+        } catch {
+            debug(.coreData, "Replay after token reset failed; jumping to current token. \(error)")
+            let viewContext = persistentContainer.viewContext
+            let currentToken = persistentContainer.persistentStoreCoordinator
+                .currentPersistentHistoryToken(fromStores: nil)
+            lastToken = currentToken
+            await viewContext.perform {
+                viewContext.refreshAllObjects()
+            }
         }
     }
 


### PR DESCRIPTION
When Trio calls `fetchPersistentHistory` it logs errors. One type of
error, the `NSPersistentHistoryTokenExpiredError` error will cause
Trio to stop refreshing data. This error can happen for a few reasons,
like not using Trio of a while or updating the database.

The fix is to refresh all objects manually and reset the persistent
history token, i.e., `lastHistoryToken` stored in UserDefaults.

This error is extremely hard to test, but I had a device stuck in this
state and confirmed the fix.
