### PR TITLE
[Part 7 of 7] Home Layout v2 – Enable Liquid Glass and adapt home chrome

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		7A11AC0DE000000000000106 /* HomeRootView+Refresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000006 /* HomeRootView+Refresh.swift */; };
 		7A11AC0DE000000000000111 /* HomeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000011 /* HomeLayout.swift */; };
 		7A11AC0DE000000000000113 /* MultiUsePanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000013 /* MultiUsePanelState.swift */; };
+		7A11AC0DE000000000000116 /* GlassChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000016 /* GlassChrome.swift */; };
 		7A11AC0DE000000000000110 /* HomeRootView+BottomControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000010 /* HomeRootView+BottomControls.swift */; };
 		7A11AC0DE00000000000010E /* HomeRootView+MealPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE00000000000000E /* HomeRootView+MealPanel.swift */; };
 		7A11AC0DE00000000000010D /* HomeRootView+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE00000000000000D /* HomeRootView+Header.swift */; };
@@ -1095,6 +1096,7 @@
 		7A11AC0DE000000000000006 /* HomeRootView+Refresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+Refresh.swift"; sourceTree = "<group>"; };
 		7A11AC0DE000000000000011 /* HomeLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLayout.swift; sourceTree = "<group>"; };
 		7A11AC0DE000000000000013 /* MultiUsePanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiUsePanelState.swift; sourceTree = "<group>"; };
+		7A11AC0DE000000000000016 /* GlassChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassChrome.swift; sourceTree = "<group>"; };
 		7A11AC0DE000000000000010 /* HomeRootView+BottomControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+BottomControls.swift"; sourceTree = "<group>"; };
 		7A11AC0DE00000000000000E /* HomeRootView+MealPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+MealPanel.swift"; sourceTree = "<group>"; };
 		7A11AC0DE00000000000000D /* HomeRootView+Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+Header.swift"; sourceTree = "<group>"; };
@@ -2398,6 +2400,7 @@
 				7A11AC0DE000000000000006 /* HomeRootView+Refresh.swift */,
 				7A11AC0DE000000000000011 /* HomeLayout.swift */,
 				7A11AC0DE000000000000013 /* MultiUsePanelState.swift */,
+				7A11AC0DE000000000000016 /* GlassChrome.swift */,
 				7A11AC0DE000000000000010 /* HomeRootView+BottomControls.swift */,
 				7A11AC0DE00000000000000E /* HomeRootView+MealPanel.swift */,
 				7A11AC0DE00000000000000D /* HomeRootView+Header.swift */,
@@ -5181,6 +5184,7 @@
 				7A11AC0DE000000000000106 /* HomeRootView+Refresh.swift in Sources */,
 				7A11AC0DE000000000000111 /* HomeLayout.swift in Sources */,
 				7A11AC0DE000000000000113 /* MultiUsePanelState.swift in Sources */,
+				7A11AC0DE000000000000116 /* GlassChrome.swift in Sources */,
 				7A11AC0DE000000000000110 /* HomeRootView+BottomControls.swift in Sources */,
 				7A11AC0DE00000000000010E /* HomeRootView+MealPanel.swift in Sources */,
 				7A11AC0DE00000000000010D /* HomeRootView+Header.swift in Sources */,

--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -922,6 +922,7 @@
 		FA6B58486AE2496F9F8589C6 /* QuickPickBolusesConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EEC5C2927FA4C5DA61A1A40 /* QuickPickBolusesConfigProvider.swift */; };
 		FE41E4D629463EE20047FD55 /* NightscoutPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */; };
 		FE66D16B291F74F8005D6F77 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */; };
+		7A11AC0DE000000000000030 /* UIHostingController+KeyboardSafeArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000130 /* UIHostingController+KeyboardSafeArea.swift */; };
 		FEFFA7A22929FE49007B8193 /* UIDevice+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */; };
 /* End PBXBuildFile section */
 
