### PR TITLE
Use Swift Oref by default

### DIFF
--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -184,7 +184,7 @@ final class BaseAPSManager: APSManager, Injectable {
             if wasParsed {
                 Task {
                     do {
-                        try await openAPS.createProfiles(useSwiftOref: settings.useSwiftOref)
+                        try await openAPS.createProfiles(useJavascriptOref: settings.useJavascriptOref)
                     } catch {
                         debug(
                             .apsManager,
@@ -434,7 +434,7 @@ final class BaseAPSManager: APSManager, Injectable {
         else {
             let result = try await openAPS.autosense(
                 shouldSmoothGlucose: settingsManager.settings.smoothGlucose,
-                useSwiftOref: settings.useSwiftOref
+                useJavascriptOref: settings.useJavascriptOref
             )
             return result != nil
         }
@@ -501,14 +501,14 @@ final class BaseAPSManager: APSManager, Injectable {
             let now = Date()
 
             // put profile creation up front since autosens needs it
-            try await openAPS.createProfiles(useSwiftOref: settings.useSwiftOref)
+            try await openAPS.createProfiles(useJavascriptOref: settings.useJavascriptOref)
             let currentTemp = try await fetchCurrentTempBasal(date: now)
             _ = try await autosense()
 
             let determination = try await openAPS.determineBasal(
                 currentTemp: currentTemp,
                 shouldSmoothGlucose: settingsManager.settings.smoothGlucose,
-                useSwiftOref: settings.useSwiftOref,
+                useJavascriptOref: settings.useJavascriptOref,
                 clock: now
             )
             iobFileDidUpdate.send(())
@@ -555,7 +555,7 @@ final class BaseAPSManager: APSManager, Injectable {
             return try await openAPS.determineBasal(
                 currentTemp: temp,
                 shouldSmoothGlucose: settingsManager.settings.smoothGlucose,
-                useSwiftOref: settings.useSwiftOref,
+                useJavascriptOref: settings.useJavascriptOref,
                 clock: Date(),
                 simulatedCarbsAmount: simulatedCarbsAmount,
                 simulatedBolusAmount: simulatedBolusAmount,

--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -385,7 +385,7 @@ final class OpenAPS {
     func determineBasal(
         currentTemp: TempBasal,
         shouldSmoothGlucose: Bool,
-        useSwiftOref: Bool,
+        useJavascriptOref: Bool,
         clock: Date = Date(),
         simulatedCarbsAmount: Decimal? = nil,
         simulatedBolusAmount: Decimal? = nil,
@@ -448,7 +448,7 @@ final class OpenAPS {
             clock: clock,
             carbs: carbsAsJSON,
             glucose: glucoseAsJSON,
-            useSwiftOref: useSwiftOref
+            useJavascriptOref: useJavascriptOref
         )
 
         // IOB calculation
@@ -457,7 +457,7 @@ final class OpenAPS {
             profile: profile,
             clock: clock,
             autosens: autosens.isEmpty ? .null : autosens,
-            useSwiftOref: useSwiftOref
+            useJavascriptOref: useJavascriptOref
         )
 
         // TODO: refactor this to core data
@@ -485,7 +485,7 @@ final class OpenAPS {
             preferences: preferences,
             basalProfile: basalProfile,
             trioCustomOrefVariables: trioCustomOrefVariables,
-            useSwiftOref: useSwiftOref
+            useJavascriptOref: useJavascriptOref
         )
 
         debug(.openAPS, "\(simulation ? "[SIMULATION]" : "") OREF DETERMINATION: \(orefDetermination)")
@@ -578,7 +578,7 @@ final class OpenAPS {
         }
     }
 
-    func autosense(shouldSmoothGlucose: Bool, useSwiftOref: Bool) async throws -> Autosens? {
+    func autosense(shouldSmoothGlucose: Bool, useJavascriptOref: Bool) async throws -> Autosens? {
         debug(.openAPS, "Start autosens")
 
         // Perform asynchronous calls in parallel
@@ -607,7 +607,7 @@ final class OpenAPS {
             profile: profile,
             carbs: carbsAsJSON,
             temptargets: tempTargets,
-            useSwiftOref: useSwiftOref
+            useJavascriptOref: useJavascriptOref
         )
 
         debug(.openAPS, "AUTOSENS: \(autosenseResult)")
@@ -621,7 +621,7 @@ final class OpenAPS {
         }
     }
 
-    func createProfiles(useSwiftOref: Bool) async throws {
+    func createProfiles(useJavascriptOref: Bool) async throws {
         debug(.openAPS, "Start creating pump profile and user profile")
 
         // Load required settings and profiles asynchronously
@@ -698,7 +698,7 @@ final class OpenAPS {
                 model: model,
                 autotune: RawJSON.null,
                 trioSettings: trioSettings,
-                useSwiftOref: useSwiftOref,
+                useJavascriptOref: useJavascriptOref,
                 clock: clock
             )
 
@@ -713,7 +713,7 @@ final class OpenAPS {
                 model: model,
                 autotune: RawJSON.null,
                 trioSettings: trioSettings,
-                useSwiftOref: useSwiftOref,
+                useJavascriptOref: useJavascriptOref,
                 clock: clock
             )
 
@@ -729,20 +729,26 @@ final class OpenAPS {
         }
     }
 
-    private func iob(pumphistory: JSON, profile: JSON, clock: JSON, autosens: JSON, useSwiftOref: Bool) async throws -> RawJSON {
+    private func iob(
+        pumphistory: JSON,
+        profile: JSON,
+        clock: JSON,
+        autosens: JSON,
+        useJavascriptOref: Bool
+    ) async throws -> RawJSON {
         // FIXME: For now we'll just remove duplicate suspends here (ISSUE-399)
         var pumphistory = pumphistory
         if let pumpHistoryArray = try? JSONBridge.pumpHistory(from: pumphistory) {
             pumphistory = pumpHistoryArray.removingDuplicateSuspendResumeEvents().rawJSON
         }
 
-        if useSwiftOref {
+        if useJavascriptOref {
+            let jsResult = await iobJavascript(pumphistory: pumphistory, profile: profile, clock: clock, autosens: autosens)
+            return try jsResult.returnOrThrow()
+        } else {
             let swiftResult = OpenAPSSwift
                 .iob(pumphistory: pumphistory, profile: profile, clock: clock, autosens: autosens)
             return try swiftResult.returnOrThrow()
-        } else {
-            let jsResult = await iobJavascript(pumphistory: pumphistory, profile: profile, clock: clock, autosens: autosens)
-            return try jsResult.returnOrThrow()
         }
     }
 
@@ -777,9 +783,19 @@ final class OpenAPS {
         clock: JSON,
         carbs: JSON,
         glucose: JSON,
-        useSwiftOref: Bool
+        useJavascriptOref: Bool
     ) async throws -> RawJSON {
-        if useSwiftOref {
+        if useJavascriptOref {
+            let jsResult = await mealJavascript(
+                pumphistory: pumphistory,
+                profile: profile,
+                basalProfile: basalProfile,
+                clock: clock,
+                carbs: carbs,
+                glucose: glucose
+            )
+            return try jsResult.returnOrThrow()
+        } else {
             let swiftResult = OpenAPSSwift
                 .meal(
                     pumphistory: pumphistory,
@@ -790,16 +806,6 @@ final class OpenAPS {
                     glucose: glucose
                 )
             return try swiftResult.returnOrThrow()
-        } else {
-            let jsResult = await mealJavascript(
-                pumphistory: pumphistory,
-                profile: profile,
-                basalProfile: basalProfile,
-                clock: clock,
-                carbs: carbs,
-                glucose: glucose
-            )
-            return try jsResult.returnOrThrow()
         }
     }
 
@@ -843,9 +849,19 @@ final class OpenAPS {
         profile: JSON,
         carbs: JSON,
         temptargets: JSON,
-        useSwiftOref: Bool
+        useJavascriptOref: Bool
     ) async throws -> RawJSON {
-        if useSwiftOref {
+        if useJavascriptOref {
+            let jsResult = await autosenseJavascript(
+                glucose: glucose,
+                pumpHistory: pumpHistory,
+                basalprofile: basalprofile,
+                profile: profile,
+                carbs: carbs,
+                temptargets: temptargets
+            )
+            return try jsResult.returnOrThrow()
+        } else {
             let swiftResult = OpenAPSSwift
                 .autosense(
                     glucose: glucose,
@@ -857,16 +873,6 @@ final class OpenAPS {
                     clock: Date()
                 )
             return try swiftResult.returnOrThrow()
-        } else {
-            let jsResult = await autosenseJavascript(
-                glucose: glucose,
-                pumpHistory: pumpHistory,
-                basalprofile: basalprofile,
-                profile: profile,
-                carbs: carbs,
-                temptargets: temptargets
-            )
-            return try jsResult.returnOrThrow()
         }
     }
 
@@ -916,28 +922,11 @@ final class OpenAPS {
         preferences: JSON,
         basalProfile: JSON,
         trioCustomOrefVariables: JSON,
-        useSwiftOref: Bool
+        useJavascriptOref: Bool
     ) async throws -> RawJSON {
         let clock = Date()
 
-        if useSwiftOref {
-            let swiftResult = OpenAPSSwift.determineBasal(
-                glucose: glucose,
-                currentTemp: currentTemp,
-                iob: iob,
-                profile: profile,
-                autosens: autosens,
-                meal: meal,
-                microBolusAllowed: microBolusAllowed,
-                reservoir: reservoir,
-                pumpHistory: pumpHistory,
-                preferences: preferences,
-                basalProfile: basalProfile,
-                trioCustomOrefVariables: trioCustomOrefVariables,
-                clock: clock
-            )
-            return try swiftResult.returnOrThrow()
-        } else {
+        if useJavascriptOref {
             let jsResult = await determineBasalJavascript(
                 glucose: glucose,
                 currentTemp: currentTemp,
@@ -954,6 +943,23 @@ final class OpenAPS {
                 clock: clock
             )
             return try jsResult.returnOrThrow()
+        } else {
+            let swiftResult = OpenAPSSwift.determineBasal(
+                glucose: glucose,
+                currentTemp: currentTemp,
+                iob: iob,
+                profile: profile,
+                autosens: autosens,
+                meal: meal,
+                microBolusAllowed: microBolusAllowed,
+                reservoir: reservoir,
+                pumpHistory: pumpHistory,
+                preferences: preferences,
+                basalProfile: basalProfile,
+                trioCustomOrefVariables: trioCustomOrefVariables,
+                clock: clock
+            )
+            return try swiftResult.returnOrThrow()
         }
     }
 
@@ -1073,24 +1079,10 @@ final class OpenAPS {
         model: JSON,
         autotune: JSON,
         trioSettings: JSON,
-        useSwiftOref: Bool,
+        useJavascriptOref: Bool,
         clock: Date
     ) async throws -> RawJSON {
-        if useSwiftOref {
-            let swiftResult = OpenAPSSwift.makeProfile(
-                preferences: preferences,
-                pumpSettings: pumpSettings,
-                bgTargets: bgTargets,
-                basalProfile: basalProfile,
-                isf: isf,
-                carbRatio: carbRatio,
-                tempTargets: tempTargets,
-                model: model,
-                trioSettings: trioSettings,
-                clock: clock
-            )
-            return try swiftResult.returnOrThrow()
-        } else {
+        if useJavascriptOref {
             let jsResult = await makeProfileJavascript(
                 preferences: preferences,
                 pumpSettings: pumpSettings,
@@ -1104,6 +1096,20 @@ final class OpenAPS {
                 trioSettings: trioSettings
             )
             return try jsResult.returnOrThrow()
+        } else {
+            let swiftResult = OpenAPSSwift.makeProfile(
+                preferences: preferences,
+                pumpSettings: pumpSettings,
+                bgTargets: bgTargets,
+                basalProfile: basalProfile,
+                isf: isf,
+                carbRatio: carbRatio,
+                tempTargets: tempTargets,
+                model: model,
+                trioSettings: trioSettings,
+                clock: clock
+            )
+            return try swiftResult.returnOrThrow()
         }
     }
 

--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -68,7 +68,7 @@ struct TrioSettings: JSON, Equatable, Encodable {
     var bolusShortcut: BolusShortcutLimit = .notAllowed
     var timeInRangeType: TimeInRangeType = .timeInTightRange
     var requireAdjustmentsConfirmation: Bool = false
-    var useSwiftOref: Bool = false
+    var useJavascriptOref: Bool = false
 
     /// Selected Garmin watchface (Trio or SwissAlpine)
     var garminWatchface: GarminWatchface = .trio
@@ -318,8 +318,8 @@ extension TrioSettings: Decodable {
             settings.requireAdjustmentsConfirmation = requireAdjustmentsConfirmation
         }
 
-        if let useSwiftOref = try? container.decode(Bool.self, forKey: .useSwiftOref) {
-            settings.useSwiftOref = useSwiftOref
+        if let useJavascriptOref = try? container.decode(Bool.self, forKey: .useJavascriptOref) {
+            settings.useJavascriptOref = useJavascriptOref
         }
 
         if let garminWatchface = try? container.decode(GarminWatchface.self, forKey: .garminWatchface) {

--- a/Trio/Sources/Modules/AlgorithmAdvancedSettings/AlgorithmAdvancedSettingsStateModel.swift
+++ b/Trio/Sources/Modules/AlgorithmAdvancedSettings/AlgorithmAdvancedSettingsStateModel.swift
@@ -22,7 +22,7 @@ extension AlgorithmAdvancedSettings {
         @Published var remainingCarbsFraction: Decimal = 1.0
         @Published var remainingCarbsCap: Decimal = 90
         @Published var noisyCGMTargetMultiplier: Decimal = 1.3
-        @Published var useSwiftOref: Bool = false
+        @Published var useJavascriptOref: Bool = false
         // preference
         @Published var insulinActionCurve: Decimal = 10
         @Published var smbDeliveryRatio: Decimal = 0.5
@@ -48,8 +48,8 @@ extension AlgorithmAdvancedSettings {
             subscribePreferencesSetting(\.remainingCarbsCap, on: $remainingCarbsCap) { remainingCarbsCap = $0 }
             subscribePreferencesSetting(\.noisyCGMTargetMultiplier, on: $noisyCGMTargetMultiplier) {
                 noisyCGMTargetMultiplier = $0 }
-            subscribeSetting(\.useSwiftOref, on: $useSwiftOref) {
-                useSwiftOref = $0 }
+            subscribeSetting(\.useJavascriptOref, on: $useJavascriptOref) {
+                useJavascriptOref = $0 }
             subscribePreferencesSetting(\.smbDeliveryRatio, on: $smbDeliveryRatio) { smbDeliveryRatio = $0 }
             subscribePreferencesSetting(\.smbInterval, on: $smbInterval) { smbInterval = $0 }
             subscribePreferencesSetting(\.smbDeliveryRatio, on: $smbDeliveryRatio) { smbDeliveryRatio = $0 }

--- a/Trio/Sources/Modules/AlgorithmAdvancedSettings/View/AlgorithmAdvancedSettingsRootView.swift
+++ b/Trio/Sources/Modules/AlgorithmAdvancedSettings/View/AlgorithmAdvancedSettingsRootView.swift
@@ -392,31 +392,30 @@ extension AlgorithmAdvancedSettings {
                 )
                 SettingInputSection(
                     decimalValue: $decimalPlaceholder,
-                    booleanValue: $state.useSwiftOref,
+                    booleanValue: $state.useJavascriptOref,
                     shouldDisplayHint: $shouldDisplayHint,
                     selectedVerboseHint: Binding(
                         get: { selectedVerboseHint },
                         set: {
                             selectedVerboseHint = $0.map { AnyView($0) }
-                            hintLabel = NSLocalizedString("Use Swift Oref", comment: "Use Swift Oref")
+                            hintLabel = NSLocalizedString("Use JavaScript Oref", comment: "Use JavaScript Oref")
                         }
                     ),
                     units: state.units,
                     type: .boolean,
-                    label: NSLocalizedString("Use Swift Oref", comment: "Use Swift Oref"),
+                    label: NSLocalizedString("Use JavaScript Oref", comment: "Use JavaScript Oref"),
                     miniHint: String(
-                        localized: "EXPERIMENTAL FEATURE! Enables new, fully Swift-based algorithm version.",
-                        comment: "Use Swift Oref mini hint"
+                        localized: "Switches back to the legacy JavaScript-based algorithm version.",
+                        comment: "Use JavaScript Oref mini hint"
                     ),
                     verboseHint:
                     VStack(alignment: .leading, spacing: 10) {
                         Text("Default: OFF").bold()
-                        Text("This feature is EXPERIMENTAL and not yet cleared for general use.").bold().foregroundStyle(.orange)
                         Text(
-                            "We're building a faster and more maintainable Swift version of the algorithm (Oref) that runs in Trio. It's faster, more accurate and improves Trio for everyone."
+                            "Trio now uses a fully Swift-based version of the algorithm (Oref) by default. It's faster, more accurate and improves Trio for everyone."
                         )
                         Text(
-                            "When enabled, Trio will no longer use the old JavaScript-based algorithm that runs virtualized on your phone. Instead, it will use a fully Swift-based algorithm."
+                            "When enabled, Trio will instead use the legacy JavaScript-based algorithm that runs virtualized on your phone. Only enable this if you encounter issues with the Swift-based algorithm."
                         )
 
                         Text(

--- a/Trio/Sources/Modules/Home/View/Header/LoopStatusView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/LoopStatusView.swift
@@ -289,7 +289,7 @@ struct LoopStatusView: View {
         }
 
         // FIXME: remove this before feat/dev-oref-swift is merged to dev
-        if state.settingsManager.settings.useSwiftOref {
+        if !state.settingsManager.settings.useJavascriptOref {
             tags.append("Swift Oref")
         }
 


### PR DESCRIPTION
This change updates the oref swift setting to be an oref javascript
setting instead, effectively defaulting all users into the Swift
implementation.

By defaulting people into the Swift implementation we will get a
chance to find any lingering issues with the implementation before
removing the Javascript code from the codebase. If there are any
issues, people can switch back to JS without needing to recompile.
