### PR TITLE
[Part 6 of 7] Home Layout v2 – Make sensor lifecycle arc count down

### DIFF
--- a/Model/Helper/CarbEntryStored+helper.swift
+++ b/Model/Helper/CarbEntryStored+helper.swift
@@ -12,6 +12,14 @@ extension NSPredicate {
         return NSPredicate(format: "isFPU == false AND date >= %@ AND carbs > 0", date as NSDate)
     }
 
+    static func carbsForChart(since date: Date) -> NSPredicate {
+        NSPredicate(format: "isFPU == false AND date >= %@ AND carbs > 0", date as NSDate)
+    }
+
+    static func fpusForChart(since date: Date) -> NSPredicate {
+        NSPredicate(format: "isFPU == true AND date >= %@", date as NSDate)
+    }
+
     static var carbsForStats: NSPredicate {
         let date = Date.threeMonthsAgo
         return NSPredicate(format: "date >= %@ AND isFPU == %@", date as NSDate, false as NSNumber)

--- a/Model/Helper/Determination+helper.swift
+++ b/Model/Helper/Determination+helper.swift
@@ -65,6 +65,10 @@ extension NSPredicate {
         return NSPredicate(format: "deliverAt >= %@", date as NSDate)
     }
 
+    static func determinationsForCobIobCharts(since date: Date) -> NSPredicate {
+        NSPredicate(format: "deliverAt >= %@", date as NSDate)
+    }
+
     static var enactedDeterminationsNotYetUploadedToNightscout: NSPredicate {
         NSPredicate(
             format: "deliverAt >= %@ AND isUploadedToNS == %@ AND enacted == %@",

--- a/Model/Helper/GlucoseStored+helper.swift
+++ b/Model/Helper/GlucoseStored+helper.swift
@@ -48,6 +48,10 @@ extension NSPredicate {
         return NSPredicate(format: "date >= %@", date as NSDate)
     }
 
+    static func glucose(since date: Date) -> NSPredicate {
+        NSPredicate(format: "date >= %@", date as NSDate)
+    }
+
     static var manualGlucose: NSPredicate {
         let date = Date.oneDayAgo
         return NSPredicate(format: "isManual == %@ AND date >= %@", true as NSNumber, date as NSDate)

--- a/Model/Helper/NSPredicates.swift
+++ b/Model/Helper/NSPredicates.swift
@@ -72,6 +72,10 @@ extension NSPredicate {
         return NSPredicate(format: "startDate >= %@", date as NSDate)
     }
 
+    static func predicateForStartDate(since date: Date) -> NSPredicate {
+        NSPredicate(format: "startDate >= %@", date as NSDate)
+    }
+
     static var carbsHistory: NSPredicate {
         let date = Date.oneDayAgo
         return NSPredicate(format: "date >= %@ AND carbs > 0", date as NSDate)

--- a/Model/Helper/PumpEvent+helper.swift
+++ b/Model/Helper/PumpEvent+helper.swift
@@ -95,6 +95,10 @@ extension NSPredicate {
         return NSPredicate(format: "timestamp >= %@", date as NSDate)
     }
 
+    static func pumpHistory(since date: Date) -> NSPredicate {
+        NSPredicate(format: "timestamp >= %@", date as NSDate)
+    }
+
     static var pumpHistoryForStats: NSPredicate {
         let date = Date.threeMonthsAgo
         return NSPredicate(format: "pumpEvent.timestamp >= %@", date as NSDate)

--- a/Model/Helper/TempTargetStored+Helper.swift
+++ b/Model/Helper/TempTargetStored+Helper.swift
@@ -26,6 +26,16 @@ extension NSPredicate {
             false as NSNumber
         )
     }
+
+    static func tempTargetsForMainChart(since date: Date) -> NSPredicate {
+        NSPredicate(
+            format: "(date >= %@ AND enabled == %@) OR (date >= %@ AND enabled == %@)",
+            date as NSDate,
+            true as NSNumber,
+            Date() as NSDate,
+            false as NSNumber
+        )
+    }
 }
 
 extension TempTargetStored {

--- a/Trio/Sources/Helpers/MainChartHelper.swift
+++ b/Trio/Sources/Helpers/MainChartHelper.swift
@@ -42,7 +42,8 @@ enum MainChartHelper {
         /// How far back the chart's `startMarker` is anchored — the fixed 24 h
         /// history window loaded on every open. Independent of the currently
         /// visible viewport, which the user can pinch-zoom within this range.
-        static let chartHistorySeconds: TimeInterval = 24 * 3600
+        static let chartHistorySeconds: TimeInterval = 72 * 3600
+        /// Backfill triggers when the visible leading edge gets this close
         /// Visible x-axis window seeded on first launch of the chart (matches the old 6 h default).
         static let defaultVisibleSeconds: TimeInterval = 6 * 3600
         /// Tightest pinch-in zoom.
@@ -51,10 +52,19 @@ enum MainChartHelper {
         static let maxVisibleSeconds: TimeInterval = 24 * 3600
         /// Double-tap cycles the visible window through these presets.
         static let zoomPresets: [TimeInterval] = [6 * 3600, 12 * 3600, 24 * 3600]
+        /// Render window extends this many visible-windows beyond each visible edge.
+        static let renderWindowPadFactor = 1.5
+        /// Re-anchor when the visible edge gets within this fraction of a
+        /// visible-window of the render window's edge.
+        static let renderWindowMarginFactor = 0.5
         /// Geometric grid for pinch commits (~4 % per step). Every committed zoom step
         /// re-lays the full-width canvas, so this bounds a halving of the visible window
         /// to roughly 18 re-layouts instead of hundreds.
         static let zoomStepRatio: Double = 1.04
+        /// Live pinch previews as a transform; once the stretch drifts past
+        /// this ratio a crisp re-layout is committed mid-gesture, so the
+        /// distortion stays bounded.
+        static let pinchCommitScaleDrift: Double = 1.25
         /// How far (pt) a one-finger touch may travel and still count as a stationary
         /// press-to-inspect; beyond this the touch becomes a pan.
         static let inspectMovementTolerance: CGFloat = 10
@@ -220,7 +230,7 @@ extension MainChartCanvas {
     }
 
     var mainChartXAxis: some AxisContent {
-        AxisMarks(values: hourAxisMarks(over: state.startMarker ... state.endMarker)) { _ in
+        AxisMarks(values: hourAxisMarks(over: windowStart ... windowEnd)) { _ in
             if displayXgridLines {
                 AxisGridLine(stroke: .init(lineWidth: 0.5, dash: [2, 3]))
             } else {
@@ -233,14 +243,24 @@ extension MainChartCanvas {
     /// labels render exactly once for the whole stack; the basal and glucose panes use
     /// `mainChartXAxis` (grid lines only) at the same absolute-anchored mark dates.
     var basalChartXAxis: some AxisContent {
-        AxisMarks(values: hourAxisMarks(over: state.startMarker ... state.endMarker)) { _ in
+        AxisMarks(values: hourAxisMarks(over: windowStart ... windowEnd)) { value in
             if displayXgridLines {
                 AxisGridLine(stroke: .init(lineWidth: 0.5, dash: [2, 3]))
             } else {
                 AxisGridLine(stroke: .init(lineWidth: 0, dash: [2, 3]))
             }
-            AxisValueLabel(format: .dateTime.hour(.defaultDigits(amPM: .narrow)), anchor: .top)
-                .font(.footnote).foregroundStyle(Color.primary)
+            // Midnight ticks carry the day ("TUE 07") so panned-back history
+            // stays unambiguous; all other ticks show the hour.
+            if let date = value.as(Date.self), calendar.component(.hour, from: date) == 0 {
+                AxisValueLabel(anchor: .top) {
+                    Text(date.formatted(.dateTime.weekday(.abbreviated).day(.twoDigits)).uppercased())
+                        .font(.footnote).bold()
+                        .foregroundStyle(Color.primary)
+                }
+            } else {
+                AxisValueLabel(format: .dateTime.hour(.defaultDigits(amPM: .narrow)), anchor: .top)
+                    .font(.footnote).foregroundStyle(Color.primary)
+            }
         }
     }
 

--- a/Trio/Sources/Helpers/MainChartHelper.swift
+++ b/Trio/Sources/Helpers/MainChartHelper.swift
@@ -47,7 +47,7 @@ enum MainChartHelper {
         /// Visible x-axis window seeded on first launch of the chart (matches the old 6 h default).
         static let defaultVisibleSeconds: TimeInterval = 6 * 3600
         /// Tightest pinch-in zoom.
-        static let minVisibleSeconds: TimeInterval = 3 * 3600
+        static let minVisibleSeconds: TimeInterval = 1 * 3600
         /// Widest pinch-out zoom.
         static let maxVisibleSeconds: TimeInterval = 24 * 3600
         /// Double-tap cycles the visible window through these presets.

--- a/Trio/Sources/Helpers/MainChartHelper.swift
+++ b/Trio/Sources/Helpers/MainChartHelper.swift
@@ -52,6 +52,10 @@ enum MainChartHelper {
         static let maxVisibleSeconds: TimeInterval = 24 * 3600
         /// Double-tap cycles the visible window through these presets.
         static let zoomPresets: [TimeInterval] = [6 * 3600, 12 * 3600, 24 * 3600]
+        /// When auto-follow re-anchors to `now` at tight zoom, the current reading sits this
+        /// fraction from the trailing edge (0.55 makes the crossover land at ~6 h, so the
+        /// forecast-anchored framing at 6 h and wider is unchanged; below it, `now` stays on-screen).
+        static let followForecastPeekFraction: CGFloat = 0.55
         /// Render window extends this many visible-windows beyond each visible edge.
         static let renderWindowPadFactor = 1.5
         /// Re-anchor when the visible edge gets within this fraction of a

--- a/Trio/Sources/Localizations/Main/Localizable.xcstrings
+++ b/Trio/Sources/Localizations/Main/Localizable.xcstrings
@@ -1547,6 +1547,7 @@
     },
     " - Manual Basal ⚠️" : {
       "comment" : "Manual Temp basal",
+      "extractionState" : "stale",
       "localizations" : {
         "bg" : {
           "stringUnit" : {
@@ -20959,6 +20960,7 @@
       }
     },
     "⚠️ Safety Notifications are OFF" : {
+      "extractionState" : "stale",
       "localizations" : {
         "bg" : {
           "stringUnit" : {
@@ -37823,6 +37825,9 @@
         }
       }
     },
+    "Alarms cannot alert you. Tap to fix." : {
+
+    },
     "Alert Sound" : {
       "comment" : "A section header for the alert sound settings.",
       "localizations" : {
@@ -52644,6 +52649,9 @@
           }
         }
       }
+    },
+    "Automated dosing is limited. Tap to review." : {
+
     },
     "Automated Insulin Delivery" : {
       "localizations" : {
@@ -112663,6 +112671,9 @@
         }
       }
     },
+    "Edge" : {
+
+    },
     "Edit" : {
       "localizations" : {
         "bg" : {
@@ -133253,6 +133264,7 @@
       }
     },
     "Fix now by turning Notifications ON." : {
+      "extractionState" : "stale",
       "localizations" : {
         "bg" : {
           "stringUnit" : {
@@ -135250,6 +135262,9 @@
           }
         }
       }
+    },
+    "Forcing loop…" : {
+
     },
     "Forecast Display Type" : {
       "localizations" : {
@@ -181062,6 +181077,9 @@
         }
       }
     },
+    "Max IOB is 0 U" : {
+
+    },
     "Max IOB is the maximum amount of insulin on board from all sources – both basal (or SMB correction) and bolus insulin – that your loop is allowed to accumulate to treat higher-than-target BG. Unlike the other two OpenAPS safety settings (max_daily_safety_multiplier and current_basal_safety_multiplier), max_iob is set as a fixed number of units of insulin. As of now manual boluses are NOT limited by this setting. \n\n To test your basal rates during nighttime, you can modify the Max IOB setting to zero while in Closed Loop. This will enable low glucose suspend mode while testing your basal rates settings." : {
       "comment" : "\"Max IOB\"",
       "extractionState" : "manual",
@@ -183573,6 +183591,7 @@
       }
     },
     "MaxIOB: 0 U" : {
+      "extractionState" : "stale",
       "localizations" : {
         "bg" : {
           "stringUnit" : {
@@ -193664,6 +193683,7 @@
       }
     },
     "No Data" : {
+      "extractionState" : "stale",
       "localizations" : {
         "bg" : {
           "stringUnit" : {
@@ -196043,6 +196063,9 @@
           }
         }
       }
+    },
+    "No Recent Glucose" : {
+
     },
     "No recent oref algorithm determination." : {
       "localizations" : {
@@ -202588,6 +202611,9 @@
           }
         }
       }
+    },
+    "Notifications Disabled" : {
+
     },
     "Notifications for “Trio” are Disabled" : {
       "localizations" : {
@@ -219616,6 +219642,9 @@
         }
       }
     },
+    "Pull down to force loop" : {
+
+    },
     "Pump" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -219994,6 +220023,9 @@
           }
         }
       }
+    },
+    "Pump clock differs from phone. Tap to review." : {
+
     },
     "Pump config" : {
       "extractionState" : "manual",
@@ -255597,6 +255629,7 @@
     },
     "Stats" : {
       "comment" : "Stats icon in main view",
+      "extractionState" : "stale",
       "localizations" : {
         "bg" : {
           "stringUnit" : {
@@ -261963,6 +261996,9 @@
           }
         }
       }
+    },
+    "Tap to add a fingerstick reading." : {
+
     },
     "Tap to Enable Bluetooth in iOS Settings" : {
       "localizations" : {
@@ -281932,6 +281968,9 @@
           }
         }
       }
+    },
+    "Time in Range" : {
+      "comment" : "Stats banner subtitle"
     },
     "Time in Range Type" : {
       "localizations" : {

--- a/Trio/Sources/Modules/Home/HomeStateModel+Setup/StartEndMarkerSetup.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel+Setup/StartEndMarkerSetup.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 extension Home.StateModel {
+    /// Leading edge of the chart-feeding fetch window (chart-only; dosing
+    /// reads its own storage fetches).
+    var chartHistoryStartDate: Date {
+        Date(timeIntervalSinceNow: -MainChartHelper.Config.chartHistorySeconds)
+    }
+
     // Update start and  end marker to fix scroll update problem with x axis
     func updateStartEndMarkers() {
         startMarker = Date(timeIntervalSinceNow: -MainChartHelper.Config.chartHistorySeconds)

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -34,6 +34,8 @@ extension Home {
         private let timer = DispatchTimer(timeInterval: 30)
         private(set) var filteredHours = 24
         var startMarker = Date(timeIntervalSinceNow: -MainChartHelper.Config.chartHistorySeconds)
+        /// Span of history the chart arrays are fetched over; grows once to
+        /// `maxChartHistorySeconds` when the user pans near the domain start.
         var endMarker = Date(timeIntervalSinceNow: TimeInterval(hours: 3))
         var manualGlucose: [BloodGlucose] = []
         var uploadStats = false
@@ -154,7 +156,7 @@ extension Home {
         @ObservationIgnored private(set) lazy var glucoseController: NSFetchedResultsController<GlucoseStored> = {
             let request = NSFetchRequest<GlucoseStored>(entityName: "GlucoseStored")
             request.sortDescriptors = [NSSortDescriptor(keyPath: \GlucoseStored.date, ascending: true)]
-            request.predicate = NSPredicate.glucose
+            request.predicate = NSPredicate.glucose(since: chartHistoryStartDate)
             request.fetchBatchSize = 50
             let controller = NSFetchedResultsController(
                 fetchRequest: request,
@@ -170,7 +172,7 @@ extension Home {
         @ObservationIgnored private(set) lazy var carbsController: NSFetchedResultsController<CarbEntryStored> = {
             let request = NSFetchRequest<CarbEntryStored>(entityName: "CarbEntryStored")
             request.sortDescriptors = [NSSortDescriptor(keyPath: \CarbEntryStored.date, ascending: false)]
-            request.predicate = NSPredicate.carbsForChart
+            request.predicate = NSPredicate.carbsForChart(since: chartHistoryStartDate)
             request.fetchBatchSize = 5
             let controller = NSFetchedResultsController(
                 fetchRequest: request,
@@ -186,7 +188,7 @@ extension Home {
         @ObservationIgnored private(set) lazy var fpuController: NSFetchedResultsController<CarbEntryStored> = {
             let request = NSFetchRequest<CarbEntryStored>(entityName: "CarbEntryStored")
             request.sortDescriptors = [NSSortDescriptor(keyPath: \CarbEntryStored.date, ascending: false)]
-            request.predicate = NSPredicate.fpusForChart
+            request.predicate = NSPredicate.fpusForChart(since: chartHistoryStartDate)
             let controller = NSFetchedResultsController(
                 fetchRequest: request,
                 managedObjectContext: viewContext,
@@ -218,7 +220,7 @@ extension Home {
         @ObservationIgnored private(set) lazy var determinationController: NSFetchedResultsController<OrefDetermination> = {
             let request = NSFetchRequest<OrefDetermination>(entityName: "OrefDetermination")
             request.sortDescriptors = [NSSortDescriptor(keyPath: \OrefDetermination.deliverAt, ascending: false)]
-            request.predicate = NSPredicate.determinationsForCobIobCharts
+            request.predicate = NSPredicate.determinationsForCobIobCharts(since: chartHistoryStartDate)
             request.fetchBatchSize = 50
             let controller = NSFetchedResultsController(
                 fetchRequest: request,
@@ -234,7 +236,7 @@ extension Home {
         @ObservationIgnored private(set) lazy var insulinController: NSFetchedResultsController<PumpEventStored> = {
             let request = NSFetchRequest<PumpEventStored>(entityName: "PumpEventStored")
             request.sortDescriptors = [NSSortDescriptor(keyPath: \PumpEventStored.timestamp, ascending: true)]
-            request.predicate = NSPredicate.pumpHistoryLast24h
+            request.predicate = NSPredicate.pumpHistory(since: chartHistoryStartDate)
             request.fetchBatchSize = 30
             let controller = NSFetchedResultsController(
                 fetchRequest: request,
@@ -281,7 +283,7 @@ extension Home {
         @ObservationIgnored private(set) lazy var overrideRunController: NSFetchedResultsController<OverrideRunStored> = {
             let request = NSFetchRequest<OverrideRunStored>(entityName: "OverrideRunStored")
             request.sortDescriptors = [NSSortDescriptor(keyPath: \OverrideRunStored.startDate, ascending: false)]
-            request.predicate = NSPredicate.predicateForStartDateOneDayAgo
+            request.predicate = NSPredicate.predicateForStartDate(since: chartHistoryStartDate)
             let controller = NSFetchedResultsController(
                 fetchRequest: request,
                 managedObjectContext: viewContext,
@@ -296,7 +298,7 @@ extension Home {
         @ObservationIgnored private(set) lazy var tempTargetController: NSFetchedResultsController<TempTargetStored> = {
             let request = NSFetchRequest<TempTargetStored>(entityName: "TempTargetStored")
             request.sortDescriptors = [NSSortDescriptor(keyPath: \TempTargetStored.date, ascending: false)]
-            request.predicate = NSPredicate.tempTargetsForMainChart
+            request.predicate = NSPredicate.tempTargetsForMainChart(since: chartHistoryStartDate)
             let controller = NSFetchedResultsController(
                 fetchRequest: request,
                 managedObjectContext: viewContext,
@@ -311,7 +313,7 @@ extension Home {
         @ObservationIgnored private(set) lazy var tempTargetRunController: NSFetchedResultsController<TempTargetRunStored> = {
             let request = NSFetchRequest<TempTargetRunStored>(entityName: "TempTargetRunStored")
             request.sortDescriptors = [NSSortDescriptor(keyPath: \TempTargetRunStored.startDate, ascending: false)]
-            request.predicate = NSPredicate.predicateForStartDateOneDayAgo
+            request.predicate = NSPredicate.predicateForStartDate(since: chartHistoryStartDate)
             let controller = NSFetchedResultsController(
                 fetchRequest: request,
                 managedObjectContext: viewContext,
@@ -362,24 +364,27 @@ extension Home {
 
         /// Called on `willEnterForegroundNotification`; idempotent at launch.
         @MainActor func reanchorFetchWindows() {
-            reanchor(glucoseController, with: NSPredicate.glucose) {
+            reanchor(glucoseController, with: NSPredicate.glucose(since: chartHistoryStartDate)) {
                 self.updateGlucoseFromController()
                 // Re-sync the chart domain even if no new reading arrived while backgrounded.
                 self.updateStartEndMarkers()
             }
-            reanchor(carbsController, with: NSPredicate.carbsForChart) { self.updateCarbsFromController() }
-            reanchor(fpuController, with: NSPredicate.fpusForChart) { self.updateFPUsFromController() }
-            reanchor(determinationController, with: NSPredicate.determinationsForCobIobCharts) {
+            reanchor(carbsController, with: NSPredicate.carbsForChart(since: chartHistoryStartDate)) {
+                self.updateCarbsFromController() }
+            reanchor(fpuController, with: NSPredicate.fpusForChart(since: chartHistoryStartDate)) {
+                self.updateFPUsFromController() }
+            reanchor(determinationController, with: NSPredicate.determinationsForCobIobCharts(since: chartHistoryStartDate)) {
                 self.updateDeterminationsFromController()
             }
-            reanchor(insulinController, with: NSPredicate.pumpHistoryLast24h) { self.updateInsulinFromController() }
-            reanchor(overrideRunController, with: NSPredicate.predicateForStartDateOneDayAgo) {
+            reanchor(insulinController, with: NSPredicate.pumpHistory(since: chartHistoryStartDate)) {
+                self.updateInsulinFromController() }
+            reanchor(overrideRunController, with: NSPredicate.predicateForStartDate(since: chartHistoryStartDate)) {
                 self.updateOverrideRunsFromController()
             }
-            reanchor(tempTargetController, with: NSPredicate.tempTargetsForMainChart) {
+            reanchor(tempTargetController, with: NSPredicate.tempTargetsForMainChart(since: chartHistoryStartDate)) {
                 self.updateTempTargetsFromController()
             }
-            reanchor(tempTargetRunController, with: NSPredicate.predicateForStartDateOneDayAgo) {
+            reanchor(tempTargetRunController, with: NSPredicate.predicateForStartDate(since: chartHistoryStartDate)) {
                 self.updateTempTargetRunsFromController()
             }
             reanchor(batteryController, with: NSPredicate.predicateFor30MinAgo) { self.updateBatteryFromController() }
@@ -911,7 +916,7 @@ extension Home {
             }
         }
 
-        private func setupGlucoseTargets() async {
+        func setupGlucoseTargets() async {
             let bgTargets = await provider.getBGTargets()
             let targetProfiles = processFetchedTargets(bgTargets, startMarker: startMarker)
             await MainActor.run {

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
@@ -31,7 +31,7 @@ extension MainChartCanvas {
                 calculateBasals()
             }
             .frame(width: canvasWidth, height: basalHeight)
-            .chartXScale(domain: state.startMarker ... state.endMarker)
+            .chartXScale(domain: windowStart ... windowEnd)
             .chartXAxis { mainChartXAxis } // grid lines only; hour labels render once, on the bottom pane
             .chartYAxis(.hidden)
             .chartYScale(domain: 0 ... basalDomainMax)

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/BasalChart.swift
@@ -58,7 +58,9 @@ extension MainChartCanvas {
 
 extension MainChartCanvas {
     func drawTempBasals() -> some ChartContent {
-        ForEach(preparedTempBasals, id: \.rate) { basal in
+        // only bars overlapping the render window; the rest clip invisibly but still cost layout
+        let visible = preparedTempBasals.filter { $0.end >= windowStart && $0.start <= windowEnd }
+        return ForEach(visible, id: \.start) { basal in
             RectangleMark(
                 xStart: .value("start", basal.start),
                 xEnd: .value("end", basal.end),
@@ -85,7 +87,8 @@ extension MainChartCanvas {
 
     func drawBasalProfile() -> some ChartContent {
         /// dashed profile line
-        ForEach(basalProfiles, id: \.self) { profile in
+        let visible = basalProfiles.filter { ($0.endDate ?? state.endMarker) >= windowStart && $0.startDate <= windowEnd }
+        return ForEach(visible, id: \.self) { profile in
             LineMark(
                 x: .value("Start Date", profile.startDate),
                 y: .value("Amount", invertedY(profile.amount)),
@@ -99,36 +102,42 @@ extension MainChartCanvas {
         }
     }
 
-    func drawSuspensions() -> some ChartContent {
+    /// Suspend→resume intervals resolved once, so the mark loop does no per-mark lookups.
+    private func suspensionIntervals() -> [(start: Date, end: Date, height: Double)] {
         let suspensions = state.suspendAndResumeEvents
-        return ForEach(suspensions) { suspension in
-            let now = Date()
+        let now = Date()
+        var intervals = [(start: Date, end: Date, height: Double)]()
 
-            if let type = suspension.type, type == EventType.pumpSuspend.rawValue, let suspensionStart = suspension.timestamp {
-                let suspensionEnd = min(
-                    (
-                        suspensions
-                            .first(where: {
-                                $0.timestamp ?? now > suspensionStart && $0.type == EventType.pumpResume.rawValue })?
-                            .timestamp
-                    ) ?? now,
-                    now
-                )
-
-                let basalProfileDuringSuspension = basalProfiles.first(where: { $0.startDate <= suspensionStart })
-                // Clamp to the explicit y-domain: the fallback height of 1 U/hr can exceed
-                // `basalDomainMax` when no profile data is available, and unlike the old
-                // auto-scaled (flipped) plot, an explicit domain would clip the mark.
-                let suspensionMarkHeight = min(basalProfileDuringSuspension?.amount ?? 1, basalDomainMax)
-
-                RectangleMark(
-                    xStart: .value("start", suspensionStart),
-                    xEnd: .value("end", suspensionEnd),
-                    yStart: .value("suspend-start", basalDomainMax),
-                    yEnd: .value("suspend-end", invertedY(suspensionMarkHeight))
-                )
-                .foregroundStyle(Color.loopGray.opacity(colorScheme == .dark ? 0.3 : 0.8))
+        for suspension in suspensions {
+            guard suspension.type == EventType.pumpSuspend.rawValue, let suspensionStart = suspension.timestamp else {
+                continue
             }
+            let suspensionEnd = min(
+                suspensions.first(where: {
+                    $0.timestamp ?? now > suspensionStart && $0.type == EventType.pumpResume.rawValue
+                })?.timestamp ?? now,
+                now
+            )
+            let basalProfileDuringSuspension = basalProfiles.first(where: { $0.startDate <= suspensionStart })
+            // Clamp to the explicit y-domain: the fallback height of 1 U/hr can exceed
+            // `basalDomainMax` when no profile data is available, and unlike the old
+            // auto-scaled (flipped) plot, an explicit domain would clip the mark.
+            let height = min(basalProfileDuringSuspension?.amount ?? 1, basalDomainMax)
+            intervals.append((suspensionStart, suspensionEnd, height))
+        }
+        return intervals
+    }
+
+    func drawSuspensions() -> some ChartContent {
+        let visible = suspensionIntervals().filter { $0.end >= windowStart && $0.start <= windowEnd }
+        return ForEach(visible, id: \.start) { interval in
+            RectangleMark(
+                xStart: .value("start", interval.start),
+                xEnd: .value("end", interval.end),
+                yStart: .value("suspend-start", basalDomainMax),
+                yEnd: .value("suspend-end", invertedY(interval.height))
+            )
+            .foregroundStyle(Color.loopGray.opacity(colorScheme == .dark ? 0.3 : 0.8))
         }
     }
 }

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/CobIobChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/CobIobChart.swift
@@ -14,7 +14,7 @@ extension MainChartCanvas {
         ])
         .chartLegend(.hidden)
         .frame(width: canvasWidth, height: cobIobHeight)
-        .chartXScale(domain: state.startMarker ... state.endMarker)
+        .chartXScale(domain: windowStart ... windowEnd)
         .chartXAxis { basalChartXAxis }
         .chartYAxis { cobIobChartYAxis }
         .chartYScale(domain: combinedYDomain())
@@ -34,7 +34,7 @@ extension MainChartCanvas {
         // We sometimes get two determinations when editing carbs, one without the entry-to-be-edited and then another one after editing the entry.
         // We are fetching determinations in descending order, so the first one is the latter determination (with correct amounts), so keeping the first one encountered.
         var seenDates = Set<Date>()
-        let filteredDeterminations = state.enactedAndNonEnactedDeterminations.filter { item in
+        let filteredDeterminations = windowedDeterminations.filter { item in
             if let date = item.deliverAt {
                 if seenDates.contains(date) {
                     // Already seen this date – filter it out.

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/CobIobChart.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/CobIobChart.swift
@@ -8,10 +8,6 @@ extension MainChartCanvas {
             drawCurrentTimeMarker()
             drawCOBIOBChart()
         }
-        .chartForegroundStyleScale([
-            "COB": Color.orange,
-            "IOB": Color.darkerBlue
-        ])
         .chartLegend(.hidden)
         .frame(width: canvasWidth, height: cobIobHeight)
         .chartXScale(domain: windowStart ... windowEnd)
@@ -54,12 +50,12 @@ extension MainChartCanvas {
             let amountCOB = Int(item.cob)
             let date: Date = item.deliverAt ?? Date()
 
-            LineMark(x: .value("Time", date), y: .value("Value", amountCOB))
-                .foregroundStyle(by: .value("Type", "COB"))
-                .position(by: .value("Axis", "COB"))
-            AreaMark(x: .value("Time", date), y: .value("Value", amountCOB))
-                .foregroundStyle(by: .value("Type", "COB"))
-                .position(by: .value("Axis", "COB"))
+            // Fixed styles + explicit series identity replace foregroundStyle(by:)/
+            // position(by:), which dragged every mark through scale resolution.
+            LineMark(x: .value("Time", date), y: .value("Value", amountCOB), series: .value("Series", "COB"))
+                .foregroundStyle(Color.orange)
+            AreaMark(x: .value("Time", date), y: .value("Value", amountCOB), series: .value("Series", "COB"))
+                .foregroundStyle(Color.orange)
                 .opacity(0.2)
 
             // MARK: - IOB line and area mark
@@ -67,13 +63,11 @@ extension MainChartCanvas {
             let rawAmount = item.iob?.doubleValue ?? 0
             let amountIOB: Double = MainChartHelper.scaledIobAmount(rawAmount)
 
-            AreaMark(x: .value("Time", date), y: .value("Amount", amountIOB))
-                .foregroundStyle(by: .value("Type", "IOB"))
-                .position(by: .value("Axis", "IOB"))
+            AreaMark(x: .value("Time", date), y: .value("Amount", amountIOB), series: .value("Series", "IOB"))
+                .foregroundStyle(Color.darkerBlue)
                 .opacity(0.2)
-            LineMark(x: .value("Time", date), y: .value("Amount", amountIOB))
-                .foregroundStyle(by: .value("Type", "IOB"))
-                .position(by: .value("Axis", "IOB"))
+            LineMark(x: .value("Time", date), y: .value("Amount", amountIOB), series: .value("Series", "IOB"))
+                .foregroundStyle(Color.darkerBlue)
         }
     }
 }

--- a/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -55,6 +55,19 @@ struct MainChartView: View {
     @State var scrollPosition = Date.now
         .addingTimeInterval(-MainChartHelper.Config.defaultVisibleSeconds)
 
+    /// Rendered slice of the domain. The canvas covers only this window (visible
+    /// ± `Config.renderWindowPadFactor` viewports), bounding canvas width and
+    /// per-layout cost no matter how long the data domain grows.
+    @State private var renderWindowStart = Date.now
+        .addingTimeInterval(-MainChartHelper.Config.defaultVisibleSeconds * 2.5)
+    @State private var renderWindowEnd = Date.now
+        .addingTimeInterval(MainChartHelper.Config.defaultVisibleSeconds * 1.5)
+
+    /// Horizontal stretch applied while a pinch is live. The zoom itself is
+    /// committed once, on release; between touch-down and release the canvas
+    /// is only transformed, never re-laid.
+    @State private var pinchScale: CGFloat = 1
+
     /// Captured at pinch start so the zoom stays anchored under the pinch centroid.
     @State private var pinchAnchor: (
         visibleAtStart: TimeInterval,
@@ -102,6 +115,8 @@ struct MainChartView: View {
                 displayYgridLines: displayYgridLines,
                 thresholdLines: thresholdLines,
                 visibleSeconds: visibleSeconds,
+                windowStart: renderWindowStart,
+                windowEnd: renderWindowEnd,
                 canvasWidth: canvasWidth,
                 basalHeight: basalHeight,
                 mainHeight: mainHeight,
@@ -110,6 +125,7 @@ struct MainChartView: View {
             )
             .equatable()
             .offset(x: -canvasOffsetX)
+            .scaleEffect(x: pinchScale, y: 1, anchor: pinchScaleAnchor)
 
             nowOffscreenGradient
 
@@ -154,12 +170,20 @@ struct MainChartView: View {
             inspectHoldTask?.cancel()
             edgePanTask?.cancel()
         }
+        .onChange(of: scrollPosition) {
+            updateRenderWindow()
+        }
+        .onChange(of: visibleSeconds) {
+            updateRenderWindow(force: true)
+        }
         .onChange(of: state.glucoseFromPersistence.last?.glucose) {
             state.updateStartEndMarkers()
             scrollToTrailingEdge()
+            updateRenderWindow()
         }
         .onChange(of: state.enactedAndNonEnactedDeterminations.first?.deliverAt) {
             scrollToTrailingEdge()
+            updateRenderWindow()
         }
         .onChange(of: units) {
             // TODO: - Refactor this to only update the Y Axis Scale
@@ -169,6 +193,7 @@ struct MainChartView: View {
             if !mainChartHasInitialized {
                 state.updateStartEndMarkers()
                 scrollToTrailingEdge()
+                updateRenderWindow(force: true)
                 mainChartHasInitialized = true
             }
         }
@@ -187,19 +212,45 @@ extension MainChartView {
     var mainHeight: CGFloat { chartHeight * 0.66 }
     var cobIobHeight: CGFloat { chartHeight * 0.24 }
 
-    private var totalSeconds: TimeInterval {
-        max(state.endMarker.timeIntervalSince(state.startMarker), 1)
+    private var windowSeconds: TimeInterval {
+        max(renderWindowEnd.timeIntervalSince(renderWindowStart), 1)
     }
 
-    /// Width of the full pre-laid-out canvas: the viewport shows `visibleSeconds` of the
-    /// `totalSeconds` domain, so the canvas is proportionally wider than the viewport.
+    /// Width of the pre-laid-out canvas covering the render window.
     private var canvasWidth: CGFloat {
-        viewportWidth * CGFloat(totalSeconds / visibleSeconds)
+        viewportWidth * CGFloat(windowSeconds / visibleSeconds)
     }
 
-    /// Pixel offset of the canvas for the current leading-edge date.
+    /// Pixel offset of the canvas for the current leading-edge date. Derived,
+    /// not stored: re-anchoring the window recomputes it consistently.
     private var canvasOffsetX: CGFloat {
-        CGFloat(scrollPosition.timeIntervalSince(state.startMarker) / totalSeconds) * canvasWidth
+        CGFloat(scrollPosition.timeIntervalSince(renderWindowStart) / windowSeconds) * canvasWidth
+    }
+
+    /// Re-anchors the render window when the visible window nears its edge.
+    /// Between re-anchors, panning stays a pure offset transform.
+    func updateRenderWindow(force: Bool = false) {
+        let pad = MainChartHelper.Config.renderWindowPadFactor * visibleSeconds
+        let margin = MainChartHelper.Config.renderWindowMarginFactor * visibleSeconds
+        let domainStart = state.startMarker
+        let domainEnd = max(state.endMarker, domainStart.addingTimeInterval(1))
+        // Trailing overscan can push the visible window past the domain; the
+        // window itself never exceeds the domain, so compare clamped edges.
+        let visibleStart = max(scrollPosition, domainStart)
+        let visibleEnd = min(scrollPosition.addingTimeInterval(visibleSeconds), domainEnd)
+
+        let nearLeft = visibleStart.timeIntervalSince(renderWindowStart) < margin
+            && renderWindowStart > domainStart
+        let nearRight = renderWindowEnd.timeIntervalSince(visibleEnd) < margin
+            && renderWindowEnd < domainEnd
+        let uncovered = visibleStart < renderWindowStart || visibleEnd > renderWindowEnd
+        guard force || nearLeft || nearRight || uncovered else { return }
+
+        let newStart = max(visibleStart.addingTimeInterval(-pad), domainStart)
+        let newEnd = min(visibleEnd.addingTimeInterval(pad), domainEnd)
+        guard newStart != renderWindowStart || newEnd != renderWindowEnd else { return }
+        renderWindowStart = newStart
+        renderWindowEnd = newEnd
     }
 
     /// Glucose y-domain padded above and below so values at the data extremes (and the carb
@@ -392,10 +443,11 @@ extension MainChartView {
         let next = presets.first(where: { $0 > visibleSeconds + 1 }) ?? presets[0]
         let trailing = scrollPosition.addingTimeInterval(visibleSeconds)
         momentumTask?.cancel()
-        withAnimation(.easeInOut(duration: 0.25)) {
-            visibleSeconds = next
-            scrollPosition = clampedLeadingEdge(trailing.addingTimeInterval(-next))
-        }
+        // Snap, like pinch commits: animating the zoom animates canvasWidth,
+        // which re-lays the canvas every animation frame.
+        visibleSeconds = next
+        scrollPosition = clampedLeadingEdge(trailing.addingTimeInterval(-next))
+        updateRenderWindow(force: true)
     }
 
     /// Clamps a proposed leading edge so the visible window never leaves the chart's domain.
@@ -610,38 +662,67 @@ extension MainChartView {
                 }
                 guard let pinch = pinchAnchor, value.magnification > 0 else { return }
 
-                // Pinch out (magnification > 1) narrows the visible window, i.e. zooms in.
-                var proposed = pinch.visibleAtStart / TimeInterval(value.magnification)
-                proposed = min(
-                    max(proposed, MainChartHelper.Config.minVisibleSeconds),
+                // Live pinch previews as a transform: stretch the already-
+                // laid-out canvas about the centroid. Pinch out
+                // (magnification > 1) narrows the visible window, i.e. zooms
+                // in. Once the stretch drifts past the commit threshold, a
+                // crisp re-layout is committed mid-gesture and the transform
+                // continues from that new baseline.
+                let proposed = min(
+                    max(pinch.visibleAtStart / TimeInterval(value.magnification), MainChartHelper.Config.minVisibleSeconds),
                     MainChartHelper.Config.maxVisibleSeconds
                 )
-                // Snap to the geometric zoom grid (~4 % steps): a full halving of the
-                // window costs ~18 canvas re-layouts instead of hundreds.
-                let ratio = MainChartHelper.Config.zoomStepRatio
-                let step = (log(proposed / MainChartHelper.Config.defaultVisibleSeconds) / log(ratio)).rounded()
-                proposed = MainChartHelper.Config.defaultVisibleSeconds * pow(ratio, step)
-                proposed = min(
-                    max(proposed, MainChartHelper.Config.minVisibleSeconds),
-                    MainChartHelper.Config.maxVisibleSeconds
-                )
+                pinchScale = CGFloat(visibleSeconds / proposed)
 
-                guard proposed != visibleSeconds else {
-                    // Still keep the anchor pinned while between grid steps.
-                    scrollPosition = clampedLeadingEdge(
-                        pinch.anchorDate.addingTimeInterval(-visibleSeconds * pinch.anchorFraction)
-                    )
-                    return
+                let drift = MainChartHelper.Config.pinchCommitScaleDrift
+                if pinchScale > drift || pinchScale < 1 / drift {
+                    commitPinchZoom(proposed)
                 }
-
-                visibleSeconds = proposed
-                scrollPosition = clampedLeadingEdge(
-                    pinch.anchorDate.addingTimeInterval(-proposed * pinch.anchorFraction)
-                )
             }
             .onEnded { _ in
+                guard pinchAnchor != nil else { return }
+                commitPinchZoom(visibleSeconds / TimeInterval(pinchScale))
+                // The commit no-ops when the zoom quantizes back to the
+                // current value; the preview must still un-stretch.
+                pinchScale = 1
                 pinchAnchor = nil
             }
+    }
+
+    /// Quantizes to the geometric zoom grid and re-lays the canvas exactly
+    /// once: window re-anchor happens in the same transaction, else the
+    /// commit first lays out the OLD window at the new zoom (a canvas up to
+    /// 12x the viewport) before re-laying at the right size.
+    private func commitPinchZoom(_ proposed: TimeInterval) {
+        guard let pinch = pinchAnchor else { return }
+        let ratio = MainChartHelper.Config.zoomStepRatio
+        let step = (log(proposed / MainChartHelper.Config.defaultVisibleSeconds) / log(ratio)).rounded()
+        var quantized = MainChartHelper.Config.defaultVisibleSeconds * pow(ratio, step)
+        quantized = min(
+            max(quantized, MainChartHelper.Config.minVisibleSeconds),
+            MainChartHelper.Config.maxVisibleSeconds
+        )
+        // A no-op commit would just snap the preview back to 1 with no fresh
+        // layout to justify it.
+        guard quantized != visibleSeconds else { return }
+
+        visibleSeconds = quantized
+        scrollPosition = clampedLeadingEdge(
+            pinch.anchorDate.addingTimeInterval(-quantized * pinch.anchorFraction)
+        )
+        updateRenderWindow(force: true)
+        pinchScale = 1
+    }
+
+    /// Anchor for the live-pinch stretch: the centroid's layout position on
+    /// the canvas, so the content under the fingers stays put on screen.
+    private var pinchScaleAnchor: UnitPoint {
+        guard let pinch = pinchAnchor, canvasWidth > 0 else { return .center }
+        // The scale composes on top of the already-offset render, anchored in
+        // the canvas's layout frame (origin at viewport 0) — so the centroid's
+        // viewport position is the anchor and the content under the fingers
+        // stays put on screen.
+        return UnitPoint(x: pinch.anchorFraction * viewportWidth / canvasWidth, y: 0.5)
     }
 }
 
@@ -705,6 +786,9 @@ struct MainChartCanvas: View {
     var displayYgridLines: Bool
     var thresholdLines: Bool
     var visibleSeconds: TimeInterval
+    /// Rendered slice of the domain; all panes share this x-scale.
+    var windowStart: Date
+    var windowEnd: Date
     var canvasWidth: CGFloat
     var basalHeight: CGFloat
     var mainHeight: CGFloat
@@ -725,6 +809,44 @@ struct MainChartCanvas: View {
 
     var upperLimit: Decimal {
         units == .mgdL ? 400 : 22.2
+    }
+
+    // The point series sliced to the render window: marks outside the window
+    // clip invisibly but still cost layout, so with 72h loaded an unfiltered
+    // re-layout (every pinch step) does 3x the work for nothing.
+    var windowedGlucose: [GlucoseStored] {
+        state.glucoseFromPersistence.filter { entry in
+            guard let date = entry.date else { return false }
+            return date >= windowStart && date <= windowEnd
+        }
+    }
+
+    var windowedInsulin: [PumpEventStored] {
+        state.insulinFromPersistence.filter { entry in
+            guard let date = entry.timestamp else { return false }
+            return date >= windowStart && date <= windowEnd
+        }
+    }
+
+    var windowedCarbs: [CarbEntryStored] {
+        state.carbsFromPersistence.filter { entry in
+            guard let date = entry.date else { return false }
+            return date >= windowStart && date <= windowEnd
+        }
+    }
+
+    var windowedFPUs: [CarbEntryStored] {
+        state.fpusFromPersistence.filter { entry in
+            guard let date = entry.date else { return false }
+            return date >= windowStart && date <= windowEnd
+        }
+    }
+
+    var windowedDeterminations: [OrefDetermination] {
+        state.enactedAndNonEnactedDeterminations.filter { entry in
+            guard let date = entry.deliverAt else { return false }
+            return date >= windowStart && date <= windowEnd
+        }
     }
 
     var body: some View {
@@ -768,7 +890,7 @@ extension MainChartCanvas {
             )
 
             GlucoseChartView(
-                glucoseData: state.glucoseFromPersistence,
+                glucoseData: windowedGlucose,
                 units: state.units,
                 highGlucose: state.highGlucose,
                 lowGlucose: state.lowGlucose,
@@ -778,17 +900,17 @@ extension MainChartCanvas {
             )
 
             InsulinView(
-                glucoseData: state.glucoseFromPersistence,
-                insulinData: state.insulinFromPersistence,
+                glucoseData: windowedGlucose,
+                insulinData: windowedInsulin,
                 units: state.units,
                 bolusDisplayThreshold: state.bolusDisplayThreshold
             )
 
             CarbView(
-                glucoseData: state.glucoseFromPersistence,
+                glucoseData: windowedGlucose,
                 units: state.units,
-                carbData: state.carbsFromPersistence,
-                fpuData: state.fpusFromPersistence,
+                carbData: windowedCarbs,
+                fpuData: windowedFPUs,
                 minValue: units == .mgdL ? state.minYAxisValue : state.minYAxisValue
                     .asMmolL
             )
@@ -804,7 +926,7 @@ extension MainChartCanvas {
             )
         }
         .frame(width: canvasWidth, height: mainHeight)
-        .chartXScale(domain: state.startMarker ... state.endMarker)
+        .chartXScale(domain: windowStart ... windowEnd)
         .chartXAxis { mainChartXAxis }
         .chartYAxis(.hidden)
         .chartYScale(domain: glucoseYDomain)
@@ -835,6 +957,8 @@ extension MainChartCanvas: Equatable {
             lhs.displayYgridLines == rhs.displayYgridLines &&
             lhs.thresholdLines == rhs.thresholdLines &&
             lhs.visibleSeconds == rhs.visibleSeconds &&
+            lhs.windowStart == rhs.windowStart &&
+            lhs.windowEnd == rhs.windowEnd &&
             lhs.canvasWidth == rhs.canvasWidth &&
             lhs.basalHeight == rhs.basalHeight &&
             lhs.mainHeight == rhs.mainHeight &&

--- a/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -866,7 +866,14 @@ struct MainChartCanvas: View {
 
 extension MainChartCanvas {
     var mainChart: some View {
-        Chart {
+        // slice each series once per layout; these were computed properties
+        // re-evaluated on every reference (glucose alone was scanned 3x)
+        let glucose = windowedGlucose
+        let insulin = windowedInsulin
+        let carbs = windowedCarbs
+        let fpus = windowedFPUs
+
+        return Chart {
             drawCurrentTimeMarker()
             drawThresholdLines()
 
@@ -890,7 +897,7 @@ extension MainChartCanvas {
             )
 
             GlucoseChartView(
-                glucoseData: windowedGlucose,
+                glucoseData: glucose,
                 units: state.units,
                 highGlucose: state.highGlucose,
                 lowGlucose: state.lowGlucose,
@@ -900,17 +907,17 @@ extension MainChartCanvas {
             )
 
             InsulinView(
-                glucoseData: windowedGlucose,
-                insulinData: windowedInsulin,
+                glucoseData: glucose,
+                insulinData: insulin,
                 units: state.units,
                 bolusDisplayThreshold: state.bolusDisplayThreshold
             )
 
             CarbView(
-                glucoseData: windowedGlucose,
+                glucoseData: glucose,
                 units: state.units,
-                carbData: windowedCarbs,
-                fpuData: windowedFPUs,
+                carbData: carbs,
+                fpuData: fpus,
                 minValue: units == .mgdL ? state.minYAxisValue : state.minYAxisValue
                     .asMmolL
             )

--- a/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -457,14 +457,20 @@ extension MainChartView {
         return min(max(proposed, earliest), max(earliest, latest))
     }
 
-    /// Anchors the visible window just past `state.endMarker`.
+    /// Anchors the visible window so the current reading stays on-screen at any zoom.
     private func scrollToTrailingEdge() {
         // Never yank the chart out from under an active gesture (pan, pinch, or an
         // in-progress inspect/scrub); the next data tick after the gesture ends will
         // re-anchor to trailing as before.
         guard !isPinching, panBaseline == nil, !isInspectLatched else { return }
         momentumTask?.cancel()
-        scrollPosition = state.endMarker.addingTimeInterval(trailingOverscan - visibleSeconds)
+        // Wide zoom keeps the forecast-anchored framing; tighter zoom (where anchoring to
+        // endMarker pushed `now` off the left) re-anchors to `now` plus a proportional peek.
+        let forecastAnchoredTrailing = state.endMarker.addingTimeInterval(trailingOverscan)
+        let nowAnchoredTrailing = Date.now
+            .addingTimeInterval(visibleSeconds * MainChartHelper.Config.followForecastPeekFraction)
+        let trailingEdge = min(forecastAnchoredTrailing, nowAnchoredTrailing)
+        scrollPosition = clampedLeadingEdge(trailingEdge.addingTimeInterval(-visibleSeconds))
     }
 
     /// One-finger gesture: movement pans (with momentum on release); a press held in

--- a/Trio/Sources/Modules/Home/View/Header/SensorLifecycle/SensorLifecycleArcView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/SensorLifecycle/SensorLifecycleArcView.swift
@@ -2,10 +2,12 @@ import LoopKit
 import LoopKitUI
 import SwiftUI
 
-/// Concentric outer ring around the glucose bobble that drains clockwise from
-/// 12 o'clock as the sensor session ages. Always renders a faint track behind
-/// the fill so the indicator's footprint is visible even at `progress == 0`.
+/// Concentric outer ring around the glucose bobble that counts down: the arc
+/// starts full and drains back toward 12 o'clock as the phase elapses, since
+/// warmup, grace period, and lifetime are all countdowns. A faint track stays
+/// behind the arc so the footprint remains visible when nearly depleted.
 struct SensorLifecycleArcView: View {
+    /// Elapsed fraction of the lifecycle phase (LoopKit `percentComplete`).
     let progress: Double
     let progressState: DeviceLifecycleProgressState
 
@@ -32,9 +34,11 @@ struct SensorLifecycleArcView: View {
                 .stroke(Color.secondary.opacity(0.4), lineWidth: Self.strokeWidth)
 
             Circle()
-                .trim(from: 0, to: max(0, min(1, progress)))
+                .trim(from: 0, to: 1 - max(0, min(1, progress)))
                 .stroke(arcColor, style: StrokeStyle(lineWidth: Self.strokeWidth, lineCap: .round))
                 .rotationEffect(.degrees(-90))
+                // mirror: the arc extends counterclockwise and drains back into 12 o'clock
+                .scaleEffect(x: -1)
                 .animation(.easeInOut(duration: 0.25), value: progress)
         }
         .frame(width: Self.diameter, height: Self.diameter)
@@ -44,10 +48,10 @@ struct SensorLifecycleArcView: View {
 
 #Preview("Arc — progress states") {
     VStack(spacing: 24) {
-        SensorLifecycleArcView(progress: 0.15, progressState: .normalCGM)
+        SensorLifecycleArcView(progress: 0.15, progressState: .normalCGM) // nearly full
         SensorLifecycleArcView(progress: 0.55, progressState: .normalCGM)
-        SensorLifecycleArcView(progress: 0.92, progressState: .warning)
-        SensorLifecycleArcView(progress: 1.0, progressState: .critical)
+        SensorLifecycleArcView(progress: 0.92, progressState: .warning) // almost drained
+        SensorLifecycleArcView(progress: 1.0, progressState: .critical) // track only
     }
     .padding(40)
     .background(Color.black)

--- a/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
@@ -604,9 +604,16 @@ extension Home.RootView {
                                 Text(tirString)
                                     .font(.title2).fontWeight(.bold).fontDesign(.rounded)
                                     .foregroundStyle(.primary)
-                                Text("Time in Range", comment: "Stats banner subtitle")
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
+                                // chart shows 72h; make the daily scope explicit
+                                (
+                                    Text("Time in Range", comment: "Stats banner subtitle").fontWeight(.semibold)
+                                        + Text(" ")
+                                        + Text("today", comment: "Stats banner scope")
+                                )
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.8)
                             }
 
                             statsDistributionBar(segments)
@@ -614,9 +621,15 @@ extension Home.RootView {
                         }
                     case .distributionBar:
                         VStack(alignment: .leading, spacing: 6) {
-                            Text("Time in Range", comment: "Stats banner subtitle")
-                                .font(.subheadline).fontWeight(.semibold)
-                                .foregroundStyle(.secondary)
+                            (
+                                Text("Time in Range", comment: "Stats banner subtitle").fontWeight(.semibold)
+                                    + Text(" ")
+                                    + Text("today", comment: "Stats banner scope")
+                            )
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.8)
 
                             statsDistributionBar(segments)
                                 .frame(height: 6)


### PR DESCRIPTION
Part 6 of 7 of the home layout v2 series, stacked on `home-refactor-72h`.

The CGM lifecycle arc around the glucose bobble now renders the remaining fraction instead of elapsed: it starts full and drains clockwise into 12 o'clock (mirrored trim), timer-style, for warm-up, grace period, and lifetime. State colors are untouched.

| Before | After |
|--------|--------|
| <img width="456" height="184" alt="image" src="https://github.com/user-attachments/assets/bc1d1b6b-6b80-476c-966d-1b06c3c717ed" /> | <img width="457" height="207" alt="image" src="https://github.com/user-attachments/assets/cd55e0e0-3f56-4e7d-9818-df1adf1b6198" /> | 