@@ -1939,6 +1940,7 @@
 		FBB3BAE7494CB771ABAC7B8B /* ISFEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorRootView.swift; sourceTree = "<group>"; };
 		FE41E4D529463EE20047FD55 /* NightscoutPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutPreferences.swift; sourceTree = "<group>"; };
 		FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
+		7A11AC0DE000000000000130 /* UIHostingController+KeyboardSafeArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIHostingController+KeyboardSafeArea.swift"; sourceTree = "<group>"; };
 		FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIDevice+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -2835,6 +2837,7 @@
 				3EF667122FE48502009FB31A /* BasalDeliveryState+Extension.swift */,
 				DD1DB7CB2BECCA1F0048B367 /* BuildDetails.swift */,
 				FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */,
+				7A11AC0DE000000000000130 /* UIHostingController+KeyboardSafeArea.swift */,
 				BD249DA62D42FE3800412DEB /* Calendar+GlucoseStatsChart.swift */,
 				CEF1ED6A2D58FB4600FAF41E /* CGMOptions.swift */,
 				38F37827261260DC009DB701 /* Color+Extensions.swift */,
@@ -5285,6 +5288,7 @@
 				38A504A425DD9C4000C5B9E8 /* UserDefaultsExtensions.swift in Sources */,
 				38FE826A25CC82DB001FF17A /* NetworkService.swift in Sources */,
 				FE66D16B291F74F8005D6F77 /* Bundle+Extensions.swift in Sources */,
+				7A11AC0DE000000000000030 /* UIHostingController+KeyboardSafeArea.swift in Sources */,
 				DD940BAC2CA75889000830A5 /* DynamicGlucoseColor.swift in Sources */,
 				3883581C25EE79BB00E024B2 /* TextFieldWithToolBar.swift in Sources */,
 				58D08B302C8DEA7500AA37D3 /* ForecastView.swift in Sources */,

--- a/Trio/Resources/Info.plist
+++ b/Trio/Resources/Info.plist
@@ -108,7 +108,7 @@
 		<string>audio</string>
 	</array>
 	<key>UIDesignRequiresCompatibility</key>
-	<true/>
+	<false/>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/Trio/Sources/Application/TrioApp.swift
+++ b/Trio/Sources/Application/TrioApp.swift
@@ -365,6 +365,7 @@ extension Notification.Name {
                 if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                    let rootVC = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController
                 {
+                    rootVC.excludeKeyboardFromSafeAreaTree()
                     AppVersionChecker.shared.checkAndNotifyVersionStatus(in: rootVC)
                 }
                 if initState.complete {

--- a/Trio/Sources/Helpers/UIHostingController+KeyboardSafeArea.swift
+++ b/Trio/Sources/Helpers/UIHostingController+KeyboardSafeArea.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Lets us reach the WindowGroup's generic root hosting controller without
+/// knowing its view type, to exclude the keyboard from its safe area.
+protocol KeyboardSafeAreaExcludable {
+    func excludeKeyboardFromSafeArea()
+}
+
+extension UIHostingController: KeyboardSafeAreaExcludable {
+    func excludeKeyboardFromSafeArea() {
+        if #available(iOS 16.4, *) {
+            safeAreaRegions = .container
+        }
+    }
+}
+
+extension UIViewController {
+    /// Walk down to the root hosting controller and drop its keyboard safe area.
+    /// iOS sometimes replays a stale keyboard frame on foreground, which
+    /// compresses the keyboard-free home layout until a rotation recomputes it.
+    func excludeKeyboardFromSafeAreaTree() {
+        (self as? KeyboardSafeAreaExcludable)?.excludeKeyboardFromSafeArea()
+        for child in children {
+            child.excludeKeyboardFromSafeAreaTree()
+        }
+    }
+}

--- a/Trio/Sources/Modules/Home/View/GlassChrome.swift
+++ b/Trio/Sources/Modules/Home/View/GlassChrome.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/// Shared chrome for the Home panels: real Liquid Glass on iOS 26,
+/// material approximation below.
+enum GlassChrome {
+    /// system-glass panel rounding (not the design patch's 17pt)
+    static let panelCornerRadius: CGFloat = 26
+
+    static var panelShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: panelCornerRadius, style: .continuous)
+    }
+}
+
+/// Glass panel background with optional tint; pre-26 falls back to
+/// ultraThinMaterial + tint fill + stroke, matching the compat-mode look.
+struct GlassPanelBackground: ViewModifier {
+    var tint: Color?
+    var tintOpacity: Double = 0.12
+    var strokeOpacity: Double = 0.35
+    var strokeWidth: CGFloat = 1
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(
+                    tint.map { Glass.regular.tint($0.opacity(tintOpacity)) } ?? .regular,
+                    in: .rect(cornerRadius: GlassChrome.panelCornerRadius, style: .continuous)
+                )
+                // faint rim keeps tinted panels legible on busy backgrounds
+                .overlay(GlassChrome.panelShape.strokeBorder(
+                    (tint ?? Color.primary).opacity(strokeOpacity * 0.6),
+                    lineWidth: strokeWidth
+                ))
+        } else {
+            content
+                .background(
+                    GlassChrome.panelShape
+                        .fill(.ultraThinMaterial)
+                        .overlay(GlassChrome.panelShape.fill((tint ?? .clear).opacity(tintOpacity)))
+                        .overlay(GlassChrome.panelShape.strokeBorder(
+                            (tint ?? Color.primary).opacity(strokeOpacity),
+                            lineWidth: strokeWidth
+                        ))
+                        .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.25 : 0.10), radius: 3, y: 1)
+                )
+        }
+    }
+}
+
+extension View {
+    func glassPanel(
+        tint: Color? = nil,
+        tintOpacity: Double = 0.12,
+        strokeOpacity: Double = 0.35,
+        strokeWidth: CGFloat = 1
+    ) -> some View {
+        modifier(GlassPanelBackground(
+            tint: tint,
+            tintOpacity: tintOpacity,
+            strokeOpacity: strokeOpacity,
+            strokeWidth: strokeWidth
+        ))
+    }
+}

