### PR TITLE
Remove explicit allowsConstrainedNetworkAccess setting for Nightscout uploads

### DIFF
--- a/Trio/Sources/Services/Network/Nightscout/NightscoutAPI.swift
+++ b/Trio/Sources/Services/Network/Nightscout/NightscoutAPI.swift
@@ -85,7 +85,6 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
 
         if let secret = secret {
@@ -138,7 +137,6 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
 
         if let secret = secret {
@@ -171,7 +169,6 @@ extension NightscoutAPI {
         ]
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.httpMethod = "DELETE"
 
@@ -210,7 +207,6 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.httpMethod = "DELETE"
 
@@ -240,7 +236,6 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.httpMethod = "DELETE"
 
@@ -279,7 +274,6 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
 
         if let secret = secret {
@@ -313,7 +307,6 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: requestURL)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -350,7 +343,6 @@ extension NightscoutAPI {
         components.path = Config.uploadEntriesPath
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -386,7 +378,6 @@ extension NightscoutAPI {
         components.path = Config.statusPath
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -425,7 +416,6 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -491,7 +481,6 @@ extension NightscoutAPI {
         components.path = Config.treatmentsPath
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -532,7 +521,6 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
 
         if let secret = secret {

--- a/Trio/Sources/Services/Network/Nightscout/NightscoutAPI.swift
+++ b/Trio/Sources/Services/Network/Nightscout/NightscoutAPI.swift
@@ -85,7 +85,7 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
 
         if let secret = secret {
@@ -138,7 +138,7 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
 
         if let secret = secret {
@@ -171,7 +171,7 @@ extension NightscoutAPI {
         ]
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.httpMethod = "DELETE"
 
@@ -210,7 +210,7 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.httpMethod = "DELETE"
 
@@ -240,7 +240,7 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.httpMethod = "DELETE"
 
@@ -279,7 +279,7 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
 
         if let secret = secret {
@@ -313,7 +313,7 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: requestURL)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -350,7 +350,7 @@ extension NightscoutAPI {
         components.path = Config.uploadEntriesPath
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -386,7 +386,7 @@ extension NightscoutAPI {
         components.path = Config.statusPath
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -425,7 +425,7 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -491,7 +491,7 @@ extension NightscoutAPI {
         components.path = Config.treatmentsPath
 
         var request = URLRequest(url: components.url!)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
 
@@ -532,7 +532,7 @@ extension NightscoutAPI {
         }
 
         var request = URLRequest(url: url)
-        request.allowsConstrainedNetworkAccess = false
+        request.allowsConstrainedNetworkAccess = true
         request.timeoutInterval = Config.timeout
 
         if let secret = secret {


### PR DESCRIPTION
## Summary

This PR removes the explicit `allowsConstrainedNetworkAccess` setting from all Nightscout upload requests.

This restores the default `URLRequest` behavior and lets iOS decide how constrained network access should be handled according to the user's system settings.

## Background

While investigating intermittent Nightscout upload failures, repeated `Constrained path prohibited` errors were observed in the logs. This PR follows the review discussion and removes the explicit flag instead of overriding the system default.