### PR TITLE
Make bolus-in-progress card in Treatments view more reliable

### DIFF
--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -693,9 +693,9 @@ extension Treatments {
         }
 
         private var bolusInProgressForEntry: Bool {
+            // .initiating covers pumps that take a few seconds before reporting progress
             (state.bolusProgress != nil || state.bolusStatus == .initiating) &&
-                state.amount > 0 && !state.externalInsulin &&
-                (state.carbs == 0 || state.fat == 0 || state.protein == 0)
+                state.amount > 0 && !state.externalInsulin
         }
 
         private var disableTaskButton: Bool {

--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -492,8 +492,7 @@ extension Treatments {
         }
 
         var treatmentButton: some View {
-            let shouldDisplayBolusProgress = state.bolusStatus != .noBolus && state.amount > 0 &&
-                !state.externalInsulin && (state.carbs == 0 || state.fat == 0 || state.protein == 0)
+            let shouldDisplayBolusProgress = bolusInProgressForEntry
 
             var treatmentButtonBackground = Color(.systemBlue)
             if limitExceeded {
@@ -693,12 +692,14 @@ extension Treatments {
             pumpBolusLimitExceeded || externalBolusLimitExceeded || carbLimitExceeded || fatLimitExceeded || proteinLimitExceeded
         }
 
+        private var bolusInProgressForEntry: Bool {
+            (state.bolusProgress != nil || state.bolusStatus == .initiating) &&
+                state.amount > 0 && !state.externalInsulin &&
+                (state.carbs == 0 || state.fat == 0 || state.protein == 0)
+        }
+
         private var disableTaskButton: Bool {
-            (
-                state.bolusStatus != .noBolus && state
-                    .amount > 0 && !state.externalInsulin && (state.carbs == 0 || state.fat == 0 || state.protein == 0)
-            ) || state
-                .addButtonPressed || limitExceeded
+            bolusInProgressForEntry || state.addButtonPressed || limitExceeded
         }
     }
 


### PR DESCRIPTION
Some manual boluses left a bolusing card stuck at 0% in the Treatments view that blocked further boluses and could not be dismissed until the app was restarted (#1308).

The card was gated on bolusStatus, which mirrors the pump's reported bolusState and can stay at inProgress after delivery has finished. Since bolusTrigger now retains that value, the card resurfaced once a new amount was entered, and the X could not clear it because there was no active bolus to cancel.

Gate the card on bolusProgress instead, the local dose reporter signal that clears reliably and that the Home view already uses, keeping the initiating state so the pre-delivery view still shows.