### PR TITLE
[Part 2 of 7] Home Layout v2 – Rework Home layout: panels, TIR banner, meal row

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -866,6 +866,7 @@
 		DDE179702C910127003CDDB7 /* OverrideStored+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE179502C910127003CDDB7 /* OverrideStored+CoreDataClass.swift */; };
 		DDE179712C910127003CDDB7 /* OverrideStored+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDE179512C910127003CDDB7 /* OverrideStored+CoreDataProperties.swift */; };
 		DDEBB05C2D89E9050032305D /* TimeInRangeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDEBB05B2D89E9050032305D /* TimeInRangeType.swift */; };
+		7A11AC0DE000000000000020 /* HomeStatsPanelFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000120 /* HomeStatsPanelFace.swift */; };
 		DDF68FFC2D9ECF7F008BF16C /* OnboardingStateModel+Nightscout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF68FFB2D9ECF77008BF16C /* OnboardingStateModel+Nightscout.swift */; };
 		DDF6902C2DA028D3008BF16C /* DiagnosticsStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF6902B2DA028D3008BF16C /* DiagnosticsStepView.swift */; };
 		DDF6905C2DA0AFC5008BF16C /* WelcomeStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF6905B2DA0AFC5008BF16C /* WelcomeStepView.swift */; };
@@ -1886,6 +1887,7 @@
 		DDE179502C910127003CDDB7 /* OverrideStored+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OverrideStored+CoreDataClass.swift"; sourceTree = "<group>"; };
 		DDE179512C910127003CDDB7 /* OverrideStored+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OverrideStored+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		DDEBB05B2D89E9050032305D /* TimeInRangeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInRangeType.swift; sourceTree = "<group>"; };
+		7A11AC0DE000000000000120 /* HomeStatsPanelFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeStatsPanelFace.swift; sourceTree = "<group>"; };
 		DDF68FFB2D9ECF77008BF16C /* OnboardingStateModel+Nightscout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OnboardingStateModel+Nightscout.swift"; sourceTree = "<group>"; };
 		DDF6902B2DA028D3008BF16C /* DiagnosticsStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsStepView.swift; sourceTree = "<group>"; };
 		DDF6905B2DA0AFC5008BF16C /* WelcomeStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeStepView.swift; sourceTree = "<group>"; };
@@ -2787,6 +2789,7 @@
 				3871F39B25ED892B0013ECB5 /* TempTarget.swift */,
 				BD54A9722D281A9C00F9C1EE /* TempTargetPresetWatch.swift */,
 				DDEBB05B2D89E9050032305D /* TimeInRangeType.swift */,
+				7A11AC0DE000000000000120 /* HomeStatsPanelFace.swift */,
 				1935363F28496F7D001E0B16 /* TrioCustomOrefVariables.swift */,
 				38AEE73C25F0200C0013F05B /* TrioSettings.swift */,
 				3811DE8E25C9D80400A708ED /* User.swift */,
@@ -5461,6 +5464,7 @@
 				BD47FD172D88AAF50043966B /* CompletedStepView.swift in Sources */,
 				DD4AFFF12DADB59100AB7387 /* AlgorithmSettingsContentsStepView.swift in Sources */,
 				DDEBB05C2D89E9050032305D /* TimeInRangeType.swift in Sources */,
+				7A11AC0DE000000000000020 /* HomeStatsPanelFace.swift in Sources */,
 				DD5DC9F32CF3D9DD00AB8703 /* AdjustmentsStateModel+TempTargets.swift in Sources */,
 				BD47FDDB2D8B659B0043966B /* BasalProfileStepView.swift in Sources */,
 				F5F7E6C1B7F098F59EB67EC5 /* TargetsEditorDataFlow.swift in Sources */,

--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -67,6 +67,11 @@
 		3811DE3125C9D49500A708ED /* HomeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE2925C9D49500A708ED /* HomeProvider.swift */; };
 		3811DE3225C9D49500A708ED /* HomeDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE2A25C9D49500A708ED /* HomeDataFlow.swift */; };
 		3811DE3525C9D49500A708ED /* HomeRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE2E25C9D49500A708ED /* HomeRootView.swift */; };
+		7A11AC0DE000000000000111 /* HomeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000011 /* HomeLayout.swift */; };
+		7A11AC0DE000000000000110 /* HomeRootView+BottomControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000010 /* HomeRootView+BottomControls.swift */; };
+		7A11AC0DE00000000000010F /* HomeRootView+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE00000000000000F /* HomeRootView+Toolbar.swift */; };
+		7A11AC0DE00000000000010E /* HomeRootView+MealPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE00000000000000E /* HomeRootView+MealPanel.swift */; };
+		7A11AC0DE00000000000010D /* HomeRootView+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE00000000000000D /* HomeRootView+Header.swift */; };
 		3811DE3F25C9D4A100A708ED /* SettingsStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE3925C9D4A100A708ED /* SettingsStateModel.swift */; };
 		3811DE4125C9D4A100A708ED /* SettingsRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE3C25C9D4A100A708ED /* SettingsRootView.swift */; };
 		3811DE4225C9D4A100A708ED /* SettingsDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE3D25C9D4A100A708ED /* SettingsDataFlow.swift */; };
@@ -1084,6 +1089,11 @@
 		3811DE2925C9D49500A708ED /* HomeProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeProvider.swift; sourceTree = "<group>"; };
 		3811DE2A25C9D49500A708ED /* HomeDataFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeDataFlow.swift; sourceTree = "<group>"; };
 		3811DE2E25C9D49500A708ED /* HomeRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeRootView.swift; sourceTree = "<group>"; };
+		7A11AC0DE000000000000011 /* HomeLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLayout.swift; sourceTree = "<group>"; };
+		7A11AC0DE000000000000010 /* HomeRootView+BottomControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+BottomControls.swift"; sourceTree = "<group>"; };
+		7A11AC0DE00000000000000F /* HomeRootView+Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+Toolbar.swift"; sourceTree = "<group>"; };
+		7A11AC0DE00000000000000E /* HomeRootView+MealPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+MealPanel.swift"; sourceTree = "<group>"; };
+		7A11AC0DE00000000000000D /* HomeRootView+Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+Header.swift"; sourceTree = "<group>"; };
 		3811DE3925C9D4A100A708ED /* SettingsStateModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsStateModel.swift; sourceTree = "<group>"; };
 		3811DE3C25C9D4A100A708ED /* SettingsRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsRootView.swift; sourceTree = "<group>"; };
 		3811DE3D25C9D4A100A708ED /* SettingsDataFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsDataFlow.swift; sourceTree = "<group>"; };
@@ -2379,6 +2389,11 @@
 			isa = PBXGroup;
 			children = (
 				3811DE2E25C9D49500A708ED /* HomeRootView.swift */,
+				7A11AC0DE000000000000011 /* HomeLayout.swift */,
+				7A11AC0DE000000000000010 /* HomeRootView+BottomControls.swift */,
+				7A11AC0DE00000000000000F /* HomeRootView+Toolbar.swift */,
+				7A11AC0DE00000000000000E /* HomeRootView+MealPanel.swift */,
+				7A11AC0DE00000000000000D /* HomeRootView+Header.swift */,
 				3833B51E260264AC003021B3 /* Chart */,
 				3833B51F260264B6003021B3 /* Header */,
 				FDB1D1005DA54C048E622761 /* QuickPickBoluses */,
@@ -5154,6 +5169,11 @@
 				3B2A3BC12E2B19C600658FB9 /* DynamicISF.swift in Sources */,
 				CEE9A6592BBB418300EB5194 /* CalibrationsDataFlow.swift in Sources */,
 				3811DE3525C9D49500A708ED /* HomeRootView.swift in Sources */,
+				7A11AC0DE000000000000111 /* HomeLayout.swift in Sources */,
+				7A11AC0DE000000000000110 /* HomeRootView+BottomControls.swift in Sources */,
+				7A11AC0DE00000000000010F /* HomeRootView+Toolbar.swift in Sources */,
+				7A11AC0DE00000000000010E /* HomeRootView+MealPanel.swift in Sources */,
+				7A11AC0DE00000000000010D /* HomeRootView+Header.swift in Sources */,
 				584C79A91D034426A1DE60CB /* SlideToConfirmView.swift in Sources */,
 				DECF1903237041E2BBBE4033 /* QuickPickBolusesInfoView.swift in Sources */,
 				3F23E18680094E6DA98628E4 /* QuickPickBolusesView.swift in Sources */,

--- a/Trio/Sources/Models/HomeStatsPanelFace.swift
+++ b/Trio/Sources/Models/HomeStatsPanelFace.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum HomeStatsPanelFace: String, JSON, CaseIterable, Identifiable, Codable, Hashable {
+    var id: String { rawValue }
+    case timeInRange
+    case distributionBar
+    case averages
+
+    var displayName: String {
+        switch self {
+        case .timeInRange:
+            return String(localized: "Time in Range", comment: "Home stats panel face option")
+        case .distributionBar:
+            return String(localized: "Distribution Bar Only", comment: "Home stats panel face option")
+        case .averages:
+            return String(localized: "Today's Averages", comment: "Home stats panel face option")
+        }
+    }
+}

--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -69,6 +69,7 @@ struct TrioSettings: JSON, Equatable, Encodable {
     var displayGlucoseForecasts: Bool = false
     var bolusShortcut: BolusShortcutLimit = .notAllowed
     var timeInRangeType: TimeInRangeType = .timeInTightRange
+    var homeStatsPanelFace: HomeStatsPanelFace = .timeInRange
     var requireAdjustmentsConfirmation: Bool = false
 
     /// Selected Garmin watchface (Trio or SwissAlpine)
@@ -321,6 +322,10 @@ extension TrioSettings: Decodable {
 
         if let timeInRangeType = try? container.decode(TimeInRangeType.self, forKey: .timeInRangeType) {
             settings.timeInRangeType = timeInRangeType
+        }
+
+        if let homeStatsPanelFace = try? container.decode(HomeStatsPanelFace.self, forKey: .homeStatsPanelFace) {
+            settings.homeStatsPanelFace = homeStatsPanelFace
         }
 
         if let requireAdjustmentsConfirmation = try? container.decode(Bool.self, forKey: .requireAdjustmentsConfirmation) {

--- a/Trio/Sources/Modules/Home/HomeStateModel+Setup/ChartAxisSetup.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel+Setup/ChartAxisSetup.swift
@@ -34,7 +34,9 @@ extension Home.StateModel {
             maxYValue = 400
         }
 
-        minYAxisValue = minOverall
+        // keep the low threshold (and target) inside the domain: RuleMarks
+        // below the floor would clamp onto the plot edge
+        minYAxisValue = min(minOverall, lowGlucose - 20)
         maxYAxisValue = maxYValue
     }
 

--- a/Trio/Sources/Modules/Home/HomeStateModel+Setup/GlucoseSetup.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel+Setup/GlucoseSetup.swift
@@ -31,3 +31,21 @@ extension Home.StateModel {
         }
     }
 }
