### PR TITLE
Fix Spurious Pump Alerts

### DIFF
--- a/Trio/Sources/Services/Alerts/TrioAlertManager.swift
+++ b/Trio/Sources/Services/Alerts/TrioAlertManager.swift
@@ -226,8 +226,18 @@ final class BaseTrioAlertManager: TrioAlertManager, Injectable {
         queue.async {
             self.liveAlerts.removeValue(forKey: identifier)
         }
-        let responder = queue.sync { responders[identifier.managerIdentifier]?.ref as? AlertResponder }
-        responder?.acknowledgeAlert(alertIdentifier: identifier.alertIdentifier) { error in
+        acknowledgeOnDevice(identifier: identifier)
+    }
+
+    /// Forwards the user's response to the issuing device manager — pump alerts
+    /// need this to also clear the alert on the device itself (e.g. pod beeps).
+    /// Only device managers register as responders (currently just the pump
+    /// manager), so Trio-internal alerts (glucose, not-looping, algorithm)
+    /// never match and bail out here.
+    private func acknowledgeOnDevice(identifier: Alert.Identifier) {
+        guard let responder = queue.sync(execute: { responders[identifier.managerIdentifier]?.ref as? AlertResponder })
+        else { return }
+        responder.acknowledgeAlert(alertIdentifier: identifier.alertIdentifier) { error in
             if let error = error {
                 debug(.service, "AlertManager ack failed for \(identifier.value): \(error)")
             }
@@ -364,6 +374,8 @@ final class BaseTrioAlertManager: TrioAlertManager, Injectable {
 
 extension BaseTrioAlertManager: TrioModalAlertResponder, TrioUserNotificationAlertResponder {
     func requestSnooze(identifier: Alert.Identifier, duration: TimeInterval) {
+        // Dismissal is the user's response — ack device-issued alerts at the PM layer too.
+        acknowledgeOnDevice(identifier: identifier)
         let untilDate = duration > 0 ? Date().addingTimeInterval(duration) : .distantPast
         if let glucoseType = GlucoseAlertType(slug: identifier.alertIdentifier) {
             broadcaster.notify(GlucoseSnoozeObserver.self, on: .main) { (observer: GlucoseSnoozeObserver) in


### PR DESCRIPTION
## Summary

The alerting rework routes pump-thrown alerts through the LoopKit protocol as intended. Tapping a notification calls acknowledgeAlert on the PM, no auto-ack anywhere. But it missed one spot: dismissing the in-app banner (and swiping away the UN) routed to snooze only, so the ack was never sent to the PM. With the app foregrounded, a pod alert could stay unacknowledged on the pod indefinitely unless the user also tapped the notification, leaving pods beeping on their repeat schedule (15 min expiration reminder, hourly low reservoir/expired) and alerts stuck as unacknowledged.

Dismissal is the user's response, so requestSnooze now also forwards the ack to the issuing device manager via acknowledgeOnDevice(), extracted from handleAcknowledgement. The forward is guarded on a registered AlertResponder – only device managers register (currently just the pump manager) – so Trio-internal alerts (glucose for Libre 3 and other CGms that require it, not-looping, algorithm) are unaffected, and PMs with no-op ack's (Medtrum, Dana, Minimed) see no behavior change.

User-facing behavior is unchanged: swipe/tap away still auto-snoozes for 15 min and dismisses both presentations, **but** pump alerts are now properly acknowledged at the PM layer (e.g. AcknowledgeAlerts reaches the pod and silences its beeps).

Fixes #1135.