### PR TITLE
[Part 2 of 6] Remove JSON marshalling for makeProfile

### DIFF
--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -625,17 +625,15 @@ final class OpenAPS {
         async let getCR = loadFileFromStorageAsync(name: Settings.carbRatios)
         async let getTempTargets = loadFileFromStorageAsync(name: Settings.tempTargets)
         async let getModel = loadFileFromStorageAsync(name: Settings.model)
-        async let getTrioSettingDefaults = loadFileFromStorageAsync(name: Trio.settings)
 
-        let (pumpSettings, bgTargets, basalProfile, isf, cr, tempTargets, model, trioSettings) = await (
+        let (pumpSettings, bgTargets, basalProfile, isf, cr, tempTargets, model) = await (
             getPumpSettings,
             getBGTargets,
             getBasalProfile,
             getISF,
             getCR,
             getTempTargets,
-            getModel,
-            getTrioSettingDefaults
+            getModel
         )
 
         // Retrieve user preferences, or set defaults if not available
@@ -680,31 +678,37 @@ final class OpenAPS {
 
         let clock = Date()
         do {
-            let pumpProfile = try makeProfile(
+            // Decode the raw settings into native models. The bundled-defaults
+            // fallback still happens in loadFileFromStorageAsync above, so decoding
+            // here preserves the same behavior it previously had inside makeProfile.
+            let pumpSettings = try JSONBridge.pumpSettings(from: pumpSettings)
+            let bgTargets = try JSONBridge.bgTargets(from: bgTargets)
+            let basalProfile = try JSONBridge.basalProfile(from: basalProfile)
+            let isf = try JSONBridge.insulinSensitivities(from: isf)
+            let carbRatio = try JSONBridge.carbRatios(from: cr)
+            let tempTargets = try JSONBridge.tempTargets(from: tempTargets)
+
+            let pumpProfile = try OpenAPSSwift.makeProfile(
                 preferences: adjustedPreferences,
                 pumpSettings: pumpSettings,
                 bgTargets: bgTargets,
                 basalProfile: basalProfile,
                 isf: isf,
-                carbRatio: cr,
+                carbRatio: carbRatio,
                 tempTargets: tempTargets,
                 model: model,
-                autotune: RawJSON.null,
-                trioSettings: trioSettings,
                 clock: clock
             )
 
-            let profile = try makeProfile(
+            let profile = try OpenAPSSwift.makeProfile(
                 preferences: adjustedPreferences,
                 pumpSettings: pumpSettings,
                 bgTargets: bgTargets,
                 basalProfile: basalProfile,
                 isf: isf,
-                carbRatio: cr,
+                carbRatio: carbRatio,
                 tempTargets: tempTargets,
                 model: model,
-                autotune: RawJSON.null,
-                trioSettings: trioSettings,
                 clock: clock
             )
 
@@ -806,34 +810,6 @@ final class OpenAPS {
             preferences: preferences,
             basalProfile: basalProfile,
             trioCustomOrefVariables: trioCustomOrefVariables,
-            clock: clock
-        )
-        return try swiftResult.returnOrThrow()
-    }
-
-    private func makeProfile(
-        preferences: JSON,
-        pumpSettings: JSON,
-        bgTargets: JSON,
-        basalProfile: JSON,
-        isf: JSON,
-        carbRatio: JSON,
-        tempTargets: JSON,
-        model: JSON,
-        autotune _: JSON,
-        trioSettings: JSON,
-        clock: Date
-    ) throws -> RawJSON {
-        let swiftResult = OpenAPSSwift.makeProfile(
-            preferences: preferences,
-            pumpSettings: pumpSettings,
-            bgTargets: bgTargets,
-            basalProfile: basalProfile,
-            isf: isf,
-            carbRatio: carbRatio,
-            tempTargets: tempTargets,
-            model: model,
-            trioSettings: trioSettings,
             clock: clock
         )
         return try swiftResult.returnOrThrow()

--- a/Trio/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/Trio/Sources/APS/OpenAPS/OpenAPS.swift
@@ -621,17 +621,17 @@ final class OpenAPS {
         async let getPumpSettings = loadFileFromStorageAsync(name: Settings.settings)
         async let getBGTargets = loadFileFromStorageAsync(name: Settings.bgTargets)
         async let getBasalProfile = loadFileFromStorageAsync(name: Settings.basalProfile)
-        async let getISF = loadFileFromStorageAsync(name: Settings.insulinSensitivities)
-        async let getCR = loadFileFromStorageAsync(name: Settings.carbRatios)
+        async let getInsulinSensitivities = loadFileFromStorageAsync(name: Settings.insulinSensitivities)
+        async let getCarbRatios = loadFileFromStorageAsync(name: Settings.carbRatios)
         async let getTempTargets = loadFileFromStorageAsync(name: Settings.tempTargets)
         async let getModel = loadFileFromStorageAsync(name: Settings.model)
 
-        let (pumpSettings, bgTargets, basalProfile, isf, cr, tempTargets, model) = await (
+        let (pumpSettings, bgTargets, basalProfile, insulinSensitivities, carbRatios, tempTargets, model) = await (
             getPumpSettings,
             getBGTargets,
             getBasalProfile,
-            getISF,
-            getCR,
+            getInsulinSensitivities,
+            getCarbRatios,
             getTempTargets,
             getModel
         )
@@ -684,8 +684,8 @@ final class OpenAPS {
             let pumpSettings = try JSONBridge.pumpSettings(from: pumpSettings)
             let bgTargets = try JSONBridge.bgTargets(from: bgTargets)
             let basalProfile = try JSONBridge.basalProfile(from: basalProfile)
-            let isf = try JSONBridge.insulinSensitivities(from: isf)
-            let carbRatio = try JSONBridge.carbRatios(from: cr)
+            let insulinSensitivities = try JSONBridge.insulinSensitivities(from: insulinSensitivities)
+            let carbRatios = try JSONBridge.carbRatios(from: carbRatios)
             let tempTargets = try JSONBridge.tempTargets(from: tempTargets)
 
             let pumpProfile = try OpenAPSSwift.makeProfile(
@@ -693,8 +693,8 @@ final class OpenAPS {
                 pumpSettings: pumpSettings,
                 bgTargets: bgTargets,
                 basalProfile: basalProfile,
-                isf: isf,
-                carbRatio: carbRatio,
+                insulinSensitivities: insulinSensitivities,
+                carbRatios: carbRatios,
                 tempTargets: tempTargets,
                 model: model,
                 clock: clock
@@ -705,8 +705,8 @@ final class OpenAPS {
                 pumpSettings: pumpSettings,
                 bgTargets: bgTargets,
                 basalProfile: basalProfile,
-                isf: isf,
-                carbRatio: carbRatio,
+                insulinSensitivities: insulinSensitivities,
+                carbRatios: carbRatios,
                 tempTargets: tempTargets,
                 model: model,
                 clock: clock

--- a/Trio/Sources/APS/OpenAPSSwift/JSONBridge.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/JSONBridge.swift
@@ -40,14 +40,6 @@ enum JSONBridge {
         try JSONBridge.from(string: from.rawJSON)
     }
 
-    static func model(from: JSON) -> String {
-        from.rawJSON
-    }
-
-    static func trioSettings(from: JSON) throws -> TrioSettings {
-        try JSONBridge.from(string: from.rawJSON)
-    }
-
     static func glucose(from: JSON) throws -> [BloodGlucose] {
         try JSONBridge.from(string: from.rawJSON)
     }

--- a/Trio/Sources/APS/OpenAPSSwift/Models/Profile.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/Models/Profile.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct Profile: Codable {
+struct Profile: JSON {
     // Kotlin-defined properties from AndroidAPS OapsProfile.kt
     // with defaults pulled from profile.js
     var dia: Decimal?

--- a/Trio/Sources/APS/OpenAPSSwift/OpenAPSSwift.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/OpenAPSSwift.swift
@@ -2,44 +2,27 @@ import Foundation
 
 struct OpenAPSSwift {
     static func makeProfile(
-        preferences: JSON,
-        pumpSettings: JSON,
-        bgTargets: JSON,
-        basalProfile: JSON,
-        isf: JSON,
-        carbRatio: JSON,
-        tempTargets: JSON,
-        model: JSON,
-        trioSettings: JSON,
+        preferences: Preferences,
+        pumpSettings: PumpSettings,
+        bgTargets: BGTargets,
+        basalProfile: [BasalProfileEntry],
+        isf: InsulinSensitivities,
+        carbRatio: CarbRatios,
+        tempTargets: [TempTarget],
+        model: String,
         clock: Date
-    ) -> (OrefFunctionResult) {
-        do {
-            let preferences = try JSONBridge.preferences(from: preferences)
-            let pumpSettings = try JSONBridge.pumpSettings(from: pumpSettings)
-            let bgTargets = try JSONBridge.bgTargets(from: bgTargets)
-            let basalProfile = try JSONBridge.basalProfile(from: basalProfile)
-            let isf = try JSONBridge.insulinSensitivities(from: isf)
-            let carbRatio = try JSONBridge.carbRatios(from: carbRatio)
-            let tempTargets = try JSONBridge.tempTargets(from: tempTargets)
-            let model = JSONBridge.model(from: model)
-            let trioSettings = try JSONBridge.trioSettings(from: trioSettings)
-
-            let profile = try ProfileGenerator.generate(
-                pumpSettings: pumpSettings,
-                bgTargets: bgTargets,
-                basalProfile: basalProfile,
-                isf: isf,
-                preferences: preferences,
-                carbRatios: carbRatio,
-                tempTargets: tempTargets,
-                model: model,
-                clock: clock
-            )
-
-            return (try .success(JSONBridge.to(profile)))
-        } catch {
-            return (.failure(error))
-        }
+    ) throws -> Profile {
+        try ProfileGenerator.generate(
+            pumpSettings: pumpSettings,
+            bgTargets: bgTargets,
+            basalProfile: basalProfile,
+            isf: isf,
+            preferences: preferences,
+            carbRatios: carbRatio,
+            tempTargets: tempTargets,
+            model: model,
+            clock: clock
+        )
     }
 
     static func determineBasal(

--- a/Trio/Sources/APS/OpenAPSSwift/OpenAPSSwift.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/OpenAPSSwift.swift
@@ -6,8 +6,8 @@ struct OpenAPSSwift {
         pumpSettings: PumpSettings,
         bgTargets: BGTargets,
         basalProfile: [BasalProfileEntry],
-        isf: InsulinSensitivities,
-        carbRatio: CarbRatios,
+        insulinSensitivities: InsulinSensitivities,
+        carbRatios: CarbRatios,
         tempTargets: [TempTarget],
         model: String,
         clock: Date
@@ -16,9 +16,9 @@ struct OpenAPSSwift {
             pumpSettings: pumpSettings,
             bgTargets: bgTargets,
             basalProfile: basalProfile,
-            isf: isf,
+            isf: insulinSensitivities,
             preferences: preferences,
-            carbRatios: carbRatio,
+            carbRatios: carbRatios,
             tempTargets: tempTargets,
             model: model,
             clock: clock


### PR DESCRIPTION
This commit removes the JSON marshalling for makeProfile. Note however that most of the data that makeProfile consumes is stored in JSON and its result is also stored in JSON, so this commit is largely about separation of responsibilities and making our algorithm functions use native types even though the JSON encoding / decoding is still happening.

We did get a minor win by removing double encoding / decoding for the Preferences struct and we will get big benefits later when we take on glucose / pump events carbs. But for now this change is mostly a refactor.