--- a/Trio/Sources/Modules/Home/View/HomeLayout.swift
+++ b/Trio/Sources/Modules/Home/View/HomeLayout.swift
@@ -18,7 +18,7 @@ enum HomeLayout {
     static let refreshTriggerDistance: CGFloat = 70
     /// indicator row height while the loop runs
     static let refreshIndicatorHeight: CGFloat = 40
-    /// minimum usable chart height; must stay below the natural SE allocation
-    /// (598 − header − meal slot − bottom zone = 238) or the bottom zone overflows
-    static let chartMinHeight: CGFloat = 220
+    /// last-resort chart floor; must stay below the tightest natural allocation
+    /// (SE under the iOS 26 tab bar + accessory leaves ~140) or the bottom zone overflows
+    static let chartMinHeight: CGFloat = 130
 }

--- a/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
@@ -321,53 +321,14 @@ extension Home.RootView {
         let isConcurrent = overrideString != nil && tempTargetString != nil
 
         ZStack {
-            RoundedRectangle(cornerRadius: 17, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay(
-                    Group {
-                        if isConcurrent {
-                            HStack(spacing: 0) {
-                                Color.purple.opacity(0.12)
-                                Color.loopGreen.opacity(0.12)
-                            }
-                            .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
-                        } else {
-                            RoundedRectangle(cornerRadius: 17, style: .continuous)
-                                .fill((tint ?? Color.clear).opacity(0.12))
-                        }
-                    }
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 17, style: .continuous)
-                        .strokeBorder(
-                            isConcurrent
-                                ? AnyShapeStyle(LinearGradient(
-                                    colors: [Color.purple.opacity(0.30), Color.loopGreen.opacity(0.30)],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                ))
-                                : AnyShapeStyle((tint ?? Color.primary).opacity(tint == nil ? 0.08 : 0.30)),
-                            lineWidth: 1
-                        )
-                )
-                .frame(height: HomeLayout.bottomPanelHeight)
-                .overlay(alignment: .bottom) {
-                    // anchored like the bolus progress bar so both panels match
-                    Group {
-                        if isConcurrent {
-                            HStack(spacing: 6) {
-                                remainingBar(overrideRemainingFraction, tint: .purple)
-                                remainingBar(tempTargetRemainingFraction, tint: .loopGreen)
-                            }
-                        } else if let tint = tint {
-                            remainingBar(overrideRemainingFraction ?? tempTargetRemainingFraction, tint: tint)
-                        }
-                    }
-                    .padding(.horizontal, 18)
-                    .padding(.bottom, 1)
+            if isConcurrent {
+                // halved tint layer the single-tint glass chrome can't express
+                HStack(spacing: 0) {
+                    Color.purple.opacity(0.12)
+                    Color.loopGreen.opacity(0.12)
                 }
-                .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
-                .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.25 : 0.10), radius: 3, y: 1)
+                .clipShape(GlassChrome.panelShape)
+            }
             HStack {
                 if let overrideString = overrideString, let tempTargetString = tempTargetString {
                     // content halves match the tint halves so icons clear the seam
@@ -437,6 +398,40 @@ extension Home.RootView {
                     Text("Select Adjustment")
                 }
         }
+        .frame(height: HomeLayout.bottomPanelHeight)
+        .glassPanel(
+            tint: isConcurrent ? nil : tint,
+            tintOpacity: 0.12,
+            strokeOpacity: isConcurrent ? 0 : (tint == nil ? 0.08 : 0.30)
+        )
+        .overlay(
+            // concurrent halves get a bicolor rim the single-tint chrome can't express
+            isConcurrent
+                ? GlassChrome.panelShape.strokeBorder(
+                    LinearGradient(
+                        colors: [Color.purple.opacity(0.30), Color.loopGreen.opacity(0.30)],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    ),
+                    lineWidth: 1
+                )
+                : nil
+        )
+        .overlay(alignment: .bottom) {
+            // anchored like the bolus progress bar so both panels match
+            Group {
+                if isConcurrent {
+                    HStack(spacing: 6) {
+                        remainingBar(overrideRemainingFraction, tint: .purple)
+                        remainingBar(tempTargetRemainingFraction, tint: .loopGreen)
+                    }
+                } else if let tint = tint {
+                    remainingBar(overrideRemainingFraction ?? tempTargetRemainingFraction, tint: tint)
+                }
+            }
+            .padding(.horizontal, 18)
+            .padding(.bottom, 1)
+        }
         // whole panel navigates; the cancel buttons' own gestures take precedence
         .contentShape(Rectangle())
         .onTapGesture {
@@ -459,61 +454,46 @@ extension Home.RootView {
             let bolusLabel = state
                 .bolusStatus == .inProgress ? String(localized: "Bolusing") : String(localized: "Initiating…")
 
-            ZStack {
-                /// rectangle as background
-                RoundedRectangle(cornerRadius: 15)
-                    .fill(
-                        colorScheme == .dark ? Color(red: 0.03921568627, green: 0.133333333, blue: 0.2156862745) : Color
-                            .insulin
-                            .opacity(0.2)
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: 15))
-                    .frame(height: HomeLayout.bottomPanelHeight)
-                    .shadow(
-                        color: colorScheme == .dark ? Color(red: 0.02745098039, green: 0.1098039216, blue: 0.1411764706) :
-                            Color.black.opacity(0.33),
-                        radius: 3
-                    )
+            HStack {
+                Image(systemName: "cross.vial.fill")
+                    .font(.system(size: 25))
 
-                /// actual bolus view
-                HStack {
-                    Image(systemName: "cross.vial.fill")
-                        .font(.system(size: 25))
+                Spacer()
 
-                    Spacer()
+                VStack {
+                    Text(bolusLabel)
+                        .font(.subheadline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text(bolusString)
+                        .font(.caption)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }.padding(.leading, 5)
 
-                    VStack {
-                        Text(bolusLabel)
-                            .font(.subheadline)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        Text(bolusString)
-                            .font(.caption)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }.padding(.leading, 5)
+                Spacer()
 
-                    Spacer()
-
-                    if state.bolusStatus == .inProgress {
-                        Button {
-                            state.showProgressView()
-                            state.cancelBolus()
-                        } label: {
-                            Image(systemName: "xmark.app")
-                                .font(.system(size: 25))
-                        }
-                    } else if state.bolusStatus == .initiating {
-                        ProgressView()
+                if state.bolusStatus == .inProgress {
+                    Button {
+                        state.showProgressView()
+                        state.cancelBolus()
+                    } label: {
+                        Image(systemName: "xmark.app")
+                            .font(.system(size: 25))
                     }
-                }.padding(.horizontal, 10)
-                    .padding(.trailing, 8)
+                } else if state.bolusStatus == .initiating {
+                    ProgressView()
+                }
             }
             .padding(.horizontal, 10)
+            .padding(.trailing, 8)
+            .frame(height: HomeLayout.bottomPanelHeight)
+            .glassPanel(tint: .insulin, tintOpacity: 0.18, strokeOpacity: 0.30)
             .overlay(alignment: .bottom) {
                 // bar hugs the panel's bottom edge (the slot no longer has outer bottom padding)
                 BolusProgressBar(progress: progress)
                     .padding(.horizontal, 18)
                     .padding(.bottom, 1)
-            }.clipShape(RoundedRectangle(cornerRadius: 15))
+            }
+            .padding(.horizontal, 10)
         }
     }
 
@@ -582,20 +562,6 @@ extension Home.RootView {
             state.showModal(for: .statistics)
         } label: {
             ZStack {
-                RoundedRectangle(cornerRadius: 17, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 17, style: .continuous)
-                            .fill(Color.insulin.opacity(0.08))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 17, style: .continuous)
-                            .strokeBorder(Color.insulin.opacity(0.35), lineWidth: 1)
-                    )
-                    .frame(height: HomeLayout.statsBannerHeight)
-                    .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
-                    .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.25 : 0.10), radius: 3, y: 1)
-
                 HStack(alignment: .center, spacing: 12) {
                     switch face {
                     case .timeInRange:
@@ -653,6 +619,8 @@ extension Home.RootView {
                 }
                 .padding(.horizontal, 16)
             }
+            .frame(height: HomeLayout.statsBannerHeight)
+            .glassPanel()
             .padding(.horizontal, 10)
             .contentShape(Rectangle())
         }
@@ -680,20 +648,6 @@ extension Home.RootView {
     ) -> some View {
         Button(action: action) {
             ZStack {
-                RoundedRectangle(cornerRadius: 17, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 17, style: .continuous)
-                            .fill(tint.opacity(isCritical ? 0.30 : 0.12))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 17, style: .continuous)
-                            .strokeBorder(tint.opacity(isCritical ? 0.8 : 0.35), lineWidth: isCritical ? 1.5 : 1)
-                    )
-                    .frame(height: HomeLayout.statsBannerHeight)
-                    .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
-                    .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.25 : 0.10), radius: 3, y: 1)
-
                 HStack(spacing: 12) {
                     adjustmentIcon(systemImage, tint: tint)
 
@@ -714,6 +668,13 @@ extension Home.RootView {
                 }
                 .padding(.horizontal, 16)
             }
