### PR TITLE
Preserve non-manager CGM lifecycle state on Home

### DIFF
--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -498,31 +498,36 @@ extension Home {
                     // warmup / stabilizing / expiry. Simulator has no
                     // CGMManager, so fall back to reading its synthetic
                     // lifecycle / highlight so the bobble sees the same
-                    // data shape a real CGM would deliver.
+                    // data shape a real CGM would deliver. Other non-manager
+                    // sources publish their own state through `GlucoseSource`.
                     let manager = self.fetchGlucoseManager.cgmManager
                     let source = self.fetchGlucoseManager.glucoseSource
                     let progress: DeviceLifecycleProgress?
-                    let highlight: DeviceStatusHighlight?
+                    let displayState: CgmDisplayState?
                     if let manager {
                         progress = manager.cgmLifecycleProgress
-                        highlight = manager.cgmStatusHighlight
+                        displayState = manager.cgmStatusHighlight.map {
+                            CgmDisplayState(
+                                localizedMessage: $0.localizedMessage,
+                                imageName: $0.imageName,
+                                status: CgmDisplayStatus.from($0.state)
+                            )
+                        }
                     } else if let sim = source as? GlucoseSimulatorSource {
                         progress = sim.cgmLifecycleProgress
-                        highlight = sim.cgmStatusHighlight
+                        displayState = sim.cgmStatusHighlight.map {
+                            CgmDisplayState(
+                                localizedMessage: $0.localizedMessage,
+                                imageName: $0.imageName,
+                                status: CgmDisplayStatus.from($0.state)
+                            )
+                        }
                     } else {
-                        progress = nil
-                        highlight = nil
+                        progress = source?.cgmProgressHighlight.value
+                        displayState = source?.cgmDisplayState.value
                     }
                     self.cgmProgressHighlight = progress
-                    if let highlight {
-                        self.cgmDisplayState = CgmDisplayState(
-                            localizedMessage: highlight.localizedMessage,
-                            imageName: highlight.imageName,
-                            status: CgmDisplayStatus.from(highlight.state)
-                        )
-                    } else {
-                        self.cgmDisplayState = nil
-                    }
+                    self.cgmDisplayState = displayState
                     self.cgmSensorExpiresAt = Self.resolveSensorExpiresAt(
                         manager: manager,
                         glucoseSource: source,


### PR DESCRIPTION
## Summary

Preserve CGM lifecycle and status state published by non-manager `GlucoseSource` implementations on the Home screen.

This supports non-direct CGM connections such as xDrip4iOS AppGroup, where Trio receives lifecycle information through the glucose source rather than through a native `CGMManager`.

## Why

Home has a periodic refresh that re-reads CGM lifecycle and status information. Before this change, that refresh only used a native `CGMManager`, with a simulator fallback. Non-manager sources can publish lifecycle and status through `GlucoseSource`, but the refresh path cleared those values because no native manager exists.

The Home view also used `cgmSensorExpiresAt` as part of the sensor ring display gate. Non-manager sources can provide valid lifecycle progress without a manager-derived expiration date, so Home now tracks when progress came from a source publisher and allows that source-origin progress to render.

## Changes

- Preserve source-published lifecycle and status during the Home refresh for non-manager glucose sources.
- Track whether lifecycle progress came from a non-manager source.
- Allow source-origin lifecycle progress to show the sensor ring without requiring a native manager expiration date.
- Keep native `CGMManager` and simulator paths separate.

## Compatibility

This remains fully backward compatible with xDrip4iOS versions before v7. Legacy AppGroup payloads that only write the top-level readings array continue to publish nil lifecycle and status state, so Trio does not fabricate a sensor ring.

Native CGM managers still refresh directly from `cgmLifecycleProgress` and `cgmStatusHighlight`. Native sources with `cgmSensorExpiresAt` still use the existing 48 hour display gate. Simulator behavior remains special-cased.

## Testing

Validated on-device with xDrip4iOS AppGroup data from the forthcoming xdripswift v7 update:
- [JohanDegraeve/xdripswift#730](https://github.com/JohanDegraeve/xdripswift/pull/730)

Tested cases:
- lifecycle ring displays from source-published state
- ring remains visible across Home refresh ticks
- legacy and no-lifecycle payloads do not fabricate ring state
- soon-to-expire `maxSensorDays` cases display correctly
- expired `maxSensorDays` cases display correctly