+
+extension Home.StateModel {
+    /// Today's glucose range distribution for the stats banner.
+    var todayGlucoseDistribution: GlucoseDailyDistributionStats {
+        let startOfDay = Calendar.current.startOfDay(for: Date())
+        let readings = glucoseFromPersistence
+            .filter { ($0.date ?? .distantPast) >= startOfDay }
+            .map { GlucoseReading(value: Int($0.glucose), date: $0.date ?? startOfDay) }
+        // first render happens before service injection
+        let timeInRangeType = settingsManager?.settings.timeInRangeType ?? .timeInTightRange
+        return GlucoseDailyDistributionStats.compute(
+            date: startOfDay,
+            readings: readings,
+            highLimit: highGlucose,
+            timeInRangeType: timeInRangeType
+        )
+    }
+}

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
@@ -32,7 +32,7 @@ extension MainChartView {
             .onChange(of: state.maxBasal) {
                 calculateBasals()
             }
-            .frame(minHeight: geo.size.height * 0.05)
+            .frame(minHeight: basalHeight)
             .frame(width: fullWidth(viewWidth: screenSize.width))
             .chartXScale(domain: state.startMarker ... state.endMarker)
             .chartXAxis { basalChartXAxis }

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
@@ -32,6 +32,10 @@ extension MainChartView {
             .onChange(of: state.maxBasal) {
                 calculateBasals()
             }
+            // profile loads async after first appearance; redraw the dashed line
+            .onChange(of: state.basalProfile) {
+                calculateBasals()
+            }
             .frame(minHeight: basalHeight)
             .frame(width: fullWidth(viewWidth: screenSize.width))
             .chartXScale(domain: state.startMarker ... state.endMarker)

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/CobIobChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/CobIobChart.swift
@@ -44,7 +44,7 @@ extension MainChartView {
             "IOB": Color.darkerBlue
         ])
         .chartLegend(.hidden)
-        .frame(minHeight: geo.size.height * 0.12)
+        .frame(minHeight: cobIobHeight)
         .frame(width: fullWidth(viewWidth: screenSize.width))
         .chartXScale(domain: state.startMarker ... state.endMarker)
         .chartXSelection(value: $selection)

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/DummyCharts.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/DummyCharts.swift
@@ -5,58 +5,27 @@ import SwiftUI
 extension MainChartView {
     /// empty chart that just shows the Y axis and Y grid lines. Created separately from `mainChart` to allow main chart to scroll horizontally while having a fixed Y axis
     var staticYAxisChart: some View {
-        Chart {
-            /// high and low threshold lines
-
-            // TODO: workaround for now: set low value to 55, to have dynamic color shades between 55 and user-set low (approx. 70); same for high glucose
-            let hardCodedLow = Decimal(55)
-            let hardCodedHigh = Decimal(220)
-            let isDynamicColorScheme = glucoseColorScheme == .dynamicColor
-
-            if thresholdLines {
-                let highColor = Trio.getDynamicGlucoseColor(
-                    glucoseValue: highGlucose,
-                    highGlucoseColorValue: isDynamicColorScheme ? hardCodedHigh : highGlucose,
-                    lowGlucoseColorValue: isDynamicColorScheme ? hardCodedLow : lowGlucose,
-                    targetGlucose: currentGlucoseTarget,
-                    glucoseColorScheme: glucoseColorScheme
-                )
-                let lowColor = Trio.getDynamicGlucoseColor(
-                    glucoseValue: lowGlucose,
-                    highGlucoseColorValue: isDynamicColorScheme ? hardCodedHigh : highGlucose,
-                    lowGlucoseColorValue: isDynamicColorScheme ? hardCodedLow : lowGlucose,
-                    targetGlucose: currentGlucoseTarget,
-                    glucoseColorScheme: glucoseColorScheme
-                )
-
-                RuleMark(y: .value("High", units == .mgdL ? highGlucose : highGlucose.asMmolL))
-                    .foregroundStyle(highColor)
-                    .lineStyle(.init(lineWidth: 1, dash: [5]))
-                RuleMark(y: .value("Low", units == .mgdL ? lowGlucose : lowGlucose.asMmolL))
-                    .foregroundStyle(lowColor)
-                    .lineStyle(.init(lineWidth: 1, dash: [5]))
-            }
-        }
-        .id("DummyMainChart")
-        .frame(
-            minHeight: geo.size.height * (0.28 - safeAreaSize)
-        )
-        .frame(width: screenSize.width - 10)
-        .chartXAxis { mainChartXAxis }
-        .chartXScale(domain: state.startMarker ... state.endMarker)
-        .chartXAxis(.hidden)
-        .chartYAxis { mainChartYAxis }
-        .chartYScale(
-            domain: units == .mgdL ? state.minYAxisValue ... state.maxYAxisValue : state.minYAxisValue.asMmolL ... state
-                .maxYAxisValue.asMmolL
-        )
-        .chartLegend(.hidden)
+        Chart {}
+            .id("DummyMainChart")
+            .frame(
+                minHeight: mainHeight
+            )
+            .frame(width: screenSize.width - 10)
+            .chartXAxis { mainChartXAxis }
+            .chartXScale(domain: state.startMarker ... state.endMarker)
+            .chartXAxis(.hidden)
+            .chartYAxis { mainChartYAxis }
+            .chartYScale(
+                domain: units == .mgdL ? state.minYAxisValue ... state.maxYAxisValue : state.minYAxisValue.asMmolL ... state
+                    .maxYAxisValue.asMmolL
+            )
+            .chartLegend(.hidden)
     }
 
     var dummyBasalChart: some View {
         Chart {}
             .id("DummyBasalChart")
-            .frame(minHeight: geo.size.height * 0.05)
+            .frame(minHeight: basalHeight)
             .frame(width: screenSize.width - 10)
             .chartXAxis { basalChartXAxis }
             .chartXAxis(.hidden)
@@ -67,7 +36,7 @@ extension MainChartView {
     var dummyCobChart: some View {
         Chart {}
             .id("DummyCobChart")
-            .frame(minHeight: geo.size.height * 0.12)
+            .frame(minHeight: cobIobHeight)
             .frame(width: screenSize.width - 10)
             .chartXScale(domain: state.startMarker ... state.endMarker)
             .chartXAxis { basalChartXAxis }

--- a/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -7,7 +7,8 @@ let calendar = Calendar.current
 
 struct MainChartView: View {
     var geo: GeometryProxy
-    var safeAreaSize: CGFloat
+    /// height allocated by the Home layout: the remainder after the fixed zones
+    var chartHeight: CGFloat
     var units: GlucoseUnits
     var hours: Int
     var highGlucose: Decimal
@@ -35,6 +36,45 @@ struct MainChartView: View {
 
     var upperLimit: Decimal {
         units == .mgdL ? 400 : 22.2
+    }
+
+    // pane splits of the chart's allocation (old 0.05/0.28/0.12 screen-fraction
+    // proportions); sums to 0.94 so pane spacing and axis labels fit the budget
+    var basalHeight: CGFloat { chartHeight * 0.10 }
+    var mainHeight: CGFloat { chartHeight * 0.60 }
+    var cobIobHeight: CGFloat { chartHeight * 0.24 }
+
+    /// drawn in the scrolling chart (not the static y-axis dummy) so the rules
+    /// share the exact plot geometry of the glucose marks
+    @ChartContentBuilder private var thresholdRuleMarks: some ChartContent {
+        // dynamic color shade anchors: 55 low / 220 high
+        let hardCodedLow = Decimal(55)
+        let hardCodedHigh = Decimal(220)
+        let isDynamicColorScheme = glucoseColorScheme == .dynamicColor
+
+        if thresholdLines {
+            let highColor = Trio.getDynamicGlucoseColor(
+                glucoseValue: highGlucose,
+                highGlucoseColorValue: isDynamicColorScheme ? hardCodedHigh : highGlucose,
+                lowGlucoseColorValue: isDynamicColorScheme ? hardCodedLow : lowGlucose,
+                targetGlucose: currentGlucoseTarget,
+                glucoseColorScheme: glucoseColorScheme
+            )
+            let lowColor = Trio.getDynamicGlucoseColor(
+                glucoseValue: lowGlucose,
+                highGlucoseColorValue: isDynamicColorScheme ? hardCodedHigh : highGlucose,
+                lowGlucoseColorValue: isDynamicColorScheme ? hardCodedLow : lowGlucose,
+                targetGlucose: currentGlucoseTarget,
+                glucoseColorScheme: glucoseColorScheme
+            )
+
+            RuleMark(y: .value("High", units == .mgdL ? highGlucose : highGlucose.asMmolL))
+                .foregroundStyle(highColor)
+                .lineStyle(.init(lineWidth: 1, dash: [5]))
+            RuleMark(y: .value("Low", units == .mgdL ? lowGlucose : lowGlucose.asMmolL))
+                .foregroundStyle(lowColor)
+                .lineStyle(.init(lineWidth: 1, dash: [5]))
+        }
     }
 
     private var selectedGlucose: GlucoseStored? {
@@ -116,6 +156,7 @@ extension MainChartView {
                 drawStartRuleMark()
                 drawEndRuleMark()
                 drawCurrentTimeMarker()
+                thresholdRuleMarks
 
                 GlucoseTargetsView(
                     targetProfiles: state.targetProfiles
@@ -189,7 +230,7 @@ extension MainChartView {
             }
             .id("MainChart")
             .frame(
-                minHeight: geo.size.height * (0.28 - safeAreaSize)
+                minHeight: mainHeight
             )
             .frame(width: fullWidth(viewWidth: screenSize.width))
             .chartXScale(domain: state.startMarker ... state.endMarker)

--- a/Trio/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
@@ -92,6 +92,12 @@ struct CurrentGlucoseView: View {
 
     @ViewBuilder private func bobbleAndTag(triangleColor: Color) -> some View {
         ZStack {
+            Circle()
+                .fill(triangleColor)
+                .frame(width: 124, height: 124)
+                .blur(radius: 24)
+                .opacity(colorScheme == .dark ? 0.32 : 0.20)
+
             if let progress = cgmProgress, shouldShowArc {
                 SensorLifecycleArcView(
                     progress: progress.percentComplete,

--- a/Trio/Sources/Modules/Home/View/HomeLayout.swift
+++ b/Trio/Sources/Modules/Home/View/HomeLayout.swift
@@ -4,7 +4,7 @@ import CoreGraphics
 enum HomeLayout {
     /// header slot: pump panel / glucose bobble / loop status; includes room
     /// for the sensor arc/tag overhanging the bobble
-    static let headerHeight: CGFloat = 166
+    static let headerHeight: CGFloat = 172
     /// meal panel slot (IOB / COB / delivery rate)
     static let mealSlotHeight: CGFloat = 44
     /// shared slot for adjustment panel and bolus progress (was 8% of screen height)

--- a/Trio/Sources/Modules/Home/View/HomeLayout.swift
+++ b/Trio/Sources/Modules/Home/View/HomeLayout.swift
@@ -1,0 +1,19 @@
+import CoreGraphics
+
+/// Fixed zone heights for the non-scrolling Home dashboard; the chart takes the remainder.
+enum HomeLayout {
+    /// header slot: pump panel / glucose bobble / loop status; includes room
+    /// for the sensor arc/tag overhanging the bobble
+    static let headerHeight: CGFloat = 166
+    /// meal panel slot (IOB / COB / delivery rate)
+    static let mealSlotHeight: CGFloat = 44
+    /// shared slot for adjustment panel and bolus progress (was 8% of screen height)
+    static let bottomPanelHeight: CGFloat = 60
+    /// clear air above (chart x-axis labels) and below (tab bar) the bottom panel
+    static let bottomZonePadding: CGFloat = 10
+    static var bottomZoneHeight: CGFloat { bottomPanelHeight + 2 * bottomZonePadding }
+    /// interim slot for the time-interval buttons; removed with the layout rework
+    static let timeButtonsRowHeight: CGFloat = 44
+    /// minimum usable chart height (basal + glucose + COB/IOB panes)
+    static let chartMinHeight: CGFloat = 260
+}

--- a/Trio/Sources/Modules/Home/View/HomeLayout.swift
+++ b/Trio/Sources/Modules/Home/View/HomeLayout.swift
@@ -9,11 +9,12 @@ enum HomeLayout {
     static let mealSlotHeight: CGFloat = 44
     /// shared slot for adjustment panel and bolus progress (was 8% of screen height)
     static let bottomPanelHeight: CGFloat = 60
-    /// clear air above (chart x-axis labels) and below (tab bar) the bottom panel
+    /// stats banner slot below the adjustment panel (multi-use panel later)
+    static let statsBannerHeight: CGFloat = 60
+    /// clear air above, between, and below the bottom-zone panels
     static let bottomZonePadding: CGFloat = 10
-    static var bottomZoneHeight: CGFloat { bottomPanelHeight + 2 * bottomZonePadding }
-    /// interim slot for the time-interval buttons; removed with the layout rework
-    static let timeButtonsRowHeight: CGFloat = 44
-    /// minimum usable chart height (basal + glucose + COB/IOB panes)
-    static let chartMinHeight: CGFloat = 260
+    static var bottomZoneHeight: CGFloat { bottomPanelHeight + statsBannerHeight + 3 * bottomZonePadding }
+    /// minimum usable chart height; must stay below the natural SE allocation
+    /// (598 − header − meal slot − bottom zone = 238) or the bottom zone overflows
+    static let chartMinHeight: CGFloat = 220
 }

--- a/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
@@ -207,9 +207,6 @@ extension Home.RootView {
                     .foregroundStyle(.secondary)
             }
         }
-        .onTapGesture {
-            selectedTab = 2
-        }
     }
 
     @ViewBuilder func adjustmentsTempTargetView(_ tempTargetString: String) -> some View {
@@ -222,9 +219,6 @@ extension Home.RootView {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-        }
-        .onTapGesture {
-            selectedTab = 2
         }
     }
 
@@ -305,8 +299,6 @@ extension Home.RootView {
             Image(systemName: "xmark.app")
                 .font(.title)
                 .foregroundStyle(Color.clear)
-        }.onTapGesture {
-            selectedTab = 2
         }
     }
 
@@ -359,16 +351,19 @@ extension Home.RootView {
                 )
                 .frame(height: HomeLayout.bottomPanelHeight)
                 .overlay(alignment: .bottom) {
-                    if isConcurrent {
-                        HStack(spacing: 6) {
-                            remainingBar(overrideRemainingFraction, tint: .purple)
-                            remainingBar(tempTargetRemainingFraction, tint: .loopGreen)
+                    // inset clears the corner curve so the bar stays inside the shape
+                    Group {
+                        if isConcurrent {
+                            HStack(spacing: 6) {
+                                remainingBar(overrideRemainingFraction, tint: .purple)
+                                remainingBar(tempTargetRemainingFraction, tint: .loopGreen)
+                            }
+                        } else if let tint = tint {
+                            remainingBar(overrideRemainingFraction ?? tempTargetRemainingFraction, tint: tint)
                         }
-                        .padding(.horizontal, 4)
-                    } else if let tint = tint {
-                        remainingBar(overrideRemainingFraction ?? tempTargetRemainingFraction, tint: tint)
-                            .padding(.horizontal, 4)
                     }
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 3)
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
                 .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.25 : 0.10), radius: 3, y: 1)
@@ -440,7 +435,13 @@ extension Home.RootView {
                 } message: {
                     Text("Select Adjustment")
                 }
-        }.padding(.horizontal, 10)
+        }
+        // whole panel navigates; the cancel buttons' own gestures take precedence
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selectedTab = 2
+        }
+        .padding(.horizontal, 10)
     }
 
     @ViewBuilder func bolusView(_ progress: Decimal) -> some View {
@@ -531,7 +532,37 @@ extension Home.RootView {
         }
     }
 
+    /// Mean glucose (mg/dL) of today's readings, nil without data.
+    private var todayMeanGlucose: Double? {
+        let startOfDay = Calendar.current.startOfDay(for: Date())
+        let values = state.glucoseFromPersistence
+            .filter { ($0.date ?? .distantPast) >= startOfDay }
+            .map { Double($0.glucose) }
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
+    private var todayAverageString: String {
+        guard let mean = todayMeanGlucose else { return "--" }
+        if state.units == .mmolL {
+            return Decimal(mean).asMmolL.formatted(.number.precision(.fractionLength(1))) + " " + GlucoseUnits.mmolL.rawValue
+        }
+        return "\(Int(mean.rounded())) " + GlucoseUnits.mgdL.rawValue
+    }
+
+    private var todayGMIString: String {
+        guard let mean = todayMeanGlucose else { return "--" }
+        let gmiPercentage = 3.31 + 0.02392 * mean
+        // settingsManager is injected after first render; default until then
+        if state.settingsManager?.settings.eA1cDisplayUnit == .mmolMol {
+            let gmiMmolMol = (gmiPercentage - 2.152) * 10.929
+            return "\(Int(gmiMmolMol.rounded())) mmol/mol"
+        }
+        return gmiPercentage.formatted(.number.precision(.fractionLength(1))) + " %"
+    }
+
     @ViewBuilder func statsBanner() -> some View {
+        let face = state.settingsManager?.settings.homeStatsPanelFace ?? .timeInRange
         let distribution = state.todayGlucoseDistribution
         let coveragePct = distribution.veryLowPct + distribution.lowPct + distribution.inRangePct + distribution
             .highPct + distribution.veryHighPct
@@ -565,18 +596,39 @@ extension Home.RootView {
                     .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.25 : 0.10), radius: 3, y: 1)
 
                 HStack(alignment: .center, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack(alignment: .firstTextBaseline, spacing: 6) {
-                            Text(tirString)
-                                .font(.title2).fontWeight(.bold).fontDesign(.rounded)
-                                .foregroundStyle(.primary)
+                    switch face {
+                    case .timeInRange:
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                                Text(tirString)
+                                    .font(.title2).fontWeight(.bold).fontDesign(.rounded)
+                                    .foregroundStyle(.primary)
+                                Text("Time in Range", comment: "Stats banner subtitle")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            statsDistributionBar(segments)
+                                .frame(height: 6)
+                        }
+                    case .distributionBar:
+                        VStack(alignment: .leading, spacing: 6) {
                             Text("Time in Range", comment: "Stats banner subtitle")
-                                .font(.subheadline)
+                                .font(.subheadline).fontWeight(.semibold)
+                                .foregroundStyle(.secondary)
+
+                            statsDistributionBar(segments)
+                                .frame(height: 6)
+                        }
+                    case .averages:
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text("\u{2300} \(todayAverageString) \u{00B7} GMI \(todayGMIString)")
+                                .font(.subheadline).fontWeight(.semibold)
+                                .foregroundStyle(.primary)
+                            Text("Today's average", comment: "Stats banner subtitle")
+                                .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
-
-                        statsDistributionBar(segments)
-                            .frame(height: 6)
                     }
 
                     Spacer(minLength: 8)
@@ -588,6 +640,7 @@ extension Home.RootView {
                 .padding(.horizontal, 16)
             }
             .padding(.horizontal, 10)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
@@ -31,6 +31,40 @@ extension Home.RootView {
         return formatter
     }
 
+    func remainingFraction(start: Date?, durationMinutes: Decimal?, indefinite: Bool) -> Double? {
+        guard !indefinite, let start = start, let durationMinutes = durationMinutes, durationMinutes > 0 else {
+            return nil
+        }
+        let total = Double(truncating: durationMinutes as NSNumber) * 60
+        let elapsed = Date().timeIntervalSince(start)
+        guard total > 0 else { return nil }
+        return min(max(1 - elapsed / total, 0), 1)
+    }
+
+    var overrideRemainingFraction: Double? {
+        guard let o = latestOverride.first else { return nil }
+        return remainingFraction(start: o.date, durationMinutes: o.duration as Decimal?, indefinite: o.indefinite)
+    }
+
+    var tempTargetRemainingFraction: Double? {
+        guard let t = latestTempTarget.first else { return nil }
+        return remainingFraction(start: t.date, durationMinutes: t.duration as Decimal?, indefinite: false)
+    }
+
+    @ViewBuilder func adjustmentIcon(_ systemName: String, tint: Color) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(tint)
+            .frame(width: 30, height: 30)
+            .background(Circle().fill(tint.opacity(0.18)))
+    }
+
+    var adjustmentTint: Color? {
+        if overrideString != nil { return Color.purple }
+        if tempTargetString != nil { return Color.loopGreen }
+        return nil
+    }
+
     var overrideString: String? {
         guard let latestOverride = latestOverride.first else {
             return nil
@@ -162,16 +196,15 @@ extension Home.RootView {
 
     @ViewBuilder func adjustmentsOverrideView(_ overrideString: String) -> some View {
         Group {
-            Image(systemName: "clock.arrow.2.circlepath")
-                .font(.title2)
-                .foregroundStyle(Color.primary, Color.purple)
-            VStack(alignment: .leading) {
+            adjustmentIcon("clock.arrow.2.circlepath", tint: Color.purple)
+            VStack(alignment: .leading, spacing: 1) {
                 Text(latestOverride.first?.name ?? String(localized: "Custom Override"))
-                    .font(.subheadline)
+                    .font(.subheadline).fontWeight(.semibold)
                     .frame(alignment: .leading)
 
                 Text(overrideString)
                     .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .onTapGesture {
@@ -181,14 +214,13 @@ extension Home.RootView {
 
     @ViewBuilder func adjustmentsTempTargetView(_ tempTargetString: String) -> some View {
         Group {
-            Image(systemName: "target")
-                .font(.title2)
-                .foregroundStyle(Color.loopGreen)
-            VStack(alignment: .leading) {
+            adjustmentIcon("target", tint: Color.loopGreen)
+            VStack(alignment: .leading, spacing: 1) {
                 Text(latestTempTarget.first?.name ?? String(localized: "Temp Target"))
-                    .font(.subheadline)
+                    .font(.subheadline).fontWeight(.semibold)
                 Text(tempTargetString)
                     .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .onTapGesture {
@@ -254,76 +286,119 @@ extension Home.RootView {
 
     @ViewBuilder func noActiveAdjustmentsView() -> some View {
         Group {
-            VStack {
+            adjustmentIcon("slider.horizontal.2.gobackward", tint: Color.secondary)
+
+            VStack(alignment: .leading, spacing: 1) {
                 Text("No Active Adjustment")
-                    .font(.subheadline)
+                    .font(.subheadline).fontWeight(.medium)
+                    .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Text("Profile at 100 %")
                     .font(.caption)
+                    .foregroundStyle(.tertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)
-            }.padding(.leading, 10)
+            }
 
             Spacer()
 
-            /// to ensure the same position....
+            // clear icon keeps text aligned with the cancel-button states
             Image(systemName: "xmark.app")
                 .font(.title)
-                // clear color for the icon
                 .foregroundStyle(Color.clear)
         }.onTapGesture {
             selectedTab = 2
         }
     }
 
+    @ViewBuilder func remainingBar(_ fraction: Double?, tint: Color) -> some View {
+        GeometryReader { barGeo in
+            if let fraction {
+                Capsule()
+                    .fill(tint.opacity(0.85))
+                    .frame(width: barGeo.size.width * fraction, height: 3)
+                    .frame(maxHeight: .infinity, alignment: .bottom)
+            }
+        }
+        .frame(height: 3)
+    }
+
     @ViewBuilder func adjustmentView() -> some View {
-//            let background = colorScheme == .dark ? Material.ultraThinMaterial.opacity(0.5) : Color.black.opacity(0.2)
+        let tint = adjustmentTint
+        // concurrent override + temp target: halved tint, one remaining bar per half
+        let isConcurrent = overrideString != nil && tempTargetString != nil
 
         ZStack {
-            /// rectangle as background
-            RoundedRectangle(cornerRadius: 15)
-                .fill(
-                    (overrideString != nil || tempTargetString != nil) ?
-                        (
-                            colorScheme == .dark ?
-                                Color(red: 0.03921568627, green: 0.133333333, blue: 0.2156862745) :
-                                Color.insulin.opacity(0.1)
-                        ) : Color.clear // Use clear and add the Material in the background
+            RoundedRectangle(cornerRadius: 17, style: .continuous)
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    Group {
+                        if isConcurrent {
+                            HStack(spacing: 0) {
+                                Color.purple.opacity(0.12)
+                                Color.loopGreen.opacity(0.12)
+                            }
+                            .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
+                        } else {
+                            RoundedRectangle(cornerRadius: 17, style: .continuous)
+                                .fill((tint ?? Color.clear).opacity(0.12))
+                        }
+                    }
                 )
-                .background(colorScheme == .dark ? Color.chart.opacity(0.25) : Color.black.opacity(0.075))
-                .clipShape(RoundedRectangle(cornerRadius: 15))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 17, style: .continuous)
+                        .strokeBorder(
+                            isConcurrent
+                                ? AnyShapeStyle(LinearGradient(
+                                    colors: [Color.purple.opacity(0.30), Color.loopGreen.opacity(0.30)],
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                ))
+                                : AnyShapeStyle((tint ?? Color.primary).opacity(tint == nil ? 0.08 : 0.30)),
+                            lineWidth: 1
+                        )
+                )
                 .frame(height: HomeLayout.bottomPanelHeight)
-                .shadow(
-                    color: (overrideString != nil || tempTargetString != nil) ?
-                        (
-                            colorScheme == .dark ? Color(red: 0.02745098039, green: 0.1098039216, blue: 0.1411764706) :
-                                Color.black.opacity(0.33)
-                        ) : Color.clear,
-                    radius: 3
-                )
+                .overlay(alignment: .bottom) {
+                    if isConcurrent {
+                        HStack(spacing: 6) {
+                            remainingBar(overrideRemainingFraction, tint: .purple)
+                            remainingBar(tempTargetRemainingFraction, tint: .loopGreen)
+                        }
+                        .padding(.horizontal, 4)
+                    } else if let tint = tint {
+                        remainingBar(overrideRemainingFraction ?? tempTargetRemainingFraction, tint: tint)
+                            .padding(.horizontal, 4)
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
+                .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.25 : 0.10), radius: 3, y: 1)
             HStack {
                 if let overrideString = overrideString, let tempTargetString = tempTargetString {
-                    HStack {
-                        adjustmentsOverrideView(overrideString)
+                    // content halves match the tint halves so icons clear the seam
+                    HStack(spacing: 0) {
+                        HStack {
+                            adjustmentsOverrideView(overrideString)
+                            Spacer(minLength: 0)
+                        }
+                        .frame(maxWidth: .infinity)
 
-                        Spacer()
+                        HStack {
+                            adjustmentsTempTargetView(tempTargetString)
+                                .padding(.leading, 8)
 
-                        Divider()
-                            .frame(height: HomeLayout.bottomPanelHeight - 24)
-                            .padding(.horizontal, 2)
+                            Spacer(minLength: 0)
 
-                        adjustmentsTempTargetView(tempTargetString)
-
-                        Spacer()
-
-                        adjustmentsCancelView({
-                            if !latestTempTarget.isEmpty, !latestOverride.isEmpty {
-                                showCancelConfirmDialog = true
-                            } else if !latestOverride.isEmpty {
-                                showCancelAlert = true
-                            } else if !latestTempTarget.isEmpty {
-                                showCancelAlert = true
-                            }
-                        })
+                            adjustmentsCancelView({
+                                if !latestTempTarget.isEmpty, !latestOverride.isEmpty {
+                                    showCancelConfirmDialog = true
+                                } else if !latestOverride.isEmpty {
+                                    showCancelAlert = true
+                                } else if !latestTempTarget.isEmpty {
+                                    showCancelAlert = true
+                                }
+                            })
+                        }
+                        .frame(maxWidth: .infinity)
                     }
                 } else if let overrideString = overrideString {
                     adjustmentsOverrideView(overrideString)
@@ -440,18 +515,99 @@ extension Home.RootView {
         }
     }
 
-    /// Bottom-anchored fixed slot shared by adjustment panel and bolus progress.
-    @ViewBuilder func bottomControls() -> some View {
-        Group {
-            if let progress = state.bolusProgress {
-                bolusView(progress)
-            } else {
-                adjustmentView()
+    func statsDistributionBar(_ segments: [(color: Color, fraction: CGFloat)]) -> some View {
+        GeometryReader { g in
+            let spacing: CGFloat = 2
+            let shown = segments.filter { $0.fraction > 0.005 }
+            let available = max(g.size.width - spacing * CGFloat(max(shown.count - 1, 0)), 0)
+            HStack(spacing: spacing) {
+                ForEach(Array(shown.enumerated()), id: \.offset) { _, segment in
+                    Capsule()
+                        .fill(segment.color)
+                        .frame(width: available * segment.fraction)
+                }
             }
+            .frame(maxHeight: .infinity)
         }
-        .frame(height: HomeLayout.bottomPanelHeight)
-        .animation(.easeInOut(duration: 0.2), value: state.bolusProgress != nil)
-        // clear air below the chart's x-axis labels and above the tab bar
+    }
+
+    @ViewBuilder func statsBanner() -> some View {
+        let distribution = state.todayGlucoseDistribution
+        let coveragePct = distribution.veryLowPct + distribution.lowPct + distribution.inRangePct + distribution
+            .highPct + distribution.veryHighPct
+        let hasData = coveragePct > 0
+        let tirString = hasData
+            ? distribution.inRangePct.formatted(.number.precision(.fractionLength(0 ... 1))) + " %"
+            : "-- %"
+        let segments: [(color: Color, fraction: CGFloat)] = hasData ? [
+            (.red, CGFloat(distribution.veryLowPct / 100)),
+            (.orange, CGFloat(distribution.lowPct / 100)),
+            (.loopGreen, CGFloat(distribution.inRangePct / 100)),
+            (.purple, CGFloat((distribution.highPct + distribution.veryHighPct) / 100))
+        ] : [(Color.secondary.opacity(0.3), 1)]
+
+        Button {
+            state.showModal(for: .statistics)
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 17, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 17, style: .continuous)
+                            .fill(Color.insulin.opacity(0.08))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 17, style: .continuous)
+                            .strokeBorder(Color.insulin.opacity(0.35), lineWidth: 1)
+                    )
+                    .frame(height: HomeLayout.statsBannerHeight)
+                    .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
+                    .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.25 : 0.10), radius: 3, y: 1)
+
+                HStack(alignment: .center, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack(alignment: .firstTextBaseline, spacing: 6) {
+                            Text(tirString)
+                                .font(.title2).fontWeight(.bold).fontDesign(.rounded)
+                                .foregroundStyle(.primary)
+                            Text("Time in Range", comment: "Stats banner subtitle")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        statsDistributionBar(segments)
+                            .frame(height: 6)
+                    }
+
+                    Spacer(minLength: 8)
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 16)
+            }
+            .padding(.horizontal, 10)
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// Bottom-anchored fixed zone: adjustment/bolus panel above the stats banner.
+    @ViewBuilder func bottomControls() -> some View {
+        VStack(spacing: HomeLayout.bottomZonePadding) {
+            Group {
+                if let progress = state.bolusProgress {
+                    bolusView(progress)
+                } else {
+                    adjustmentView()
+                }
+            }
+            .frame(height: HomeLayout.bottomPanelHeight)
+            .animation(.easeInOut(duration: 0.2), value: state.bolusProgress != nil)
+
+            statsBanner()
+                .frame(height: HomeLayout.statsBannerHeight)
+        }
         .padding(.vertical, HomeLayout.bottomZonePadding)
     }
 }

--- a/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
@@ -302,16 +302,17 @@ extension Home.RootView {
         }
     }
 
+    // same track pattern as BolusProgressBar, slightly slimmer
     @ViewBuilder func remainingBar(_ fraction: Double?, tint: Color) -> some View {
         GeometryReader { barGeo in
             if let fraction {
-                Capsule()
+                RoundedRectangle(cornerRadius: 15)
                     .fill(tint.opacity(0.85))
-                    .frame(width: barGeo.size.width * fraction, height: 3)
+                    .frame(width: barGeo.size.width * fraction, height: 4)
                     .frame(maxHeight: .infinity, alignment: .bottom)
             }
         }
-        .frame(height: 3)
+        .frame(height: 4)
     }
 
     @ViewBuilder func adjustmentView() -> some View {
@@ -351,7 +352,7 @@ extension Home.RootView {
                 )
                 .frame(height: HomeLayout.bottomPanelHeight)
                 .overlay(alignment: .bottom) {
-                    // inset clears the corner curve so the bar stays inside the shape
+                    // anchored like the bolus progress bar so both panels match
                     Group {
                         if isConcurrent {
                             HStack(spacing: 6) {
@@ -362,8 +363,8 @@ extension Home.RootView {
                             remainingBar(overrideRemainingFraction ?? tempTargetRemainingFraction, tint: tint)
                         }
                     }
-                    .padding(.horizontal, 14)
-                    .padding(.bottom, 3)
+                    .padding(.horizontal, 18)
+                    .padding(.bottom, 1)
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
                 .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.25 : 0.10), radius: 3, y: 1)

--- a/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
@@ -1,0 +1,457 @@
+import CoreData
+import SwiftDate
+import SwiftUI
+
+// MARK: - Zone E: bottom controls (adjustment panel / bolus progress)
+
+extension Home.RootView {
+    var bolusProgressFormatter: NumberFormatter {
+        let fractionDigits: Int = switch state.settingsManager.preferences.bolusIncrement {
+        case 0.1: 1
+        case 0.025: 3
+        default: 2
+        }
+
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimum = 0
+        formatter.maximumFractionDigits = fractionDigits
+        formatter.minimumFractionDigits = fractionDigits
+        formatter.allowsFloats = true
+        formatter.roundingIncrement = Double(state.settingsManager.preferences.bolusIncrement) as NSNumber
+        return formatter
+    }
+
+    private var fetchedTargetFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        if state.units == .mmolL {
+            formatter.maximumFractionDigits = 1
+        } else { formatter.maximumFractionDigits = 0 }
+        return formatter
+    }
+
+    var overrideString: String? {
+        guard let latestOverride = latestOverride.first else {
+            return nil
+        }
+
+        guard let settingsManager = state.settingsManager else {
+            return nil
+        }
+
+        let percent = latestOverride.percentage
+        let percentString = percent == 100 ? "" : "\(percent.formatted(.number)) %"
+
+        let unit = state.units
+        var target = (latestOverride.target ?? 0) as Decimal
+        target = unit == .mmolL ? target.asMmolL : target
+
+        var targetString = target == 0 ? "" : (fetchedTargetFormatter.string(from: target as NSNumber) ?? "") + " " + unit
+            .rawValue
+        if tempTargetString != nil {
+            targetString = ""
+        }
+
+        let duration = latestOverride.duration ?? 0
+        let addedMinutes = Int(truncating: duration)
+        let date = latestOverride.date ?? Date()
+        let newDuration = max(
+            Decimal(Date().distance(to: date.addingTimeInterval(addedMinutes.minutes.timeInterval)).minutes),
+            0
+        )
+        let indefinite = latestOverride.indefinite
+        var durationString = ""
+
+        if !indefinite {
+            if newDuration >= 1 {
+                durationString = formatHrMin(Int(newDuration))
+            } else if newDuration > 0 {
+                durationString = "\(Int(newDuration * 60)) s"
+
+            } else {
+                /// Do not show the Override anymore
+                Task {
+                    guard let objectID = self.latestOverride.first?.objectID else { return }
+                    await state.cancelOverride(withID: objectID)
+                }
+            }
+        }
+
+        let smbScheduleString = latestOverride
+            .smbIsScheduledOff && ((latestOverride.start?.stringValue ?? "") != (latestOverride.end?.stringValue ?? ""))
+            ? " \(formatTimeRange(start: latestOverride.start?.stringValue, end: latestOverride.end?.stringValue))"
+            : ""
+
+        let smbToggleString = latestOverride.smbIsOff || latestOverride
+            .smbIsScheduledOff ? String(localized: "SMBs Off\(smbScheduleString)") : ""
+
+        var smbMinuteString: String = ""
+        var uamMinuteString: String = ""
+
+        if !latestOverride.smbIsOff, latestOverride.advancedSettings {
+            if let smbMinutes = latestOverride.smbMinutes,
+               smbMinutes.decimalValue != settingsManager.preferences.maxSMBBasalMinutes
+            {
+                smbMinuteString = "SMB\u{00A0}\(smbMinutes)\u{00A0}" +
+                    String(localized: "m", comment: "Abbreviation for Minutes")
+            }
+
+            if let uamMinutes = latestOverride.uamMinutes,
+               uamMinutes.decimalValue != settingsManager.preferences.maxUAMSMBBasalMinutes
+            {
+                uamMinuteString = "UAM\u{00A0}\(uamMinutes)\u{00A0}" +
+                    String(localized: "m", comment: "Abbreviation for Minutes")
+            }
+        }
+
+        let components = [durationString, percentString, targetString, smbToggleString, smbMinuteString, uamMinuteString]
+            .filter { !$0.isEmpty }
+        return components.isEmpty ? nil : components.joined(separator: ", ")
+    }
+
+    var tempTargetString: String? {
+        guard let latestTempTarget = latestTempTarget.first else {
+            return nil
+        }
+        let duration = latestTempTarget.duration
+        let addedMinutes = Int(truncating: duration ?? 0)
+        let date = latestTempTarget.date ?? Date()
+        let newDuration = max(
+            Decimal(Date().distance(to: date.addingTimeInterval(addedMinutes.minutes.timeInterval)).minutes),
+            0
+        )
+        var durationString = ""
+        var percentageString = ""
+        var target = (latestTempTarget.target ?? 100) as Decimal
+        // Use TempTargetCalculations to get effective HBT (handles both custom and auto-adjusted standard TT)
+        let effectiveHBT = TempTargetCalculations.computeEffectiveHBT(
+            tempTargetHalfBasalTarget: latestTempTarget.halfBasalTarget?.decimalValue,
+            settingHalfBasalTarget: state.settingHalfBasalTarget,
+            target: target,
+            autosensMax: state.autosensMax
+        ) ?? state.settingHalfBasalTarget
+        var showPercentage = false
+        if target > 100, state.isExerciseModeActive || state.highTTraisesSens { showPercentage = true }
+        if target < 100, state.lowTTlowersSens, state.autosensMax > 1 { showPercentage = true }
+        if showPercentage {
+            percentageString =
+                " \(Int(TempTargetCalculations.computeAdjustedPercentage(halfBasalTarget: effectiveHBT, target: target, autosensMax: state.autosensMax)))%"
+        }
+        target = state.units == .mmolL ? target.asMmolL : target
+        let targetString = target == 0 ? "" : (fetchedTargetFormatter.string(from: target as NSNumber) ?? "") + " " +
+            state.units.rawValue + percentageString
+
+        if newDuration >= 1 {
+            durationString =
+                "\(newDuration.formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) min"
+        } else if newDuration > 0 {
+            durationString =
+                "\((newDuration * 60).formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) s"
+        } else {
+            /// Do not show the Temp Target anymore
+            Task {
+                guard let objectID = self.latestTempTarget.first?.objectID else { return }
+                await state.cancelTempTarget(withID: objectID)
+            }
+        }
+
+        let components = [targetString, durationString].filter { !$0.isEmpty }
+        return components.isEmpty ? nil : components.joined(separator: ", ")
+    }
+
+    @ViewBuilder func adjustmentsOverrideView(_ overrideString: String) -> some View {
+        Group {
+            Image(systemName: "clock.arrow.2.circlepath")
+                .font(.title2)
+                .foregroundStyle(Color.primary, Color.purple)
+            VStack(alignment: .leading) {
+                Text(latestOverride.first?.name ?? String(localized: "Custom Override"))
+                    .font(.subheadline)
+                    .frame(alignment: .leading)
+
+                Text(overrideString)
+                    .font(.caption)
+            }
+        }
+        .onTapGesture {
+            selectedTab = 2
+        }
+    }
+
+    @ViewBuilder func adjustmentsTempTargetView(_ tempTargetString: String) -> some View {
+        Group {
+            Image(systemName: "target")
+                .font(.title2)
+                .foregroundStyle(Color.loopGreen)
+            VStack(alignment: .leading) {
+                Text(latestTempTarget.first?.name ?? String(localized: "Temp Target"))
+                    .font(.subheadline)
+                Text(tempTargetString)
+                    .font(.caption)
+            }
+        }
+        .onTapGesture {
+            selectedTab = 2
+        }
+    }
+
+    @ViewBuilder func adjustmentsCancelView(_ cancelAction: @escaping () -> Void) -> some View {
+        Image(systemName: "xmark.app")
+            .font(.title)
+            .onTapGesture {
+                cancelAction()
+            }
+    }
+
+    @ViewBuilder func adjustmentsCancelTempTargetView() -> some View {
+        Image(systemName: "xmark.app")
+            .font(.title)
+            .confirmationDialog(
+                "Stop the Temp Target \"\(latestTempTarget.first?.name ?? "")\"?",
+                isPresented: $isConfirmStopTempTargetShown,
+                titleVisibility: .visible
+            ) {
+                Button("Stop", role: .destructive) {
+                    Task {
+                        guard let objectID = latestTempTarget.first?.objectID else { return }
+                        await state.cancelTempTarget(withID: objectID)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            }
+            .padding(.trailing, 8)
+            .onTapGesture {
+                if !latestTempTarget.isEmpty {
+                    isConfirmStopTempTargetShown = true
+                }
+            }
+    }
+
+    @ViewBuilder func adjustmentsCancelOverrideView() -> some View {
+        Image(systemName: "xmark.app")
+            .font(.title)
+            .confirmationDialog(
+                "Stop the Override \"\(latestOverride.first?.name ?? "")\"?",
+                isPresented: $isConfirmStopOverridePresented,
+                titleVisibility: .visible
+            ) {
+                Button("Stop", role: .destructive) {
+                    Task {
+                        guard let objectID = latestOverride.first?.objectID else { return }
+                        await state.cancelOverride(withID: objectID)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            }
+            .padding(.trailing, 8)
+            .onTapGesture {
+                if !latestOverride.isEmpty {
+                    isConfirmStopOverridePresented = true
+                }
+            }
+    }
+
+    @ViewBuilder func noActiveAdjustmentsView() -> some View {
+        Group {
+            VStack {
+                Text("No Active Adjustment")
+                    .font(.subheadline)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Text("Profile at 100 %")
+                    .font(.caption)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }.padding(.leading, 10)
+
+            Spacer()
+
+            /// to ensure the same position....
+            Image(systemName: "xmark.app")
+                .font(.title)
+                // clear color for the icon
+                .foregroundStyle(Color.clear)
+        }.onTapGesture {
+            selectedTab = 2
+        }
+    }
+
+    @ViewBuilder func adjustmentView() -> some View {
+//            let background = colorScheme == .dark ? Material.ultraThinMaterial.opacity(0.5) : Color.black.opacity(0.2)
+
+        ZStack {
+            /// rectangle as background
+            RoundedRectangle(cornerRadius: 15)
+                .fill(
+                    (overrideString != nil || tempTargetString != nil) ?
+                        (
+                            colorScheme == .dark ?
+                                Color(red: 0.03921568627, green: 0.133333333, blue: 0.2156862745) :
+                                Color.insulin.opacity(0.1)
+                        ) : Color.clear // Use clear and add the Material in the background
+                )
+                .background(colorScheme == .dark ? Color.chart.opacity(0.25) : Color.black.opacity(0.075))
+                .clipShape(RoundedRectangle(cornerRadius: 15))
+                .frame(height: HomeLayout.bottomPanelHeight)
+                .shadow(
+                    color: (overrideString != nil || tempTargetString != nil) ?
+                        (
+                            colorScheme == .dark ? Color(red: 0.02745098039, green: 0.1098039216, blue: 0.1411764706) :
+                                Color.black.opacity(0.33)
+                        ) : Color.clear,
+                    radius: 3
+                )
+            HStack {
+                if let overrideString = overrideString, let tempTargetString = tempTargetString {
+                    HStack {
+                        adjustmentsOverrideView(overrideString)
+
+                        Spacer()
+
+                        Divider()
+                            .frame(height: HomeLayout.bottomPanelHeight - 24)
+                            .padding(.horizontal, 2)
+
+                        adjustmentsTempTargetView(tempTargetString)
+
+                        Spacer()
+
+                        adjustmentsCancelView({
+                            if !latestTempTarget.isEmpty, !latestOverride.isEmpty {
+                                showCancelConfirmDialog = true
+                            } else if !latestOverride.isEmpty {
+                                showCancelAlert = true
+                            } else if !latestTempTarget.isEmpty {
+                                showCancelAlert = true
+                            }
+                        })
+                    }
+                } else if let overrideString = overrideString {
+                    adjustmentsOverrideView(overrideString)
+                    Spacer()
+                    adjustmentsCancelOverrideView()
+
+                } else if let tempTargetString = tempTargetString {
+                    HStack {
+                        adjustmentsTempTargetView(tempTargetString)
+                        Spacer()
+                        adjustmentsCancelTempTargetView()
+                    }
+                } else {
+                    noActiveAdjustmentsView()
+                }
+            }.padding(.horizontal, 10)
+                .confirmationDialog("Adjustment to Stop", isPresented: $showCancelConfirmDialog) {
+                    Button("Stop Override", role: .destructive) {
+                        Task {
+                            guard let objectID = latestOverride.first?.objectID else { return }
+                            await state.cancelOverride(withID: objectID)
+                        }
+                    }
+                    Button("Stop Temp Target", role: .destructive) {
+                        Task {
+                            guard let objectID = latestTempTarget.first?.objectID else { return }
+                            await state.cancelTempTarget(withID: objectID)
+                        }
+                    }
+                    Button("Stop All Adjustments", role: .destructive) {
+                        Task {
+                            guard let overrideObjectID = latestOverride.first?.objectID else { return }
+                            await state.cancelOverride(withID: overrideObjectID)
+
+                            guard let tempTargetObjectID = latestTempTarget.first?.objectID else { return }
+                            await state.cancelTempTarget(withID: tempTargetObjectID)
+                        }
+                    }
+                } message: {
+                    Text("Select Adjustment")
+                }
+        }.padding(.horizontal, 10)
+    }
+
+    @ViewBuilder func bolusView(_ progress: Decimal) -> some View {
+        /// ensure that state.lastPumpBolus has a value, i.e. there is a last bolus done by the pump and not an external bolus
+        /// - TRUE:  show the pump bolus
+        /// - FALSE:  do not show a progress bar at all
+        if let bolusTotal = state.lastPumpBolus?.bolus?.amount {
+            let bolusFraction = progress * (bolusTotal as Decimal)
+            let bolusString =
+                (bolusProgressFormatter.string(from: bolusFraction as NSNumber) ?? "0")
+                    + String(localized: " of ", comment: "Bolus string partial message: 'x U of y U' in home view") +
+                    (Formatter.decimalFormatterWithThreeFractionDigits.string(from: bolusTotal as NSNumber) ?? "0")
+                    + String(localized: " U", comment: "Insulin unit")
+            let bolusLabel = state
+                .bolusStatus == .inProgress ? String(localized: "Bolusing") : String(localized: "Initiating…")
+
+            ZStack {
+                /// rectangle as background
+                RoundedRectangle(cornerRadius: 15)
+                    .fill(
+                        colorScheme == .dark ? Color(red: 0.03921568627, green: 0.133333333, blue: 0.2156862745) : Color
+                            .insulin
+                            .opacity(0.2)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 15))
+                    .frame(height: HomeLayout.bottomPanelHeight)
+                    .shadow(
+                        color: colorScheme == .dark ? Color(red: 0.02745098039, green: 0.1098039216, blue: 0.1411764706) :
+                            Color.black.opacity(0.33),
+                        radius: 3
+                    )
+
+                /// actual bolus view
+                HStack {
+                    Image(systemName: "cross.vial.fill")
+                        .font(.system(size: 25))
+
+                    Spacer()
+
+                    VStack {
+                        Text(bolusLabel)
+                            .font(.subheadline)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Text(bolusString)
+                            .font(.caption)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }.padding(.leading, 5)
+
+                    Spacer()
+
+                    if state.bolusStatus == .inProgress {
+                        Button {
+                            state.showProgressView()
+                            state.cancelBolus()
+                        } label: {
+                            Image(systemName: "xmark.app")
+                                .font(.system(size: 25))
+                        }
+                    } else if state.bolusStatus == .initiating {
+                        ProgressView()
+                    }
+                }.padding(.horizontal, 10)
+                    .padding(.trailing, 8)
+            }
+            .padding(.horizontal, 10)
+            .overlay(alignment: .bottom) {
+                // bar hugs the panel's bottom edge (the slot no longer has outer bottom padding)
+                BolusProgressBar(progress: progress)
+                    .padding(.horizontal, 18)
+                    .padding(.bottom, 1)
+            }.clipShape(RoundedRectangle(cornerRadius: 15))
+        }
+    }
+
+    /// Bottom-anchored fixed slot shared by adjustment panel and bolus progress.
+    @ViewBuilder func bottomControls() -> some View {
+        Group {
+            if let progress = state.bolusProgress {
+                bolusView(progress)
+            } else {
+                adjustmentView()
+            }
+        }
+        .frame(height: HomeLayout.bottomPanelHeight)
+        .animation(.easeInOut(duration: 0.2), value: state.bolusProgress != nil)
+        // clear air below the chart's x-axis labels and above the tab bar
+        .padding(.vertical, HomeLayout.bottomZonePadding)
+    }
+}

--- a/Trio/Sources/Modules/Home/View/HomeRootView+Header.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+Header.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Zone B: header (pump panel / glucose bobble / loop status)
+
+extension Home.RootView {
+    var cgmSelectionButtons: some View {
+        ForEach(cgmOptions, id: \.name) { option in
+            if let cgm = state.listOfCGM.first(where: option.predicate) {
+                Button(option.name) {
+                    state.addCGM(cgm: cgm)
+                }
+            }
+        }
+    }
+
+    var glucoseView: some View {
+        CurrentGlucoseView(
+            timerDate: state.timerDate,
+            units: state.units,
+            alarm: state.alarm,
+            lowGlucose: state.lowGlucose,
+            highGlucose: state.highGlucose,
+            cgmAvailable: state.cgmAvailable,
+            currentGlucoseTarget: state.currentGlucoseTarget,
+            glucoseColorScheme: state.glucoseColorScheme,
+            glucose: state.latestTwoGlucoseValues,
+            cgmProgress: state.cgmProgressHighlight,
+            cgmStatus: state.cgmDisplayState,
+            cgmSensorExpiresAt: state.cgmSensorExpiresAt,
+            cgmWarmupEndsAt: state.cgmWarmupEndsAt
+        )
+        .onTapGesture {
+            if !state.cgmAvailable {
+                showCGMSelection.toggle()
+            } else {
+                state.shouldDisplayCGMSetupSheet.toggle()
+            }
+        }
+        .onLongPressGesture {
+            let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
+            impactHeavy.impactOccurred()
+            showSnoozeSheet = true
+        }
+    }
+
+    var pumpView: some View {
+        PumpView(
+            reservoir: state.reservoir,
+            name: state.pumpName,
+            expiresAtDate: state.pumpExpiresAtDate,
+            activatedAtDate: state.pumpActivatedAtDate,
+            timerDate: state.timerDate,
+            pumpStatusHighlightMessage: state.pumpStatusHighlightMessage,
+            battery: state.batteryFromPersistence
+        )
+        .onTapGesture {
+            if state.pumpDisplayState == nil {
+                // shows user confirmation dialog with pump model choices, then proceeds to setup
+                showPumpSelection.toggle()
+            } else {
+                // sends user to pump settings
+                state.shouldDisplayPumpSetupSheet.toggle()
+            }
+        }
+    }
+
+    @ViewBuilder func rightHeaderPanel() -> some View {
+        VStack(alignment: .leading, spacing: 20) {
+            /// Loop view at bottomLeading
+            LoopView(
+                closedLoop: state.closedLoop,
+                timerDate: state.timerDate,
+                isLooping: state.isLooping,
+                lastLoopDate: state.lastLoopDate,
+                manualTempBasal: state.manualTempBasal,
+                determination: state.determinationsFromPersistence
+            )
+            .onTapGesture {
+                state.isLoopStatusPresented = true
+            }
+            .onLongPressGesture {
+                let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
+                impactHeavy.impactOccurred()
+                state.runLoop()
+            }
+            /// eventualBG string at bottomTrailing
+
+            if let eventualBG = state.enactedAndNonEnactedDeterminations.first?.eventualBG {
+                let eventualGlucose = eventualBG as Decimal
+                HStack {
+                    Image(systemName: "arrow.right.circle")
+                        .font(.callout)
+                        .fontWeight(.bold)
+
+                    Text(state.units == .mgdL ? eventualGlucose.description : eventualGlucose.formattedAsMmolL)
+                        .font(.callout)
+                        .fontWeight(.bold)
+                        .fontDesign(.rounded)
+                }
+                // aligns the evBG icon exactly with the first pixel of loop status icon
+                .padding(.leading, 12)
+            } else {
+                HStack {
+                    Image(systemName: "arrow.right.circle")
+                        .font(.callout).fontWeight(.bold)
+                    Text("--")
+                        .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+                }
+            }
+        }
+    }
+}

--- a/Trio/Sources/Modules/Home/View/HomeRootView+MealPanel.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+MealPanel.swift
@@ -4,51 +4,6 @@ import SwiftUI
 // MARK: - Zone C: meal panel (IOB / COB / delivery rate)
 
 extension Home.RootView {
-    var basalString: String? {
-        var rate: NSNumber = 0
-        var manualBasalString = ""
-
-        guard let apsManager = state.apsManager else {
-            return nil
-        }
-
-        if apsManager.isScheduledBasal == true {
-            guard let scheduledRate = scheduledBasalDeliveryRate(at: Date()) else {
-                return nil
-            }
-            rate = scheduledRate
-        } else {
-            guard let lastTempBasal = state.tempBasals.last?.tempBasal, let tempRate = lastTempBasal.rate else {
-                return nil
-            }
-            if apsManager.isManualTempBasal {
-                manualBasalString = String(
-                    localized: " - Manual Basal ⚠️",
-                    comment: "Manual Temp basal"
-                )
-            }
-            rate = tempRate
-        }
-
-        let rateString = Formatter.decimalFormatterWithThreeFractionDigits.string(from: rate) ?? "0"
-        return rateString + String(localized: " U/hr", comment: "Unit per hour with space") +
-            manualBasalString
-    }
-
-    func scheduledBasalDeliveryRate(at when: Date) -> NSNumber? {
-        let calendar = Calendar(identifier: .gregorian)
-        // calendar.timeZone = timeZone /// should come from pumpManager in case it's different!
-
-        let hours = calendar.component(.hour, from: when)
-        let minutes = calendar.component(.minute, from: when)
-        let totalMinutes = hours * 60 + minutes
-
-        if let rate = findBasalRateForOffset(for: totalMinutes, in: state.basalProfile) {
-            return NSDecimalNumber(decimal: rate)
-        }
-        return nil
-    }
-
     @ViewBuilder func mealPanel() -> some View {
         HStack {
             HStack {
@@ -84,46 +39,38 @@ extension Home.RootView {
 
             Spacer()
 
-            if state.maxIOB == 0.0 {
-                HStack {
-                    Image(systemName: "exclamationmark.circle.fill")
-                    Text("MaxIOB: 0 U")
-                }.bold()
-                    .foregroundStyle(Color.red)
-                    .font(.callout)
-            } else {
-                HStack {
-                    /// Only display the insulin delivery rate info if the pump is not
-                    /// suspended and is available (e.g., pod is paired & not faulted).
-                    let pumpAvailable = state.apsManager.isScheduledBasal != nil
-                    if !state.apsManager.isSuspended && pumpAvailable {
-                        Image(systemName: "drop.circle")
-                            .font(.callout)
-                            .foregroundColor(.insulinTintColor)
-                        if let basalString = self.basalString {
-                            /// Adjust opacity when displaying a scheduled basal rate
-                            let opacity = state.apsManager?.isScheduledBasal == true ? 0.6 : 1.0
-                            if basalString.count > 5 {
-                                Text(basalString)
-                                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.85)
-                                    .truncationMode(.tail)
-                                    .allowsTightening(true)
-                                    .opacity(opacity)
-                            } else {
-                                // Short strings can just display normally
-                                Text(basalString)
-                                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-                                    .opacity(opacity)
-                            }
-                        } else {
-                            Text("No Data")
-                                .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-                        }
-                    }
-                }
-            }
+            alarmsPill
         }.padding(.horizontal)
+    }
+
+    func refreshAlarmsSnooze() {
+        alarmsSnoozeUntil = UserDefaults.standard
+            .object(forKey: "UserNotificationsManager.snoozeUntilDate") as? Date ?? .distantPast
+    }
+
+    /// Bell pill matching the header pills; countdown replaces the label while snoozed.
+    @ViewBuilder var alarmsPill: some View {
+        // timerDate keeps the countdown ticking
+        let isSnoozed = alarmsSnoozeUntil > state.timerDate
+        let remainingMinutes = max(Int(ceil(alarmsSnoozeUntil.timeIntervalSince(state.timerDate) / 60)), 0)
+
+        Button {
+            showSnoozeSheet = true
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: isSnoozed ? "bell.slash.fill" : "bell.fill")
+                    .font(.callout)
+                Text(isSnoozed ? "\(remainingMinutes) m" : String(localized: "Alarms", comment: "Alarms header item"))
+                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+            }
+            .padding(.vertical, 5)
+            .padding(.horizontal, 10)
+            .foregroundStyle(isSnoozed ? AnyShapeStyle(.secondary) : AnyShapeStyle(.primary))
+            .overlay(
+                Capsule()
+                    .stroke(Color.primary.opacity(0.4), lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Trio/Sources/Modules/Home/View/HomeRootView+MealPanel.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+MealPanel.swift
@@ -1,0 +1,129 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Zone C: meal panel (IOB / COB / delivery rate)
+
+extension Home.RootView {
+    var basalString: String? {
+        var rate: NSNumber = 0
+        var manualBasalString = ""
+
+        guard let apsManager = state.apsManager else {
+            return nil
+        }
+
+        if apsManager.isScheduledBasal == true {
+            guard let scheduledRate = scheduledBasalDeliveryRate(at: Date()) else {
+                return nil
+            }
+            rate = scheduledRate
+        } else {
+            guard let lastTempBasal = state.tempBasals.last?.tempBasal, let tempRate = lastTempBasal.rate else {
+                return nil
+            }
+            if apsManager.isManualTempBasal {
+                manualBasalString = String(
+                    localized: " - Manual Basal ⚠️",
+                    comment: "Manual Temp basal"
+                )
+            }
+            rate = tempRate
+        }
+
+        let rateString = Formatter.decimalFormatterWithThreeFractionDigits.string(from: rate) ?? "0"
+        return rateString + String(localized: " U/hr", comment: "Unit per hour with space") +
+            manualBasalString
+    }
+
+    func scheduledBasalDeliveryRate(at when: Date) -> NSNumber? {
+        let calendar = Calendar(identifier: .gregorian)
+        // calendar.timeZone = timeZone /// should come from pumpManager in case it's different!
+
+        let hours = calendar.component(.hour, from: when)
+        let minutes = calendar.component(.minute, from: when)
+        let totalMinutes = hours * 60 + minutes
+
+        if let rate = findBasalRateForOffset(for: totalMinutes, in: state.basalProfile) {
+            return NSDecimalNumber(decimal: rate)
+        }
+        return nil
+    }
+
+    @ViewBuilder func mealPanel() -> some View {
+        HStack {
+            HStack {
+                Image(systemName: "syringe.fill")
+                    .font(.callout)
+                    .foregroundColor(Color.insulin)
+                Text(
+                    (
+                        Formatter.decimalFormatterWithTwoFractionDigits
+                            .string(from: state.currentIOB as NSNumber) ?? "0"
+                    ) +
+                        String(localized: " U", comment: "Insulin unit")
+                )
+                .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+            }
+
+            Spacer()
+
+            HStack {
+                Image(systemName: "fork.knife")
+                    .font(.callout)
+                    .foregroundColor(.loopYellow)
+                Text(
+                    (
+                        Formatter.decimalFormatterWithTwoFractionDigits.string(
+                            from: NSNumber(value: state.enactedAndNonEnactedDeterminations.first?.cob ?? 0)
+                        ) ?? "0"
+                    ) +
+                        String(localized: " g", comment: "gram of carbs")
+                )
+                .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+            }
+
+            Spacer()
+
+            if state.maxIOB == 0.0 {
+                HStack {
+                    Image(systemName: "exclamationmark.circle.fill")
+                    Text("MaxIOB: 0 U")
+                }.bold()
+                    .foregroundStyle(Color.red)
+                    .font(.callout)
+            } else {
+                HStack {
+                    /// Only display the insulin delivery rate info if the pump is not
+                    /// suspended and is available (e.g., pod is paired & not faulted).
+                    let pumpAvailable = state.apsManager.isScheduledBasal != nil
+                    if !state.apsManager.isSuspended && pumpAvailable {
+                        Image(systemName: "drop.circle")
+                            .font(.callout)
+                            .foregroundColor(.insulinTintColor)
+                        if let basalString = self.basalString {
+                            /// Adjust opacity when displaying a scheduled basal rate
+                            let opacity = state.apsManager?.isScheduledBasal == true ? 0.6 : 1.0
+                            if basalString.count > 5 {
+                                Text(basalString)
+                                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.85)
+                                    .truncationMode(.tail)
+                                    .allowsTightening(true)
+                                    .opacity(opacity)
+                            } else {
+                                // Short strings can just display normally
+                                Text(basalString)
+                                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+                                    .opacity(opacity)
+                            }
+                        } else {
+                            Text("No Data")
+                                .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+                        }
+                    }
+                }
+            }
+        }.padding(.horizontal)
+    }
+}

--- a/Trio/Sources/Modules/Home/View/HomeRootView+MealPanel.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+MealPanel.swift
@@ -5,41 +5,43 @@ import SwiftUI
 
 extension Home.RootView {
     @ViewBuilder func mealPanel() -> some View {
-        HStack {
-            HStack {
-                Image(systemName: "syringe.fill")
-                    .font(.callout)
-                    .foregroundColor(Color.insulin)
-                Text(
-                    (
-                        Formatter.decimalFormatterWithTwoFractionDigits
-                            .string(from: state.currentIOB as NSNumber) ?? "0"
-                    ) +
-                        String(localized: " U", comment: "Insulin unit")
-                )
-                .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-            }
-
-            Spacer()
-
-            HStack {
+        ZStack {
+            // the carb value itself sits on the panel's midline; the icon hangs off it
+            Text(
+                (
+                    Formatter.decimalFormatterWithTwoFractionDigits.string(
+                        from: NSNumber(value: state.enactedAndNonEnactedDeterminations.first?.cob ?? 0)
+                    ) ?? "0"
+                ) +
+                    String(localized: " g", comment: "gram of carbs")
+            )
+            .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+            .overlay(alignment: .leading) {
                 Image(systemName: "fork.knife")
                     .font(.callout)
                     .foregroundColor(.loopYellow)
-                Text(
-                    (
-                        Formatter.decimalFormatterWithTwoFractionDigits.string(
-                            from: NSNumber(value: state.enactedAndNonEnactedDeterminations.first?.cob ?? 0)
-                        ) ?? "0"
-                    ) +
-                        String(localized: " g", comment: "gram of carbs")
-                )
-                .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+                    .alignmentGuide(.leading) { $0.width + 5 }
             }
 
-            Spacer()
+            HStack {
+                HStack {
+                    Image(systemName: "syringe.fill")
+                        .font(.callout)
+                        .foregroundColor(Color.insulin)
+                    Text(
+                        (
+                            Formatter.decimalFormatterWithTwoFractionDigits
+                                .string(from: state.currentIOB as NSNumber) ?? "0"
+                        ) +
+                            String(localized: " U", comment: "Insulin unit")
+                    )
+                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+                }
 
-            alarmsPill
+                Spacer()
+
+                alarmsPill
+            }
         }.padding(.horizontal)
     }
 
@@ -57,19 +59,32 @@ extension Home.RootView {
         Button {
             showSnoozeSheet = true
         } label: {
-            HStack(spacing: 5) {
-                Image(systemName: isSnoozed ? "bell.slash.fill" : "bell.fill")
-                    .font(.callout)
-                Text(isSnoozed ? "\(remainingMinutes) m" : String(localized: "Alarms", comment: "Alarms header item"))
-                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+            Group {
+                if isSnoozed {
+                    HStack(spacing: 5) {
+                        Image(systemName: "bell.slash.fill")
+                            .font(.callout)
+                        Text("\(remainingMinutes) m")
+                            .font(.callout).fontWeight(.bold).fontDesign(.rounded)
+                    }
+                    .padding(.vertical, 5)
+                    .padding(.horizontal, 10)
+                    .foregroundStyle(.secondary)
+                    .overlay(
+                        Capsule()
+                            .stroke(Color.primary.opacity(0.4), lineWidth: 2)
+                    )
+                } else {
+                    Image(systemName: "bell.fill")
+                        .font(.callout)
+                        .foregroundStyle(.primary)
+                        .frame(width: 32, height: 32)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.primary.opacity(0.4), lineWidth: 2)
+                        )
+                }
             }
-            .padding(.vertical, 5)
-            .padding(.horizontal, 10)
-            .foregroundStyle(isSnoozed ? AnyShapeStyle(.secondary) : AnyShapeStyle(.primary))
-            .overlay(
-                Capsule()
-                    .stroke(Color.primary.opacity(0.4), lineWidth: 2)
-            )
         }
         .buttonStyle(.plain)
     }

--- a/Trio/Sources/Modules/Home/View/HomeRootView+Toolbar.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+Toolbar.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Toolbar: conditional warning items (notifications off, pump timezone)
+
+extension Home.RootView {
+    @ViewBuilder func pumpTimezoneView(_ badgeImage: UIImage, _ badgeColor: Color) -> some View {
+        HStack {
+            Image(uiImage: badgeImage.withRenderingMode(.alwaysTemplate))
+                .font(.system(size: 14))
+                .colorMultiply(badgeColor)
+            Text(String(localized: "Time Change Detected", comment: ""))
+                .bold()
+                .font(.system(size: 14))
+                .foregroundStyle(badgeColor)
+        }
+        .onTapGesture {
+            if state.pumpDisplayState != nil {
+                // sends user to pump settings
+                state.shouldDisplayPumpSetupSheet.toggle()
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.vertical, 5)
+        .padding(.horizontal, 10)
+        .overlay(
+            Capsule()
+                .stroke(badgeColor.opacity(0.4), lineWidth: 2)
+        )
+    }
+
+    @ViewBuilder func alertSafetyNotificationsView(geo: GeometryProxy) -> some View {
+        ZStack {
+            /// rectangle as background
+            RoundedRectangle(cornerRadius: 15)
+                .fill(
+                    Color(
+                        red: 0.9,
+                        green: 0.133333333,
+                        blue: 0.2156862745
+                    )
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 15))
+                .frame(height: geo.size.height * 0.08)
+                .coordinateSpace(name: "alertSafetyNotificationsView")
+                .shadow(
+                    color: colorScheme == .dark ? Color(red: 0.02745098039, green: 0.1098039216, blue: 0.1411764706) :
+                        Color.black.opacity(0.33),
+                    radius: 3
+                )
+            HStack {
+                Spacer()
+                VStack {
+                    Text("⚠️ Safety Notifications are OFF")
+                        .font(.headline)
+                        .fontWeight(.bold)
+                        .fontDesign(.rounded)
+                        .foregroundStyle(.white.gradient)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text("Fix now by turning Notifications ON.")
+                        .font(.footnote)
+                        .fontDesign(.rounded)
+                        .foregroundStyle(.white.gradient)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }.padding(.leading, 5)
+                Spacer()
+                Image(systemName: "chevron.right").foregroundColor(.white)
+                    .font(.headline)
+            }.padding(.horizontal, 10)
+                .padding(.trailing, 8)
+                .onTapGesture {
+                    UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                }
+        }.padding(.horizontal, 10)
+            .padding(.top, 0)
+    }
+}

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -4,12 +4,6 @@ import SwiftDate
 import SwiftUI
 import Swinject
 
-struct TimePicker: Identifiable {
-    var active: Bool
-    let hours: Int16
-    var id: String { hours.description }
-}
-
 extension Home {
     struct RootView: BaseView {
         let resolver: Resolver
@@ -36,13 +30,8 @@ extension Home {
         @State var showPumpSelection: Bool = false
         @State var showCGMSelection: Bool = false
         @State var showSnoozeSheet: Bool = false
+        @State var alarmsSnoozeUntil: Date = .distantPast
         @State var notificationsDisabled = false
-        @State var timeButtons: [TimePicker] = [
-            TimePicker(active: false, hours: 4),
-            TimePicker(active: false, hours: 6),
-            TimePicker(active: false, hours: 12),
-            TimePicker(active: false, hours: 24)
-        ]
 
         @FetchRequest(fetchRequest: OverrideStored.fetch(
             NSPredicate.lastActiveOverride,
@@ -56,7 +45,7 @@ extension Home {
             fetchLimit: 1
         )) var latestTempTarget: FetchedResults<TempTargetStored>
 
-        private var historySFSymbol: String {
+        var historySFSymbol: String {
             if #available(iOS 17.0, *) {
                 return "book.pages"
             } else {
@@ -64,83 +53,10 @@ extension Home {
             }
         }
 
-        // Returns the scheduled basal rate for the current time based on the saved basal scheduled.
-        // Would be better if in the future BasalDeliveryStatus could be updated to include this info.
-
-        var timeIntervalButtons: some View {
-            let buttonColor = (colorScheme == .dark ? Color.white : Color.black).opacity(0.8)
-
-            return HStack(alignment: .center) {
-                ForEach(timeButtons) { button in
-                    Button(action: {
-                        state.hours = button.hours
-                    }) {
-                        Group {
-                            if button.active {
-                                Text(
-                                    button.hours.description + "\u{00A0}" +
-                                        String(localized: "h", comment: "h")
-                                )
-                            } else {
-                                Text(button.hours.description)
-                            }
-                        }
-                        .font(.footnote)
-                        .fontWeight(button.active ? .semibold : .regular)
-                        .padding(.vertical, 5)
-                        .padding(.horizontal, 10)
-                        .foregroundColor(
-                            button
-                                .active ? (colorScheme == .dark ? Color.bgDarkerDarkBlue : Color.white) : buttonColor
-                        )
-                        .background(button.active ? buttonColor.opacity(colorScheme == .dark ? 1 : 0.8) : Color.clear)
-                        .clipShape(Capsule())
-                        .overlay(
-                            Capsule()
-                                .stroke(button.active ? buttonColor.opacity(0.4) : Color.clear, lineWidth: 2)
-                        )
-                    }
-                }
-            }
-        }
-
-        var statsIconString: String {
-            if #available(iOS 18, *) {
-                return "chart.line.text.clipboard"
-            } else {
-                return "list.clipboard"
-            }
-        }
-
-        @ViewBuilder private func tappableButton(
-            buttonColor: Color,
-            label: String,
-            iconString: String,
-            action: @escaping () -> Void
-        ) -> some View {
-            Button(action: {
-                action()
-            }) {
-                HStack {
-                    Image(systemName: iconString)
-                    Text(label)
-                }
-                .font(.footnote)
-                .padding(.vertical, 5)
-                .padding(.horizontal, 10)
-                .foregroundStyle(buttonColor)
-                .overlay(
-                    Capsule()
-                        .stroke(buttonColor.opacity(0.4), lineWidth: 2)
-                )
-            }
-        }
-
         @ViewBuilder func mainChart(geo: GeometryProxy) -> some View {
             // the chart is the only flexible zone: it takes what the fixed slots leave over
             let chartHeight = max(
-                geo.size.height - HomeLayout.headerHeight - HomeLayout.mealSlotHeight - HomeLayout
-                    .timeButtonsRowHeight - HomeLayout.bottomZoneHeight,
+                geo.size.height - HomeLayout.headerHeight - HomeLayout.mealSlotHeight - HomeLayout.bottomZoneHeight,
                 HomeLayout.chartMinHeight
             )
             ZStack {
@@ -162,12 +78,47 @@ extension Home {
             }
             // enforce the zone budget; panes flex within it
             .frame(height: chartHeight)
+            .overlay(alignment: .bottomTrailing) {
+                chartInfoButton
+                    .offset(x: 0, y: -10)
+            }
+            .overlay(alignment: .topTrailing) {
+                // borderless capsule (not a control); centered in the basal
+                // pane band so it clears the y-axis labels on every device size
+                if let rate = currentBasalRateLabel {
+                    Text(rate)
+                        .font(.system(size: 14, weight: .semibold))
+                        .fontDesign(.rounded)
+                        .foregroundStyle(Color.insulin)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(.ultraThinMaterial))
+                        .frame(height: chartHeight * 0.10)
+                        .padding(.trailing, 8)
+                }
+            }
         }
 
-        func highlightButtons() {
-            for i in 0 ..< timeButtons.count {
-                timeButtons[i].active = timeButtons[i].hours == state.hours
+        private var currentBasalRateLabel: String? {
+            guard let rate = state.tempBasals.last?.tempBasal?.rate else { return nil }
+            let value = Formatter.decimalFormatterWithTwoFractionDigits.string(from: rate) ?? "\(rate)"
+            return value + String(localized: " U/hr", comment: "Unit per hour with space")
+        }
+
+        @ViewBuilder private var chartInfoButton: some View {
+            Button {
+                state.isLegendPresented.toggle()
+            } label: {
+                Image(systemName: "info")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 32, height: 32)
+                    .background(Circle().fill(.ultraThinMaterial))
+                    .overlay(Circle().strokeBorder(Color.primary.opacity(0.12), lineWidth: 1))
             }
+            .contentShape(Circle())
+            .padding(.bottom, 6)
+            .padding(.trailing, 8)
         }
 
         @ViewBuilder func mainViewElements(_ geo: GeometryProxy) -> some View {
@@ -212,30 +163,6 @@ extension Home {
                 mealPanel().frame(height: HomeLayout.mealSlotHeight)
 
                 mainChart(geo: geo)
-
-                HStack {
-                    tappableButton(
-                        buttonColor: (colorScheme == .dark ? Color.white : Color.black).opacity(0.8),
-                        label: String(localized: "Stats", comment: "Stats icon in main view"),
-                        iconString: statsIconString,
-                        action: { state.showModal(for: .statistics) }
-                    )
-
-                    Spacer()
-
-                    timeIntervalButtons
-
-                    Spacer()
-
-                    tappableButton(
-                        buttonColor: (colorScheme == .dark ? Color.white : Color.black).opacity(0.8),
-                        label: String(localized: "Info", comment: "Info icon in main view"),
-                        iconString: "info",
-                        action: { state.isLegendPresented.toggle() }
-                    )
-                }
-                .padding(.horizontal)
-                .frame(height: HomeLayout.timeButtonsRowHeight)
             }
             // fill the screen; zones stay top-aligned, chart takes the slack
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -263,13 +190,13 @@ extension Home {
                     // fixed zones bust beyond XXL; cap dashboard type size
                     .dynamicTypeSize(...DynamicTypeSize.xxLarge)
             }
-            .onChange(of: state.hours) {
-                highlightButtons()
-            }
             .onAppear {
-                configureView {
-                    highlightButtons()
-                }
+                configureView()
+                refreshAlarmsSnooze()
+            }
+            // UserDefaults changes don't invalidate views; refresh on sheet dismissal
+            .onChange(of: showSnoozeSheet) {
+                if !showSnoozeSheet { refreshAlarmsSnooze() }
             }
             .navigationTitle("Home")
             .navigationBarHidden(true)

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -13,7 +13,6 @@ struct TimePicker: Identifiable {
 extension Home {
     struct RootView: BaseView {
         let resolver: Resolver
-        let safeAreaSize: CGFloat = 0.08
 
         @Environment(\.managedObjectContext) var moc
         @Environment(\.colorScheme) var colorScheme
@@ -57,32 +56,6 @@ extension Home {
             fetchLimit: 1
         )) var latestTempTarget: FetchedResults<TempTargetStored>
 
-        var bolusProgressFormatter: NumberFormatter {
-            let fractionDigits: Int = switch state.settingsManager.preferences.bolusIncrement {
-            case 0.1: 1
-            case 0.025: 3
-            default: 2
-            }
-
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            formatter.minimum = 0
-            formatter.maximumFractionDigits = fractionDigits
-            formatter.minimumFractionDigits = fractionDigits
-            formatter.allowsFloats = true
-            formatter.roundingIncrement = Double(state.settingsManager.preferences.bolusIncrement) as NSNumber
-            return formatter
-        }
-
-        private var fetchedTargetFormatter: NumberFormatter {
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            if state.units == .mmolL {
-                formatter.maximumFractionDigits = 1
-            } else { formatter.maximumFractionDigits = 0 }
-            return formatter
-        }
-
         private var historySFSymbol: String {
             if #available(iOS 17.0, *) {
                 return "book.pages"
@@ -91,267 +64,8 @@ extension Home {
             }
         }
 
-        @ViewBuilder func pumpTimezoneView(_ badgeImage: UIImage, _ badgeColor: Color) -> some View {
-            HStack {
-                Image(uiImage: badgeImage.withRenderingMode(.alwaysTemplate))
-                    .font(.system(size: 14))
-                    .colorMultiply(badgeColor)
-                Text(String(localized: "Time Change Detected", comment: ""))
-                    .bold()
-                    .font(.system(size: 14))
-                    .foregroundStyle(badgeColor)
-            }
-            .onTapGesture {
-                if state.pumpDisplayState != nil {
-                    // sends user to pump settings
-                    state.shouldDisplayPumpSetupSheet.toggle()
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .center)
-            .padding(.vertical, 5)
-            .padding(.horizontal, 10)
-            .overlay(
-                Capsule()
-                    .stroke(badgeColor.opacity(0.4), lineWidth: 2)
-            )
-        }
-
-        var cgmSelectionButtons: some View {
-            ForEach(cgmOptions, id: \.name) { option in
-                if let cgm = state.listOfCGM.first(where: option.predicate) {
-                    Button(option.name) {
-                        state.addCGM(cgm: cgm)
-                    }
-                }
-            }
-        }
-
-        var glucoseView: some View {
-            CurrentGlucoseView(
-                timerDate: state.timerDate,
-                units: state.units,
-                alarm: state.alarm,
-                lowGlucose: state.lowGlucose,
-                highGlucose: state.highGlucose,
-                cgmAvailable: state.cgmAvailable,
-                currentGlucoseTarget: state.currentGlucoseTarget,
-                glucoseColorScheme: state.glucoseColorScheme,
-                glucose: state.latestTwoGlucoseValues,
-                cgmProgress: state.cgmProgressHighlight,
-                cgmStatus: state.cgmDisplayState,
-                cgmSensorExpiresAt: state.cgmSensorExpiresAt,
-                cgmWarmupEndsAt: state.cgmWarmupEndsAt
-            )
-            .onTapGesture {
-                if !state.cgmAvailable {
-                    showCGMSelection.toggle()
-                } else {
-                    state.shouldDisplayCGMSetupSheet.toggle()
-                }
-            }
-            .onLongPressGesture {
-                let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
-                impactHeavy.impactOccurred()
-                showSnoozeSheet = true
-            }
-        }
-
-        var pumpView: some View {
-            PumpView(
-                reservoir: state.reservoir,
-                name: state.pumpName,
-                expiresAtDate: state.pumpExpiresAtDate,
-                activatedAtDate: state.pumpActivatedAtDate,
-                timerDate: state.timerDate,
-                pumpStatusHighlightMessage: state.pumpStatusHighlightMessage,
-                battery: state.batteryFromPersistence
-            )
-            .onTapGesture {
-                if state.pumpDisplayState == nil {
-                    // shows user confirmation dialog with pump model choices, then proceeds to setup
-                    showPumpSelection.toggle()
-                } else {
-                    // sends user to pump settings
-                    state.shouldDisplayPumpSetupSheet.toggle()
-                }
-            }
-        }
-
-        var basalString: String? {
-            var rate: NSNumber = 0
-            var manualBasalString = ""
-
-            guard let apsManager = state.apsManager else {
-                return nil
-            }
-
-            if apsManager.isScheduledBasal == true {
-                guard let scheduledRate = scheduledBasalDeliveryRate(at: Date()) else {
-                    return nil
-                }
-                rate = scheduledRate
-            } else {
-                guard let lastTempBasal = state.tempBasals.last?.tempBasal, let tempRate = lastTempBasal.rate else {
-                    return nil
-                }
-                if apsManager.isManualTempBasal {
-                    manualBasalString = String(
-                        localized: " - Manual Basal ⚠️",
-                        comment: "Manual Temp basal"
-                    )
-                }
-                rate = tempRate
-            }
-
-            let rateString = Formatter.decimalFormatterWithThreeFractionDigits.string(from: rate) ?? "0"
-            return rateString + String(localized: " U/hr", comment: "Unit per hour with space") +
-                manualBasalString
-        }
-
         // Returns the scheduled basal rate for the current time based on the saved basal scheduled.
         // Would be better if in the future BasalDeliveryStatus could be updated to include this info.
-        func scheduledBasalDeliveryRate(at when: Date) -> NSNumber? {
-            let calendar = Calendar(identifier: .gregorian)
-            // calendar.timeZone = timeZone /// should come from pumpManager in case it's different!
-
-            let hours = calendar.component(.hour, from: when)
-            let minutes = calendar.component(.minute, from: when)
-            let totalMinutes = hours * 60 + minutes
-
-            if let rate = findBasalRateForOffset(for: totalMinutes, in: state.basalProfile) {
-                return NSDecimalNumber(decimal: rate)
-            }
-            return nil
-        }
-
-        var overrideString: String? {
-            guard let latestOverride = latestOverride.first else {
-                return nil
-            }
-
-            guard let settingsManager = state.settingsManager else {
-                return nil
-            }
-
-            let percent = latestOverride.percentage
-            let percentString = percent == 100 ? "" : "\(percent.formatted(.number)) %"
-
-            let unit = state.units
-            var target = (latestOverride.target ?? 0) as Decimal
-            target = unit == .mmolL ? target.asMmolL : target
-
-            var targetString = target == 0 ? "" : (fetchedTargetFormatter.string(from: target as NSNumber) ?? "") + " " + unit
-                .rawValue
-            if tempTargetString != nil {
-                targetString = ""
-            }
-
-            let duration = latestOverride.duration ?? 0
-            let addedMinutes = Int(truncating: duration)
-            let date = latestOverride.date ?? Date()
-            let newDuration = max(
-                Decimal(Date().distance(to: date.addingTimeInterval(addedMinutes.minutes.timeInterval)).minutes),
-                0
-            )
-            let indefinite = latestOverride.indefinite
-            var durationString = ""
-
-            if !indefinite {
-                if newDuration >= 1 {
-                    durationString = formatHrMin(Int(newDuration))
-                } else if newDuration > 0 {
-                    durationString = "\(Int(newDuration * 60)) s"
-
-                } else {
-                    /// Do not show the Override anymore
-                    Task {
-                        guard let objectID = self.latestOverride.first?.objectID else { return }
-                        await state.cancelOverride(withID: objectID)
-                    }
-                }
-            }
-
-            let smbScheduleString = latestOverride
-                .smbIsScheduledOff && ((latestOverride.start?.stringValue ?? "") != (latestOverride.end?.stringValue ?? ""))
-                ? " \(formatTimeRange(start: latestOverride.start?.stringValue, end: latestOverride.end?.stringValue))"
-                : ""
-
-            let smbToggleString = latestOverride.smbIsOff || latestOverride
-                .smbIsScheduledOff ? String(localized: "SMBs Off\(smbScheduleString)") : ""
-
-            var smbMinuteString: String = ""
-            var uamMinuteString: String = ""
-
-            if !latestOverride.smbIsOff, latestOverride.advancedSettings {
-                if let smbMinutes = latestOverride.smbMinutes,
-                   smbMinutes.decimalValue != settingsManager.preferences.maxSMBBasalMinutes
-                {
-                    smbMinuteString = "SMB\u{00A0}\(smbMinutes)\u{00A0}" +
-                        String(localized: "m", comment: "Abbreviation for Minutes")
-                }
-
-                if let uamMinutes = latestOverride.uamMinutes,
-                   uamMinutes.decimalValue != settingsManager.preferences.maxUAMSMBBasalMinutes
-                {
-                    uamMinuteString = "UAM\u{00A0}\(uamMinutes)\u{00A0}" +
-                        String(localized: "m", comment: "Abbreviation for Minutes")
-                }
-            }
-
-            let components = [durationString, percentString, targetString, smbToggleString, smbMinuteString, uamMinuteString]
-                .filter { !$0.isEmpty }
-            return components.isEmpty ? nil : components.joined(separator: ", ")
-        }
-
-        var tempTargetString: String? {
-            guard let latestTempTarget = latestTempTarget.first else {
-                return nil
-            }
-            let duration = latestTempTarget.duration
-            let addedMinutes = Int(truncating: duration ?? 0)
-            let date = latestTempTarget.date ?? Date()
-            let newDuration = max(
-                Decimal(Date().distance(to: date.addingTimeInterval(addedMinutes.minutes.timeInterval)).minutes),
-                0
-            )
-            var durationString = ""
-            var percentageString = ""
-            var target = (latestTempTarget.target ?? 100) as Decimal
-            // Use TempTargetCalculations to get effective HBT (handles both custom and auto-adjusted standard TT)
-            let effectiveHBT = TempTargetCalculations.computeEffectiveHBT(
-                tempTargetHalfBasalTarget: latestTempTarget.halfBasalTarget?.decimalValue,
-                settingHalfBasalTarget: state.settingHalfBasalTarget,
-                target: target,
-                autosensMax: state.autosensMax
-            ) ?? state.settingHalfBasalTarget
-            var showPercentage = false
-            if target > 100, state.isExerciseModeActive || state.highTTraisesSens { showPercentage = true }
-            if target < 100, state.lowTTlowersSens, state.autosensMax > 1 { showPercentage = true }
-            if showPercentage {
-                percentageString =
-                    " \(Int(TempTargetCalculations.computeAdjustedPercentage(halfBasalTarget: effectiveHBT, target: target, autosensMax: state.autosensMax)))%"
-            }
-            target = state.units == .mmolL ? target.asMmolL : target
-            let targetString = target == 0 ? "" : (fetchedTargetFormatter.string(from: target as NSNumber) ?? "") + " " +
-                state.units.rawValue + percentageString
-
-            if newDuration >= 1 {
-                durationString =
-                    "\(newDuration.formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) min"
-            } else if newDuration > 0 {
-                durationString =
-                    "\((newDuration * 60).formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) s"
-            } else {
-                /// Do not show the Temp Target anymore
-                Task {
-                    guard let objectID = self.latestTempTarget.first?.objectID else { return }
-                    await state.cancelTempTarget(withID: objectID)
-                }
-            }
-
-            let components = [targetString, durationString].filter { !$0.isEmpty }
-            return components.isEmpty ? nil : components.joined(separator: ", ")
-        }
 
         var timeIntervalButtons: some View {
             let buttonColor = (colorScheme == .dark ? Color.white : Color.black).opacity(0.8)
@@ -423,10 +137,16 @@ extension Home {
         }
 
         @ViewBuilder func mainChart(geo: GeometryProxy) -> some View {
+            // the chart is the only flexible zone: it takes what the fixed slots leave over
+            let chartHeight = max(
+                geo.size.height - HomeLayout.headerHeight - HomeLayout.mealSlotHeight - HomeLayout
+                    .timeButtonsRowHeight - HomeLayout.bottomZoneHeight,
+                HomeLayout.chartMinHeight
+            )
             ZStack {
                 MainChartView(
                     geo: geo,
-                    safeAreaSize: notificationsDisabled == true ? safeAreaSize : 0,
+                    chartHeight: chartHeight,
                     units: state.units,
                     hours: state.filteredHours,
                     highGlucose: state.highGlucose,
@@ -440,463 +160,14 @@ extension Home {
                     state: state
                 )
             }
-            .padding(.bottom, UIDevice.adjustPadding(min: 0, max: nil))
+            // enforce the zone budget; panes flex within it
+            .frame(height: chartHeight)
         }
 
         func highlightButtons() {
             for i in 0 ..< timeButtons.count {
                 timeButtons[i].active = timeButtons[i].hours == state.hours
             }
-        }
-
-        @ViewBuilder func rightHeaderPanel(_: GeometryProxy) -> some View {
-            VStack(alignment: .leading, spacing: 20) {
-                /// Loop view at bottomLeading
-                LoopView(
-                    closedLoop: state.closedLoop,
-                    timerDate: state.timerDate,
-                    isLooping: state.isLooping,
-                    lastLoopDate: state.lastLoopDate,
-                    manualTempBasal: state.manualTempBasal,
-                    determination: state.determinationsFromPersistence
-                )
-                .onTapGesture {
-                    state.isLoopStatusPresented = true
-                }
-                .onLongPressGesture {
-                    let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
-                    impactHeavy.impactOccurred()
-                    state.runLoop()
-                }
-                /// eventualBG string at bottomTrailing
-
-                if let eventualBG = state.enactedAndNonEnactedDeterminations.first?.eventualBG {
-                    let eventualGlucose = eventualBG as Decimal
-                    HStack {
-                        Image(systemName: "arrow.right.circle")
-                            .font(.callout)
-                            .fontWeight(.bold)
-
-                        Text(state.units == .mgdL ? eventualGlucose.description : eventualGlucose.formattedAsMmolL)
-                            .font(.callout)
-                            .fontWeight(.bold)
-                            .fontDesign(.rounded)
-                    }
-                    // aligns the evBG icon exactly with the first pixel of loop status icon
-                    .padding(.leading, 12)
-                } else {
-                    HStack {
-                        Image(systemName: "arrow.right.circle")
-                            .font(.callout).fontWeight(.bold)
-                        Text("--")
-                            .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-                    }
-                }
-            }
-        }
-
-        @ViewBuilder func mealPanel(_: GeometryProxy) -> some View {
-            HStack {
-                HStack {
-                    Image(systemName: "syringe.fill")
-                        .font(.callout)
-                        .foregroundColor(Color.insulin)
-                    Text(
-                        (
-                            Formatter.decimalFormatterWithTwoFractionDigits
-                                .string(from: state.currentIOB as NSNumber) ?? "0"
-                        ) +
-                            String(localized: " U", comment: "Insulin unit")
-                    )
-                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-                }
-
-                Spacer()
-
-                HStack {
-                    Image(systemName: "fork.knife")
-                        .font(.callout)
-                        .foregroundColor(.loopYellow)
-                    Text(
-                        (
-                            Formatter.decimalFormatterWithTwoFractionDigits.string(
-                                from: NSNumber(value: state.enactedAndNonEnactedDeterminations.first?.cob ?? 0)
-                            ) ?? "0"
-                        ) +
-                            String(localized: " g", comment: "gram of carbs")
-                    )
-                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-                }
-
-                Spacer()
-
-                if state.maxIOB == 0.0 {
-                    HStack {
-                        Image(systemName: "exclamationmark.circle.fill")
-                        Text("MaxIOB: 0 U")
-                    }.bold()
-                        .foregroundStyle(Color.red)
-                        .font(.callout)
-                } else {
-                    HStack {
-                        /// Only display the insulin delivery rate info if the pump is not
-                        /// suspended and is available (e.g., pod is paired & not faulted).
-                        let pumpAvailable = state.apsManager.isScheduledBasal != nil
-                        if !state.apsManager.isSuspended && pumpAvailable {
-                            Image(systemName: "drop.circle")
-                                .font(.callout)
-                                .foregroundColor(.insulinTintColor)
-                            if let basalString = self.basalString {
-                                /// Adjust opacity when displaying a scheduled basal rate
-                                let opacity = state.apsManager?.isScheduledBasal == true ? 0.6 : 1.0
-                                if basalString.count > 5 {
-                                    Text(basalString)
-                                        .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-                                        .lineLimit(1)
-                                        .minimumScaleFactor(0.85)
-                                        .truncationMode(.tail)
-                                        .allowsTightening(true)
-                                        .opacity(opacity)
-                                } else {
-                                    // Short strings can just display normally
-                                    Text(basalString)
-                                        .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-                                        .opacity(opacity)
-                                }
-                            } else {
-                                Text("No Data")
-                                    .font(.callout).fontWeight(.bold).fontDesign(.rounded)
-                            }
-                        }
-                    }
-                }
-            }.padding(.horizontal)
-        }
-
-        @ViewBuilder func adjustmentsOverrideView(_ overrideString: String) -> some View {
-            Group {
-                Image(systemName: "clock.arrow.2.circlepath")
-                    .font(.title2)
-                    .foregroundStyle(Color.primary, Color.purple)
-                VStack(alignment: .leading) {
-                    Text(latestOverride.first?.name ?? String(localized: "Custom Override"))
-                        .font(.subheadline)
-                        .frame(alignment: .leading)
-
-                    Text(overrideString)
-                        .font(.caption)
-                }
-            }
-            .onTapGesture {
-                selectedTab = 2
-            }
-        }
-
-        @ViewBuilder func adjustmentsTempTargetView(_ tempTargetString: String) -> some View {
-            Group {
-                Image(systemName: "target")
-                    .font(.title2)
-                    .foregroundStyle(Color.loopGreen)
-                VStack(alignment: .leading) {
-                    Text(latestTempTarget.first?.name ?? String(localized: "Temp Target"))
-                        .font(.subheadline)
-                    Text(tempTargetString)
-                        .font(.caption)
-                }
-            }
-            .onTapGesture {
-                selectedTab = 2
-            }
-        }
-
-        @ViewBuilder func adjustmentsCancelView(_ cancelAction: @escaping () -> Void) -> some View {
-            Image(systemName: "xmark.app")
-                .font(.title)
-                .onTapGesture {
-                    cancelAction()
-                }
-        }
-
-        @ViewBuilder func adjustmentsCancelTempTargetView() -> some View {
-            Image(systemName: "xmark.app")
-                .font(.title)
-                .confirmationDialog(
-                    "Stop the Temp Target \"\(latestTempTarget.first?.name ?? "")\"?",
-                    isPresented: $isConfirmStopTempTargetShown,
-                    titleVisibility: .visible
-                ) {
-                    Button("Stop", role: .destructive) {
-                        Task {
-                            guard let objectID = latestTempTarget.first?.objectID else { return }
-                            await state.cancelTempTarget(withID: objectID)
-                        }
-                    }
-                    Button("Cancel", role: .cancel) {}
-                }
-                .padding(.trailing, 8)
-                .onTapGesture {
-                    if !latestTempTarget.isEmpty {
-                        isConfirmStopTempTargetShown = true
-                    }
-                }
-        }
-
-        @ViewBuilder func adjustmentsCancelOverrideView() -> some View {
-            Image(systemName: "xmark.app")
-                .font(.title)
-                .confirmationDialog(
-                    "Stop the Override \"\(latestOverride.first?.name ?? "")\"?",
-                    isPresented: $isConfirmStopOverridePresented,
-                    titleVisibility: .visible
-                ) {
-                    Button("Stop", role: .destructive) {
-                        Task {
-                            guard let objectID = latestOverride.first?.objectID else { return }
-                            await state.cancelOverride(withID: objectID)
-                        }
-                    }
-                    Button("Cancel", role: .cancel) {}
-                }
-                .padding(.trailing, 8)
-                .onTapGesture {
-                    if !latestOverride.isEmpty {
-                        isConfirmStopOverridePresented = true
-                    }
-                }
-        }
-
-        @ViewBuilder func noActiveAdjustmentsView() -> some View {
-            Group {
-                VStack {
-                    Text("No Active Adjustment")
-                        .font(.subheadline)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Text("Profile at 100 %")
-                        .font(.caption)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }.padding(.leading, 10)
-
-                Spacer()
-
-                /// to ensure the same position....
-                Image(systemName: "xmark.app")
-                    .font(.title)
-                    // clear color for the icon
-                    .foregroundStyle(Color.clear)
-            }.onTapGesture {
-                selectedTab = 2
-            }
-        }
-
-        @ViewBuilder func adjustmentView(geo: GeometryProxy) -> some View {
-//            let background = colorScheme == .dark ? Material.ultraThinMaterial.opacity(0.5) : Color.black.opacity(0.2)
-
-            ZStack {
-                /// rectangle as background
-                RoundedRectangle(cornerRadius: 15)
-                    .fill(
-                        (overrideString != nil || tempTargetString != nil) ?
-                            (
-                                colorScheme == .dark ?
-                                    Color(red: 0.03921568627, green: 0.133333333, blue: 0.2156862745) :
-                                    Color.insulin.opacity(0.1)
-                            ) : Color.clear // Use clear and add the Material in the background
-                    )
-                    .background(colorScheme == .dark ? Color.chart.opacity(0.25) : Color.black.opacity(0.075))
-                    .clipShape(RoundedRectangle(cornerRadius: 15))
-                    .frame(height: geo.size.height * 0.08)
-                    .shadow(
-                        color: (overrideString != nil || tempTargetString != nil) ?
-                            (
-                                colorScheme == .dark ? Color(red: 0.02745098039, green: 0.1098039216, blue: 0.1411764706) :
-                                    Color.black.opacity(0.33)
-                            ) : Color.clear,
-                        radius: 3
-                    )
-                HStack {
-                    if let overrideString = overrideString, let tempTargetString = tempTargetString {
-                        HStack {
-                            adjustmentsOverrideView(overrideString)
-
-                            Spacer()
-
-                            Divider()
-                                .frame(height: geo.size.height * 0.05)
-                                .padding(.horizontal, 2)
-
-                            adjustmentsTempTargetView(tempTargetString)
-
-                            Spacer()
-
-                            adjustmentsCancelView({
-                                if !latestTempTarget.isEmpty, !latestOverride.isEmpty {
-                                    showCancelConfirmDialog = true
-                                } else if !latestOverride.isEmpty {
-                                    showCancelAlert = true
-                                } else if !latestTempTarget.isEmpty {
-                                    showCancelAlert = true
-                                }
-                            })
-                        }
-                    } else if let overrideString = overrideString {
-                        adjustmentsOverrideView(overrideString)
-                        Spacer()
-                        adjustmentsCancelOverrideView()
-
-                    } else if let tempTargetString = tempTargetString {
-                        HStack {
-                            adjustmentsTempTargetView(tempTargetString)
-                            Spacer()
-                            adjustmentsCancelTempTargetView()
-                        }
-                    } else {
-                        noActiveAdjustmentsView()
-                    }
-                }.padding(.horizontal, 10)
-                    .confirmationDialog("Adjustment to Stop", isPresented: $showCancelConfirmDialog) {
-                        Button("Stop Override", role: .destructive) {
-                            Task {
-                                guard let objectID = latestOverride.first?.objectID else { return }
-                                await state.cancelOverride(withID: objectID)
-                            }
-                        }
-                        Button("Stop Temp Target", role: .destructive) {
-                            Task {
-                                guard let objectID = latestTempTarget.first?.objectID else { return }
-                                await state.cancelTempTarget(withID: objectID)
-                            }
-                        }
-                        Button("Stop All Adjustments", role: .destructive) {
-                            Task {
-                                guard let overrideObjectID = latestOverride.first?.objectID else { return }
-                                await state.cancelOverride(withID: overrideObjectID)
-
-                                guard let tempTargetObjectID = latestTempTarget.first?.objectID else { return }
-                                await state.cancelTempTarget(withID: tempTargetObjectID)
-                            }
-                        }
-                    } message: {
-                        Text("Select Adjustment")
-                    }
-            }.padding(.horizontal, 10).padding(.bottom, UIDevice.adjustPadding(min: nil, max: 10))
-        }
-
-        @ViewBuilder func bolusView(geo: GeometryProxy, _ progress: Decimal) -> some View {
-            /// ensure that state.lastPumpBolus has a value, i.e. there is a last bolus done by the pump and not an external bolus
-            /// - TRUE:  show the pump bolus
-            /// - FALSE:  do not show a progress bar at all
-            if let bolusTotal = state.lastPumpBolus?.bolus?.amount {
-                let bolusFraction = progress * (bolusTotal as Decimal)
-                let bolusString =
-                    (bolusProgressFormatter.string(from: bolusFraction as NSNumber) ?? "0")
-                        + String(localized: " of ", comment: "Bolus string partial message: 'x U of y U' in home view") +
-                        (Formatter.decimalFormatterWithThreeFractionDigits.string(from: bolusTotal as NSNumber) ?? "0")
-                        + String(localized: " U", comment: "Insulin unit")
-                let bolusLabel = state
-                    .bolusStatus == .inProgress ? String(localized: "Bolusing") : String(localized: "Initiating…")
-
-                ZStack {
-                    /// rectangle as background
-                    RoundedRectangle(cornerRadius: 15)
-                        .fill(
-                            colorScheme == .dark ? Color(red: 0.03921568627, green: 0.133333333, blue: 0.2156862745) : Color
-                                .insulin
-                                .opacity(0.2)
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 15))
-                        .frame(height: geo.size.height * 0.08)
-                        .shadow(
-                            color: colorScheme == .dark ? Color(red: 0.02745098039, green: 0.1098039216, blue: 0.1411764706) :
-                                Color.black.opacity(0.33),
-                            radius: 3
-                        )
-
-                    /// actual bolus view
-                    HStack {
-                        Image(systemName: "cross.vial.fill")
-                            .font(.system(size: 25))
-
-                        Spacer()
-
-                        VStack {
-                            Text(bolusLabel)
-                                .font(.subheadline)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            Text(bolusString)
-                                .font(.caption)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }.padding(.leading, 5)
-
-                        Spacer()
-
-                        if state.bolusStatus == .inProgress {
-                            Button {
-                                state.showProgressView()
-                                state.cancelBolus()
-                            } label: {
-                                Image(systemName: "xmark.app")
-                                    .font(.system(size: 25))
-                            }
-                        } else if state.bolusStatus == .initiating {
-                            ProgressView()
-                        }
-                    }.padding(.horizontal, 10)
-                        .padding(.trailing, 8)
-                }
-                .padding(.horizontal, 10)
-                .padding(.bottom, UIDevice.adjustPadding(min: nil, max: 10))
-                .overlay(alignment: .bottom) {
-                    BolusProgressBar(progress: progress)
-                        .padding(.horizontal, 18)
-                        .padding(.bottom, 9)
-                }.clipShape(RoundedRectangle(cornerRadius: 15))
-            }
-        }
-
-        @ViewBuilder func alertSafetyNotificationsView(geo: GeometryProxy) -> some View {
-            ZStack {
-                /// rectangle as background
-                RoundedRectangle(cornerRadius: 15)
-                    .fill(
-                        Color(
-                            red: 0.9,
-                            green: 0.133333333,
-                            blue: 0.2156862745
-                        )
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: 15))
-                    .frame(height: geo.size.height * safeAreaSize)
-                    .coordinateSpace(name: "alertSafetyNotificationsView")
-                    .shadow(
-                        color: colorScheme == .dark ? Color(red: 0.02745098039, green: 0.1098039216, blue: 0.1411764706) :
-                            Color.black.opacity(0.33),
-                        radius: 3
-                    )
-                HStack {
-                    Spacer()
-                    VStack {
-                        Text("⚠️ Safety Notifications are OFF")
-                            .font(.headline)
-                            .fontWeight(.bold)
-                            .fontDesign(.rounded)
-                            .foregroundStyle(.white.gradient)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Text("Fix now by turning Notifications ON.")
-                            .font(.footnote)
-                            .fontDesign(.rounded)
-                            .foregroundStyle(.white.gradient)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }.padding(.leading, 5)
-                    Spacer()
-                    Image(systemName: "chevron.right").foregroundColor(.white)
-                        .font(.headline)
-                }.padding(.horizontal, 10)
-                    .padding(.trailing, 8)
-                    .onTapGesture {
-                        UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
-                    }
-            }.padding(.horizontal, 10)
-                .padding(.top, 0)
         }
 
         @ViewBuilder func mainViewElements(_ geo: GeometryProxy) -> some View {
@@ -910,7 +181,7 @@ extension Home {
                         /// right panel with loop status and evBG
                         HStack {
                             Spacer()
-                            rightHeaderPanel(geo)
+                            rightHeaderPanel()
                         }.padding(.trailing, 20)
 
                         /// glucose bobble
@@ -923,19 +194,22 @@ extension Home {
                         }.padding(.leading, 20)
                     }
                 }
-                .padding(.top, 10)
-                .safeAreaInset(edge: .top, spacing: 0) {
-                    if notificationsDisabled {
-                        alertSafetyNotificationsView(geo: geo)
-                    }
-                    if let badgeImage = state.pumpStatusBadgeImage, let badgeColor = state.pumpStatusBadgeColor {
-                        pumpTimezoneView(badgeImage, badgeColor)
-                            .padding(.horizontal, 20)
+                // fixed slot: header state changes never reflow the zones below
+                .frame(height: HomeLayout.headerHeight)
+                // layout-inert warnings; the multi-use panel absorbs these later
+                .overlay(alignment: .top) {
+                    VStack(spacing: 4) {
+                        if notificationsDisabled {
+                            alertSafetyNotificationsView(geo: geo)
+                        }
+                        if let badgeImage = state.pumpStatusBadgeImage, let badgeColor = state.pumpStatusBadgeColor {
+                            pumpTimezoneView(badgeImage, badgeColor)
+                                .padding(.horizontal, 20)
+                        }
                     }
                 }
 
-                mealPanel(geo).padding(.top, UIDevice.adjustPadding(min: nil, max: 30))
-                    .padding(.bottom, UIDevice.adjustPadding(min: nil, max: 20))
+                mealPanel().frame(height: HomeLayout.mealSlotHeight)
 
                 mainChart(geo: geo)
 
@@ -949,8 +223,7 @@ extension Home {
 
                     Spacer()
 
-                    timeIntervalButtons.padding(.top, UIDevice.adjustPadding(min: 0, max: 10))
-                        .padding(.bottom, UIDevice.adjustPadding(min: 0, max: 10))
+                    timeIntervalButtons
 
                     Spacer()
 
@@ -960,14 +233,15 @@ extension Home {
                         iconString: "info",
                         action: { state.isLegendPresented.toggle() }
                     )
-                }.padding([.horizontal, .bottom])
-
-                if let progress = state.bolusProgress {
-                    bolusView(geo: geo, progress)
-                        .padding(.bottom, UIDevice.adjustPadding(min: nil, max: 40))
-                } else {
-                    adjustmentView(geo: geo).padding(.bottom, UIDevice.adjustPadding(min: nil, max: 40))
                 }
+                .padding(.horizontal)
+                .frame(height: HomeLayout.timeButtonsRowHeight)
+            }
+            // fill the screen; zones stay top-aligned, chart takes the slack
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            // safe-area anchor: the tab bar can never cover the bottom controls
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                bottomControls()
             }
             .background(appState.trioBackgroundColor(for: colorScheme))
             .onReceive(
@@ -986,6 +260,8 @@ extension Home {
         @ViewBuilder func mainView() -> some View {
             GeometryReader { geo in
                 mainViewElements(geo)
+                    // fixed zones bust beyond XXL; cap dashboard type size
+                    .dynamicTypeSize(...DynamicTypeSize.xxLarge)
             }
             .onChange(of: state.hours) {
                 highlightButtons()
@@ -1178,39 +454,6 @@ extension Home {
                 ))
             }
         }
-    }
-}
-
-extension UIDevice {
-    public enum DeviceSize: CGFloat {
-        case smallDevice = 667 // Height for 4" iPhone SE
-        case largeDevice = 852 // Height for 6.1" iPhone 15 Pro
-    }
-
-    @usableFromInline static func adjustPadding(
-        min: CGFloat? = nil,
-        max: CGFloat? = nil
-    ) -> CGFloat? {
-        if UIScreen.screenHeight > UIDevice.DeviceSize.smallDevice.rawValue {
-            if UIScreen.screenHeight >= UIDevice.DeviceSize.largeDevice.rawValue {
-                return max
-            } else {
-                return min != nil ?
-                    (max != nil ? max! * (UIScreen.screenHeight / UIDevice.DeviceSize.largeDevice.rawValue) : nil) : nil
-            }
-        } else {
-            return min
-        }
-    }
-}
-
-extension UIScreen {
-    static var screenHeight: CGFloat {
-        UIScreen.main.bounds.height
-    }
-
-    static var screenWidth: CGFloat {
-        UIScreen.main.bounds.width
     }
 }
 

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -94,7 +94,7 @@ extension Home {
                         .padding(.vertical, 3)
                         .background(Capsule().fill(.ultraThinMaterial))
                         .frame(height: chartHeight * 0.10)
-                        .padding(.trailing, 8)
+                        .padding(.trailing, 16)
                 }
             }
         }
@@ -118,7 +118,8 @@ extension Home {
             }
             .contentShape(Circle())
             .padding(.bottom, 6)
-            .padding(.trailing, 8)
+            // same trailing inset as the alarm bell in the meal row
+            .padding(.trailing, 16)
         }
 
         @ViewBuilder func mainViewElements(_ geo: GeometryProxy) -> some View {

--- a/Trio/Sources/Modules/Stat/StatStateModel+Setup/GlucoseStatsSetup.swift
+++ b/Trio/Sources/Modules/Stat/StatStateModel+Setup/GlucoseStatsSetup.swift
@@ -52,6 +52,46 @@ struct GlucoseDailyDistributionStats: Identifiable {
     }
 }
 
+extension GlucoseDailyDistributionStats {
+    /// Pure range-distribution computation shared by Stat and the Home stats banner.
+    static func compute(
+        date: Date,
+        readings: [GlucoseReading],
+        highLimit: Decimal,
+        timeInRangeType: TimeInRangeType
+    ) -> GlucoseDailyDistributionStats {
+        let totalReadings = Double(readings.count)
+
+        let veryHighReadings = readings.filter { $0.value > 250 }.count
+        let highReadings = readings.filter { $0.value > Int(highLimit) && $0.value <= 250 }.count
+        let inRangeReadings = readings.filter { $0.value >= timeInRangeType.bottomThreshold && $0.value <= Int(highLimit) }
+            .count
+        let inSmallRangeReadings = readings
+            .filter { $0.value >= timeInRangeType.bottomThreshold && $0.value <= timeInRangeType.topThreshold }.count
+        let lowReadings = readings.filter { $0.value < timeInRangeType.bottomThreshold && $0.value >= 54 }.count
+        let veryLowReadings = readings.filter { $0.value < 54 }.count
+
+        let veryLowPct = totalReadings > 0 ? Double(veryLowReadings) / totalReadings * 100 : 0
+        let lowPct = totalReadings > 0 ? Double(lowReadings) / totalReadings * 100 : 0
+        let inSmallRangePct = totalReadings > 0 ? Double(inSmallRangeReadings) / totalReadings * 100 : 0
+        let inRangePct = totalReadings > 0 ? Double(inRangeReadings) / totalReadings * 100 : 0
+        let highPct = totalReadings > 0 ? Double(highReadings) / totalReadings * 100 : 0
+        let veryHighPct = totalReadings > 0 ? Double(veryHighReadings) / totalReadings * 100 : 0
+
+        return GlucoseDailyDistributionStats(
+            date: date,
+            timeInRangeType: timeInRangeType,
+            readings: [],
+            veryLowPct: veryLowPct,
+            lowPct: lowPct,
+            inSmallRangePct: inSmallRangePct,
+            inRangePct: inRangePct,
+            highPct: highPct,
+            veryHighPct: veryHighPct
+        )
+    }
+}
+
 /// Represents percentile-based statistical data for daily glucose metrics
 struct GlucoseDailyPercentileStats: Identifiable {
     let id = UUID()
@@ -217,39 +257,11 @@ extension Stat.StateModel {
         highLimit: Decimal,
         timeInRangeType: TimeInRangeType
     ) -> GlucoseDailyDistributionStats {
-        let totalReadings = Double(readings.count)
-
-        // Count readings in each range
-        let veryHighReadings = readings.filter { $0.value > 250 }.count
-        let highReadings = readings.filter { $0.value > Int(highLimit) && $0.value <= 250 }.count
-        let inRangeReadings = readings.filter { $0.value >= timeInRangeType.bottomThreshold && $0.value <= Int(highLimit) }
-            .count
-        let inSmallRangeReadings = readings
-            .filter { $0.value >= timeInRangeType.bottomThreshold && $0.value <= timeInRangeType.topThreshold }.count
-        let lowReadings = readings.filter { $0.value < timeInRangeType.bottomThreshold && $0.value >= 54 }.count
-        let veryLowReadings = readings.filter { $0.value < 54 }.count
-
-        // Calculate percentages
-        let veryLowPct = totalReadings > 0 ? Double(veryLowReadings) / totalReadings * 100 : 0
-        let lowPct = totalReadings > 0 ? Double(lowReadings) / totalReadings * 100 : 0
-        let inSmallRangePct = totalReadings > 0 ? Double(inSmallRangeReadings) / totalReadings * 100 : 0
-        let inRangePct = totalReadings > 0 ? Double(inRangeReadings) / totalReadings * 100 : 0
-        let highPct = totalReadings > 0 ? Double(highReadings) / totalReadings * 100 : 0
-        let veryHighPct = totalReadings > 0 ? Double(veryHighReadings) / totalReadings * 100 : 0
-
-        // Create empty managed object array since we don't need the actual Core Data objects
-        let emptyStoredArray: [GlucoseStored] = []
-
-        return GlucoseDailyDistributionStats(
+        GlucoseDailyDistributionStats.compute(
             date: date,
-            timeInRangeType: timeInRangeType,
-            readings: emptyStoredArray,
-            veryLowPct: veryLowPct,
-            lowPct: lowPct,
-            inSmallRangePct: inSmallRangePct,
-            inRangePct: inRangePct,
-            highPct: highPct,
-            veryHighPct: veryHighPct
+            readings: readings,
+            highLimit: highLimit,
+            timeInRangeType: timeInRangeType
         )
     }
 

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
@@ -14,6 +14,7 @@ extension UserInterfaceSettings {
         @Published var glucoseColorScheme: GlucoseColorScheme = .staticColor
         @Published var eA1cDisplayUnit: EstimatedA1cDisplayUnit = .percent
         @Published var timeInRangeType: TimeInRangeType = .timeInTightRange
+        @Published var homeStatsPanelFace: HomeStatsPanelFace = .timeInRange
         @Published var requireAdjustmentsConfirmation: Bool = false
 
         var units: GlucoseUnits = .mgdL
@@ -45,6 +46,7 @@ extension UserInterfaceSettings {
             subscribeSetting(\.eA1cDisplayUnit, on: $eA1cDisplayUnit) { eA1cDisplayUnit = $0 }
 
             subscribeSetting(\.timeInRangeType, on: $timeInRangeType) { timeInRangeType = $0 }
+            subscribeSetting(\.homeStatsPanelFace, on: $homeStatsPanelFace) { homeStatsPanelFace = $0 }
 
             subscribeSetting(\.requireAdjustmentsConfirmation, on: $requireAdjustmentsConfirmation) {
                 requireAdjustmentsConfirmation = $0 }

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -543,6 +543,46 @@ extension UserInterfaceSettings {
                     }.padding(.bottom)
                 }.settingsSearchTarget(label: String(localized: "Time in Range Type"))
 
+                Section {
+                    VStack(alignment: .leading) {
+                        Picker(
+                            selection: $state.homeStatsPanelFace,
+                            label: Text("Home Statistics Panel").multilineTextAlignment(.leading)
+                        ) {
+                            ForEach(HomeStatsPanelFace.allCases) { selection in
+                                Text(selection.displayName).tag(selection)
+                            }
+                        }.padding(.top)
+
+                        HStack(alignment: .center) {
+                            Text(
+                                "Choose what the statistics panel on the home screen displays."
+                            )
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                            .lineLimit(nil)
+                            Spacer()
+                            Button(
+                                action: {
+                                    hintLabel = String(localized: "Home Statistics Panel")
+                                    selectedVerboseHint =
+                                        AnyView(
+                                            Text(
+                                                "Choose what the statistics panel on the home screen shows by default. Tapping the panel always opens the full statistics view.\n\nTime in Range: today's time in range percentage with a glucose distribution bar.\n\nDistribution Bar Only: just the glucose distribution bar, without the percentage.\n\nToday's Averages: today's average glucose and GMI (Glucose Management Index)."
+                                            )
+                                        )
+                                    shouldDisplayHint.toggle()
+                                },
+                                label: {
+                                    HStack {
+                                        Image(systemName: "questionmark.circle")
+                                    }
+                                }
+                            ).buttonStyle(BorderlessButtonStyle())
+                        }.padding(.top)
+                    }.padding(.bottom)
+                }.settingsSearchTarget(label: String(localized: "Home Statistics Panel"))
+
                 SettingInputSection(
                     decimalValue: $state.carbsRequiredThreshold,
                     booleanValue: $state.showCarbsRequiredBadge,


### PR DESCRIPTION
Part 2 of 7 of the home layout v2 series, stacked on `home-refactor-zoning`.

Applies the layout design worked out with @marv-out out onto the zone structure: restructured header with pump/loop panels, glass-style adjustments card with remaining-time bar, stats banner slot, meal info row with alarms pill, floating chart-info button, and the top-trailing temp basal rate label. Time-interval buttons are removed; the chart y-axis gains a domain floor so threshold/target lines never clamp to the plot edge.

No Liquid Glass yet (compatibility mode stays on until part 7). Verified light/dark on SE3, 17 Pro, and Pro Max.

| 17 Pro iOS 26.4 | 17 Pro Max iOS 26.5 | 16 Pro iOS 18.5 | SE 3 iOS 26.5 |
|--------|--------|--------|--------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/3c26892e-effc-4548-a45e-94fbc3a8239d" /> | <img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/f3e9665c-3cfc-4e9f-b11c-af5b9b71104c" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e2b45249-9383-406b-a5ea-7af4a4147e09" /> | <img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/f31ffcdf-c1a2-461b-938c-b36f386a3226" /> | 
