### PR TITLE
Remove core data fetch limits (already time predicate limited)

### DIFF
--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -1050,17 +1050,14 @@ final class BaseAPSManager: APSManager, Injectable {
             let glucose24h = try await fetchGlucose(predicate: NSPredicate.predicateForOneDayAgo, fetchLimit: 288, batchSize: 50)
             let glucoseOneWeek = try await fetchGlucose(
                 predicate: NSPredicate.predicateForOneWeek,
-                fetchLimit: 288 * 7,
                 batchSize: 250
             )
             let glucoseOneMonth = try await fetchGlucose(
                 predicate: NSPredicate.predicateForOneMonth,
-                fetchLimit: 288 * 7 * 30,
                 batchSize: 500
             )
             let glucoseThreeMonths = try await fetchGlucose(
                 predicate: NSPredicate.predicateForThreeMonths,
-                fetchLimit: 288 * 7 * 30 * 3,
                 batchSize: 1000
             )
 

--- a/Trio/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/Trio/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -274,8 +274,7 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
             onContext: context,
             predicate: NSPredicate.pumpHistoryLast24h,
             key: "timestamp",
-            ascending: false,
-            fetchLimit: 288
+            ascending: false
         )
 
         return await context.perform {

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -139,18 +139,18 @@ extension Home {
                 cgmSensorExpiresAt: state.cgmSensorExpiresAt,
                 cgmWarmupEndsAt: state.cgmWarmupEndsAt
             )
-                .onTapGesture {
-                    if !state.cgmAvailable {
-                        showCGMSelection.toggle()
-                    } else {
-                        state.shouldDisplayCGMSetupSheet.toggle()
-                    }
+            .onTapGesture {
+                if !state.cgmAvailable {
+                    showCGMSelection.toggle()
+                } else {
+                    state.shouldDisplayCGMSetupSheet.toggle()
                 }
-                .onLongPressGesture {
-                    let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
-                    impactHeavy.impactOccurred()
-                    state.showModal(for: .snooze)
-                }
+            }
+            .onLongPressGesture {
+                let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
+                impactHeavy.impactOccurred()
+                state.showModal(for: .snooze)
+            }
         }
 
         var pumpView: some View {

--- a/Trio/Sources/Services/BolusCalculator/BolusCalculationManager.swift
+++ b/Trio/Sources/Services/BolusCalculator/BolusCalculationManager.swift
@@ -196,8 +196,7 @@ final class BaseBolusCalculationManager: BolusCalculationManager, Injectable {
             onContext: glucoseFetchContext,
             predicate: NSPredicate.glucose,
             key: "date",
-            ascending: false,
-            fetchLimit: 288
+            ascending: false
         )
 
         return try await glucoseFetchContext.perform {

--- a/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
+++ b/Trio/Sources/Services/LiveActivity/Data/DataManager.swift
@@ -11,8 +11,7 @@ extension LiveActivityManager {
             onContext: context,
             predicate: NSPredicate.predicateForSixHoursAgo,
             key: "date",
-            ascending: false,
-            fetchLimit: 72
+            ascending: false
         )
 
         return try await context.perform {

--- a/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
+++ b/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
@@ -379,8 +379,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
             onContext: backgroundContext,
             predicate: NSPredicate.glucose,
             key: "date",
-            ascending: false,
-            fetchLimit: 288
+            ascending: false
         )
 
         return try await backgroundContext.perform {


### PR DESCRIPTION
We had a few fetch limits in place that were potentially leading to fetch results, especially for pump history.

E.g. `getPumpHistory()` uses `pumpHistoryLast24h` but `fetchLimit: 288`.  With TBRs every 5-15 min (96-288/day) plus SMBs and manual user-initiated boluses, there are well over 288 events per day. This could potentially lead to the most‑recent 288 fetch result truncating pump eventing, covering less than 24h.

Similar for fetching glucose, where the predicate did not exclude potential manual glucose entries, leading to a false assumption of one reading per 5 minutes (288(day). 