+            .frame(height: HomeLayout.statsBannerHeight)
+            .glassPanel(
+                tint: tint,
+                tintOpacity: isCritical ? 0.30 : 0.12,
+                strokeOpacity: isCritical ? 0.8 : 0.35,
+                strokeWidth: isCritical ? 1.5 : 1
+            )
             .padding(.horizontal, 10)
             .contentShape(Rectangle())
         }

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -25,6 +25,7 @@ extension Home {
         @State var isMenuPresented = false
         @State var showTreatments = false
         @State var selectedTab: Int = 0
+        static let treatmentTabTag = 4
         @State var showQuickBolusPicker = false
         @State var showQuickBolusNoHistory = false
         @State var showPumpSelection: Bool = false
@@ -300,6 +301,131 @@ extension Home {
         }
 
         @ViewBuilder func tabBar() -> some View {
+            if #available(iOS 26.0, *) {
+                modernTabBar()
+            } else {
+                legacyTabBar()
+            }
+        }
+
+        /// Legacy layout on the glass bar: a dead middle slot with the
+        /// treatment button overlaid; the slot's selection is swallowed.
+        @available(iOS 26.0, *)
+        @ViewBuilder private func modernTabBar() -> some View {
+            ZStack(alignment: .bottom) {
+                TabView(selection: modernTabSelection) {
+                    let carbsRequiredBadge: String? = carbsRequiredBadgeValue
+
+                    NavigationStack { mainView() }
+                        .tabItem { Label("", systemImage: "chart.xyaxis.line") }
+                        .badge(carbsRequiredBadge).tag(0)
+                        .accessibilityLabel(Text("Main"))
+
+                    NavigationStack { History.RootView(resolver: resolver) }
+                        .tabItem { Label("", systemImage: historySFSymbol) }.tag(1)
+                        .accessibilityLabel(Text("History"))
+
+                    Spacer()
+                        // nbsp title + empty image: invisible item that still
+                        // holds a full-width slot for the overlaid button
+                        .tabItem { Label {
+                            Text(String(repeating: "\u{00A0}", count: 12))
+                        } icon: {
+                            Image(uiImage: UIImage())
+                        } }
+                        .tag(RootView.treatmentTabTag)
+
+                    NavigationStack { Adjustments.RootView(resolver: resolver) }
+                        .tabItem {
+                            Label(
+                                "",
+                                systemImage: "slider.horizontal.2.gobackward"
+                            ) }.tag(2)
+                        .accessibilityLabel(Text("Adjustments"))
+
+                    NavigationStack(path: self.$settingsPath) {
+                        Settings.RootView(resolver: resolver) }
+                        .environment(settingsSearchHighlight)
+                        .tabItem { Label(
+                            "",
+                            systemImage: "gear"
+                        ) }.tag(3)
+                        .accessibilityLabel(Text("Settings"))
+                }
+                .tint(Color.tabBar)
+
+                treatmentButton
+                    // the floating bar tracks the screen edge, not the safe area
+                    .padding(.bottom, 28)
+            }
+            .ignoresSafeArea(.container, edges: .bottom)
+            .ignoresSafeArea(.keyboard, edges: .bottom)
+            .blur(radius: state.waitForSuggestion ? 8 : 0)
+            .onChange(of: selectedTab) {
+                if selectedTab != 3, !settingsPath.isEmpty {
+                    settingsPath = NavigationPath()
+                }
+            }
+        }
+
+        private var modernTabSelection: Binding<Int> {
+            Binding(
+                get: { selectedTab },
+                set: { newValue in
+                    if newValue == RootView.treatmentTabTag {
+                        let previous = selectedTab
+                        selectedTab = newValue
+                        DispatchQueue.main.async {
+                            selectedTab = previous
+                        }
+                    } else {
+                        selectedTab = newValue
+                    }
+                }
+            )
+        }
+
+        private var treatmentButton: some View {
+            Image(systemName: "plus.circle.fill")
+                .font(.system(size: 40))
+                .foregroundStyle(Color.tabBar)
+                .padding(.vertical, 2)
+                .padding(.horizontal, 24)
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    state.showModal(for: .treatmentView)
+                }
+                .onLongPressGesture(minimumDuration: 0.5) {
+                    guard state.enableQuickBolus else { return }
+                    let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
+                    impactHeavy.impactOccurred()
+                    Task {
+                        await state.loadQuickBolusSuggestions()
+                        if state.quickBolusHistory.isEmpty {
+                            showQuickBolusNoHistory = true
+                        } else {
+                            showQuickBolusPicker = true
+                        }
+                    }
+                }
+                .accessibilityLabel(Text("Add Treatment"))
+        }
+
+        private var carbsRequiredBadgeValue: String? {
+            guard let carbsRequired = state.enactedAndNonEnactedDeterminations.first?.carbsRequired,
+                  state.showCarbsRequiredBadge
+            else {
+                return nil
+            }
+            let carbsRequiredDecimal = Decimal(carbsRequired)
+            if carbsRequiredDecimal > state.settingsManager.settings.carbsRequiredThreshold {
+                let numberAsNSNumber = NSDecimalNumber(decimal: carbsRequiredDecimal)
+                return (Formatter.decimalFormatterWithTwoFractionDigits.string(from: numberAsNSNumber) ?? "") + " g"
+            }
+            return nil
+        }
+
+        @ViewBuilder private func legacyTabBar() -> some View {
             ZStack(alignment: .bottom) {
                 TabView(selection: $selectedTab) {
                     let carbsRequiredBadge: String? = {
@@ -342,28 +468,7 @@ extension Home {
                 }
                 .tint(Color.tabBar)
 
-                Image(systemName: "plus.circle.fill")
-                    .font(.system(size: 40))
-                    .foregroundStyle(Color.tabBar)
-                    .padding(.vertical, 2)
-                    .padding(.horizontal, 24)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        state.showModal(for: .treatmentView)
-                    }
-                    .onLongPressGesture(minimumDuration: 0.5) {
-                        guard state.enableQuickBolus else { return }
-                        let impactHeavy = UIImpactFeedbackGenerator(style: .heavy)
-                        impactHeavy.impactOccurred()
-                        Task {
-                            await state.loadQuickBolusSuggestions()
-                            if state.quickBolusHistory.isEmpty {
-                                showQuickBolusNoHistory = true
-                            } else {
-                                showQuickBolusPicker = true
-                            }
-                        }
-                    }
+                treatmentButton
             }.ignoresSafeArea(.keyboard, edges: .bottom).blur(radius: state.waitForSuggestion ? 8 : 0)
                 .onChange(of: selectedTab) {
                     // reset only when leaving Settings; programmatic pushes survive the switch

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -354,9 +354,13 @@ extension Home {
                 }
                 .tint(Color.tabBar)
 
-                treatmentButton
-                    // the floating bar tracks the screen edge, not the safe area
-                    .padding(.bottom, 28)
+                // fixed distance from the physical screen bottom; immune to
+                // safe-area changes (keyboard, accessories)
+                GeometryReader { geo in
+                    treatmentButton
+                        .position(x: geo.size.width / 2, y: geo.size.height - 52)
+                }
+                .ignoresSafeArea(.all, edges: .bottom)
             }
             .ignoresSafeArea(.container, edges: .bottom)
             .ignoresSafeArea(.keyboard, edges: .bottom)

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -204,6 +204,8 @@ extension Home {
                     // fixed zones bust beyond XXL; cap dashboard type size
                     .dynamicTypeSize(...DynamicTypeSize.xxLarge)
             }
+            // no inline text input here; a stale keyboard inset must never shrink the zone budget
+            .ignoresSafeArea(.keyboard, edges: .bottom)
             .onAppear {
                 configureView()
                 refreshAlarmsSnooze()


### PR DESCRIPTION
Part 7 of 7 of the home layout v2 series, stacked on `home-refactor-sensor-arc`.

Turns off `UIDesignRequiresCompatibility`: real Liquid Glass on iOS 26 via a shared `GlassChrome` (glass panels with rim strokes, capsule and circle variants) with ultraThinMaterial fallbacks below 26. The adjustments card, multi-use/TIR banners, and bolus progress panel move onto the shared chrome; the adjustments card keeps split tints and a bicolor rim for concurrent override + temp target. The tab bar becomes icon-only with an invisible width-holding middle slot and the overlaid treatment button (tap = treatment sheet, long-press = quick bolus), centered via a small UIKit probe; the pre-26 tab bar is unchanged. The chart's minimum height drops to fit the taller iOS 26 bar geometry on SE-class devices.

Verified light/dark on SE3 + 17 Pro (iOS 26.5), Pro Max, and iPhone 16 Pro on iOS 18.5 for the legacy path.

| 17 Pro iOS 26.4 | SE 3 iOS 26.5 | 16 Pro iOS 18.5 |
|--------|--------|--------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/7f83aaf6-e4d9-4d83-a425-d8d2d7510c1e" /> | <img width="750" height="1334" alt="image" src="https://github.com/user-attachments/assets/52418457-2936-4ff6-b235-83f74138e60e" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/0c5ac731-db6e-423b-a352-ecd3119c2070" /> | 