### PR TITLE
Shorten Omnipod selection string in Onboarding to avoid break

### DIFF
--- a/Trio/Sources/Modules/Onboarding/View/OnboardingView+Util.swift
+++ b/Trio/Sources/Modules/Onboarding/View/OnboardingView+Util.swift
@@ -553,7 +553,7 @@ enum PumpOptionForOnboardingUnits: String, Equatable, CaseIterable, Identifiable
         case .minimed:
             return "Medtronic"
         case .omni:
-            return "All Omnipod Types"
+            return "Omnipod"
         case .dana:
             return "Dana (RS/-i)"
         case .medtrum:


### PR DESCRIPTION
Change `All Omnipod Types` to `Omnipod` for the Onboarding selection to avoid UI breakage.
We don't specifically list the Medtrum and different RS models for Dana, or the different reservoir-size models for Medtrum.

<img width="790" height="700" alt="image" src="https://github.com/user-attachments/assets/3c15d768-ad0a-42c5-b38e-83dc6f71bb1e" />
