### PR TITLE
Update minimum carb ratio in oref-swift to 1

### DIFF
--- a/Trio/Sources/APS/OpenAPSSwift/Profile/Carbs.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/Profile/Carbs.swift
@@ -19,7 +19,7 @@ struct Carbs {
         }
 
         // Check for invalid values
-        if currentRatio < 3 || currentRatio > 150 {
+        if currentRatio < 1 || currentRatio > 150 {
             warning(.openAPS, "Warning: carbRatio of \(currentRatio) out of bounds.")
             return nil
         }

--- a/TrioTests/OpenAPSSwiftTests/ProfileCarbsTests.swift
+++ b/TrioTests/OpenAPSSwiftTests/ProfileCarbsTests.swift
@@ -35,11 +35,23 @@ import Testing
         #expect(ratio == 1) // 12 grams per exchange
     }
 
+    @Test("should allow ratios of 1") func allowLowRatios() async throws {
+        let schedule = CarbRatios(
+            units: .grams,
+            schedule: [
+                CarbRatioEntry(start: "00:00:00", offset: 0, ratio: 1)
+            ]
+        )
+        let now = Calendar.current.date(from: DateComponents(year: 2025, month: 1, day: 26, hour: 2))!
+        let ratio = Carbs.carbRatioLookup(carbRatio: schedule, now: now)
+        #expect(ratio == 1)
+    }
+
     @Test("should reject invalid ratios") func rejectInvalidRatios() async throws {
         let invalidSchedule = CarbRatios(
             units: .grams,
             schedule: [
-                CarbRatioEntry(start: "00:00:00", offset: 0, ratio: 2),
+                CarbRatioEntry(start: "00:00:00", offset: 0, ratio: 0.5),
                 CarbRatioEntry(start: "03:00:00", offset: 180, ratio: 15)
             ]
         )


### PR DESCRIPTION
The oref-swift implementation for Profile still used the old logic for
minimum carb ratios of 3, this commit updates that value to 1 to be
consistent with the JS implementation.

Added a unit test for this case and tested it in the simulator to confirm the same behavior and the fix after I implemented it.

Thanks to @MikePlante1 for finding the root cause and oddst for reporting it.

Fixes: https://github.com/nightscout/Trio/issues/1282 
