### PR TITLE
Set default Color Scheme to Dynamic and align Stats Charts and Static Scheme to Dynamic Scheme

### DIFF
--- a/LiveActivity/LiveActivity+Helper.swift
+++ b/LiveActivity/LiveActivity+Helper.swift
@@ -70,6 +70,11 @@ extension NumberFormatter {
 }
 
 extension Color {
+    // Static Glucose Color Scheme band colors — needs to be kept in sync with DynamicGlucoseColor.swift
+    static let staticLow = Color(hue: 0.0 / 360.0, saturation: 0.6, brightness: 0.9)
+    static let staticInRange = Color(hue: 120.0 / 360.0, saturation: 0.6, brightness: 0.9)
+    static let staticHigh = Color(hue: 270.0 / 360.0, saturation: 0.6, brightness: 0.9)
+
     // Helper function to decide how to pick the glucose color
     static func getDynamicGlucoseColor(
         glucoseValue: Decimal,
@@ -87,14 +92,14 @@ extension Color {
                 targetGlucose: targetGlucose
             )
         }
-        // Otheriwse, use static (orange = high, red = low, green = range)
+        // Otherwise, use static colors
         else {
             if glucoseValue >= highGlucoseColorValue {
-                return Color.orange
+                return Color.staticHigh
             } else if glucoseValue <= lowGlucoseColorValue {
-                return Color.red
+                return Color.staticLow
             } else {
-                return Color.green
+                return Color.staticInRange
             }
         }
     }

--- a/Trio/Sources/Helpers/DynamicGlucoseColor.swift
+++ b/Trio/Sources/Helpers/DynamicGlucoseColor.swift
@@ -64,3 +64,14 @@ public func calculateHueBasedGlucoseColor(
     let color = Color(hue: hue, saturation: 0.6, brightness: 0.9)
     return color
 }
+
+// Discrete band colors sampled from the dynamic gradient above
+public extension Color {
+    static let dynamicRed = Color(hue: 0.0 / 360.0, saturation: 0.6, brightness: 0.9)
+    static let dynamicOrange = Color(hue: 30.0 / 360.0, saturation: 0.6, brightness: 0.9)
+    static let dynamicGreen = Color(hue: 120.0 / 360.0, saturation: 0.6, brightness: 0.9)
+    static let dynamicTeal = Color(hue: 165.0 / 360.0, saturation: 0.6, brightness: 0.9)
+    static let dynamicBlue = Color(hue: 200.0 / 360.0, saturation: 0.6, brightness: 0.9)
+    static let dynamicIndigo = Color(hue: 235.0 / 360.0, saturation: 0.6, brightness: 0.9)
+    static let dynamicPurple = Color(hue: 270.0 / 360.0, saturation: 0.6, brightness: 0.9)
+}

--- a/Trio/Sources/Helpers/DynamicGlucoseColor.swift
+++ b/Trio/Sources/Helpers/DynamicGlucoseColor.swift
@@ -18,14 +18,14 @@ public func getDynamicGlucoseColor(
             targetGlucose: targetGlucose
         )
     }
-    // Otheriwse, use static (orange = high, red = low, green = range)
+    // Otherwise, use the static colors
     else {
         if glucoseValue >= highGlucoseColorValue {
-            return Color.orange
+            return Color.staticHigh
         } else if glucoseValue <= lowGlucoseColorValue {
-            return Color.red
+            return Color.staticLow
         } else {
-            return Color.green
+            return Color.staticInRange
         }
     }
 }
@@ -74,4 +74,9 @@ public extension Color {
     static let dynamicBlue = Color(hue: 200.0 / 360.0, saturation: 0.6, brightness: 0.9)
     static let dynamicIndigo = Color(hue: 235.0 / 360.0, saturation: 0.6, brightness: 0.9)
     static let dynamicPurple = Color(hue: 270.0 / 360.0, saturation: 0.6, brightness: 0.9)
+
+    // Colors used when the Static Glucose Color Scheme is selected
+    static let staticLow = Color.dynamicRed
+    static let staticInRange = Color.dynamicGreen
+    static let staticHigh = Color.dynamicPurple
 }

--- a/Trio/Sources/Localizations/Main/Localizable.xcstrings
+++ b/Trio/Sources/Localizations/Main/Localizable.xcstrings
@@ -111043,6 +111043,9 @@
         }
       }
     },
+    "Dynamic (Default):" : {
+
+    },
     "Dynamic Insulin Sensitivity" : {
       "localizations" : {
         "bg" : {
@@ -112169,6 +112172,7 @@
       }
     },
     "Dynamic:" : {
+      "extractionState" : "stale",
       "localizations" : {
         "bg" : {
           "stringUnit" : {
@@ -222383,6 +222387,9 @@
         }
       }
     },
+    "Purple = Above Range" : {
+
+    },
     "Quantity Carbs" : {
       "localizations" : {
         "bg" : {
@@ -314392,6 +314399,7 @@
       }
     },
     "Yellow = Above Range" : {
+      "extractionState" : "stale",
       "localizations" : {
         "bg" : {
           "stringUnit" : {

--- a/Trio/Sources/Models/BGTargets.swift
+++ b/Trio/Sources/Models/BGTargets.swift
@@ -24,3 +24,41 @@ struct BGTargetEntry: JSON {
     let start: String
     let offset: Int
 }
+
+extension BGTargets {
+    func currentTarget(at date: Date = Date()) -> Decimal? {
+        let calendar = Calendar.current
+
+        for (index, entry) in targets.enumerated() {
+            guard let entryTime = TherapySettingsUtil.parseTime(entry.start) else {
+                debug(.default, "Invalid BG target entry start time: \(entry.start)")
+                continue
+            }
+            let components = calendar.dateComponents([.hour, .minute, .second], from: entryTime)
+            guard let start = calendar.date(
+                bySettingHour: components.hour ?? 0,
+                minute: components.minute ?? 0,
+                second: components.second ?? 0,
+                of: date
+            ) else { continue }
+
+            let end: Date
+            if index < targets.count - 1, let nextTime = TherapySettingsUtil.parseTime(targets[index + 1].start) {
+                let nextComponents = calendar.dateComponents([.hour, .minute, .second], from: nextTime)
+                end = calendar.date(
+                    bySettingHour: nextComponents.hour ?? 0,
+                    minute: nextComponents.minute ?? 0,
+                    second: nextComponents.second ?? 0,
+                    of: date
+                ) ?? start
+            } else {
+                end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
+            }
+
+            if date >= start, date < end {
+                return entry.low
+            }
+        }
+        return nil
+    }
+}

--- a/Trio/Sources/Models/GlucoseColorScheme.swift
+++ b/Trio/Sources/Models/GlucoseColorScheme.swift
@@ -4,15 +4,15 @@ import UIKit
 
 public enum GlucoseColorScheme: String, JSON, CaseIterable, Identifiable, Codable, Hashable {
     public var id: String { rawValue }
-    case staticColor
     case dynamicColor
+    case staticColor
 
     var displayName: String {
         switch self {
-        case .staticColor:
-            return String(localized: "Static")
         case .dynamicColor:
             return String(localized: "Dynamic")
+        case .staticColor:
+            return String(localized: "Static")
         }
     }
 }

--- a/Trio/Sources/Models/TrioSettings.swift
+++ b/Trio/Sources/Models/TrioSettings.swift
@@ -41,7 +41,7 @@ struct TrioSettings: JSON, Equatable, Encodable {
     var eA1cDisplayUnit: EstimatedA1cDisplayUnit = .percent
     var high: Decimal = 180
     var low: Decimal = 70
-    var glucoseColorScheme: GlucoseColorScheme = .staticColor
+    var glucoseColorScheme: GlucoseColorScheme = .dynamicColor
     var xGridLines: Bool = true
     var yGridLines: Bool = true
     var hideInsulinBadge: Bool = false

--- a/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel.swift
+++ b/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel.swift
@@ -100,50 +100,11 @@ extension Adjustments {
 
         /// Retrieves the current glucose target based on the time of day.
         func getCurrentGlucoseTarget() async {
-            let now = Date()
-            let calendar = Calendar.current
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "HH:mm:ss"
-            dateFormatter.timeZone = TimeZone.current
-
             let bgTargets = await provider.getBGTargets()
-            let entries: [(start: String, value: Decimal)] = bgTargets.targets.map { ($0.start, $0.low) }
-
-            for (index, entry) in entries.enumerated() {
-                guard let entryTime = dateFormatter.date(from: entry.start) else {
-                    print("Invalid entry start time: \(entry.start)")
-                    continue
-                }
-
-                let entryComponents = calendar.dateComponents([.hour, .minute, .second], from: entryTime)
-                let entryStartTime = calendar.date(
-                    bySettingHour: entryComponents.hour!,
-                    minute: entryComponents.minute!,
-                    second: entryComponents.second!,
-                    of: now
-                )!
-
-                let entryEndTime: Date
-                if index < entries.count - 1,
-                   let nextEntryTime = dateFormatter.date(from: entries[index + 1].start)
-                {
-                    let nextEntryComponents = calendar.dateComponents([.hour, .minute, .second], from: nextEntryTime)
-                    entryEndTime = calendar.date(
-                        bySettingHour: nextEntryComponents.hour!,
-                        minute: nextEntryComponents.minute!,
-                        second: nextEntryComponents.second!,
-                        of: now
-                    )!
-                } else {
-                    entryEndTime = calendar.date(byAdding: .day, value: 1, to: entryStartTime)!
-                }
-
-                if now >= entryStartTime, now < entryEndTime {
-                    await MainActor.run {
-                        currentGlucoseTarget = entry.value
-                        target = currentGlucoseTarget
-                    }
-                    return
+            if let currentTarget = bgTargets.currentTarget() {
+                await MainActor.run {
+                    currentGlucoseTarget = currentTarget
+                    target = currentGlucoseTarget
                 }
             }
         }

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -930,46 +930,8 @@ extension Home {
         }
 
         private func getCurrentGlucoseTarget() async {
-            let now = Date()
-            let calendar = Calendar.current
-
-            let entries: [(start: String, value: Decimal)] = bgTargets.targets.map { ($0.start, $0.low) }
-
-            for (index, entry) in entries.enumerated() {
-                guard let entryTime = TherapySettingsUtil.parseTime(entry.start) else {
-                    debug(.default, "Invalid entry start time: \(entry.start)")
-                    continue
-                }
-
-                let entryComponents = calendar.dateComponents([.hour, .minute, .second], from: entryTime)
-                let entryStartTime = calendar.date(
-                    bySettingHour: entryComponents.hour!,
-                    minute: entryComponents.minute!,
-                    second: entryComponents.second!,
-                    of: now
-                )!
-
-                let entryEndTime: Date
-                if index < entries.count - 1,
-                   let nextEntryTime = TherapySettingsUtil.parseTime(entries[index + 1].start)
-                {
-                    let nextEntryComponents = calendar.dateComponents([.hour, .minute, .second], from: nextEntryTime)
-                    entryEndTime = calendar.date(
-                        bySettingHour: nextEntryComponents.hour!,
-                        minute: nextEntryComponents.minute!,
-                        second: nextEntryComponents.second!,
-                        of: now
-                    )!
-                } else {
-                    entryEndTime = calendar.date(byAdding: .day, value: 1, to: entryStartTime)!
-                }
-
-                if now >= entryStartTime, now < entryEndTime {
-                    await MainActor.run {
-                        currentGlucoseTarget = entry.value
-                    }
-                    return
-                }
+            if let target = bgTargets.currentTarget() {
+                await MainActor.run { currentGlucoseTarget = target }
             }
         }
 

--- a/Trio/Sources/Modules/Stat/View/ChartsView.swift
+++ b/Trio/Sources/Modules/Stat/View/ChartsView.swift
@@ -64,17 +64,17 @@ struct ChartsView: View {
                     PointMark(
                         x: .value("Time", item.date ?? Date(), unit: .second),
                         y: .value("Value", Decimal(item.glucose) * conversionFactor)
-                    ).foregroundStyle(Color.orange.gradient).symbolSize(size).interpolationMethod(.cardinal)
+                    ).foregroundStyle(Color.staticHigh.gradient).symbolSize(size).interpolationMethod(.cardinal)
                 } else if item.glucose < Int(lowLimit) {
                     PointMark(
                         x: .value("Time", item.date ?? Date(), unit: .second),
                         y: .value("Value", Decimal(item.glucose) * conversionFactor)
-                    ).foregroundStyle(Color.red.gradient).symbolSize(size).interpolationMethod(.cardinal)
+                    ).foregroundStyle(Color.staticLow.gradient).symbolSize(size).interpolationMethod(.cardinal)
                 } else {
                     PointMark(
                         x: .value("Time", item.date ?? Date(), unit: .second),
                         y: .value("Value", Decimal(item.glucose) * conversionFactor)
-                    ).foregroundStyle(Color.green.gradient).symbolSize(size).interpolationMethod(.cardinal)
+                    ).foregroundStyle(Color.staticInRange.gradient).symbolSize(size).interpolationMethod(.cardinal)
                 }
             }
         }
@@ -133,13 +133,13 @@ struct ChartsView: View {
                     localized:
                     "Low",
                     comment: ""
-                ) + " (<\(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fraction)))))": .red,
-                String(localized: "In Range", comment: ""): .green,
+                ) + " (<\(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fraction)))))": .staticLow,
+                String(localized: "In Range", comment: ""): .staticInRange,
                 String(
                     localized:
                     "High",
                     comment: ""
-                ) + " (>\(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fraction)))))": .orange
+                ) + " (>\(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fraction)))))": .staticHigh
             ]).frame(maxHeight: 25)
         }
         .frame(maxWidth: .infinity, alignment: .center) // Align the entire VStack to center
@@ -194,13 +194,13 @@ struct ChartsView: View {
                 localized:
                 "Low",
                 comment: ""
-            ) + " (< \(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fraction)))))": .red,
-            "\(low.formatted(.number.precision(.fractionLength(fraction)))) - \(high.formatted(.number.precision(.fractionLength(fraction))))": .green,
+            ) + " (< \(low.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fraction)))))": .staticLow,
+            "\(low.formatted(.number.precision(.fractionLength(fraction)))) - \(high.formatted(.number.precision(.fractionLength(fraction))))": .staticInRange,
             String(
                 localized:
                 "High",
                 comment: ""
-            ) + " (> \(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fraction)))))": .orange
+            ) + " (> \(high.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fraction)))))": .staticHigh
         ])
     }
 
@@ -218,7 +218,7 @@ struct ChartsView: View {
                         .foregroundColor(.secondary)
                     Text("\(value.formatted(.number.precision(.fractionLength(0 ... 1)))) %")
                         .frame(width: 45, alignment: .trailing)
-                        .foregroundColor(.orange)
+                        .foregroundColor(.staticHigh)
                 }.font(.caption)
                 HStack {
                     let value = 100.0 * Double(mapGlucoseNormal.count) / Double(mapGlucose.count)
@@ -227,7 +227,7 @@ struct ChartsView: View {
                         .foregroundColor(.secondary)
                     Text("\(value.formatted(.number.precision(.fractionLength(0 ... 1)))) %")
                         .frame(width: 45, alignment: .trailing)
-                        .foregroundColor(.green)
+                        .foregroundColor(.staticInRange)
                 }.font(.caption)
                 HStack {
                     let value = 100.0 * Double(mapGlucoseAcuteLow.count) / Double(mapGlucose.count)
@@ -236,7 +236,7 @@ struct ChartsView: View {
                         .foregroundColor(.secondary)
                     Text("\(value.formatted(.number.precision(.fractionLength(0 ... 1)))) %")
                         .frame(width: 45, alignment: .trailing)
-                        .foregroundColor(.red)
+                        .foregroundColor(.staticLow)
                 }.font(.caption)
             }
         }
@@ -254,14 +254,14 @@ struct ChartsView: View {
                     let value = 100.0 * Double(mapGlucoseLow.count) / Double(mapGlucose.count)
                     Text(units == .mmolL ? "< 3.3" : "< 59").font(.caption2).foregroundColor(.secondary)
                     Text(value.formatted(.number.precision(.fractionLength(0 ... 1)))).font(.caption)
-                        .foregroundColor(value == 0 ? .green : .red)
+                        .foregroundColor(value == 0 ? .staticInRange : .staticLow)
                     Text("%").font(.caption)
                 }
                 Spacer()
                 HStack {
                     let value = 100.0 * Double(mapGlucoseNormal.count) / Double(mapGlucose.count)
                     Text(units == .mmolL ? "3.9-7.8" : "70-140").foregroundColor(.secondary)
-                    Text(value.formatted(.number.precision(.fractionLength(0 ... 1)))).foregroundColor(.green)
+                    Text(value.formatted(.number.precision(.fractionLength(0 ... 1)))).foregroundColor(.staticInRange)
                     Text("%").foregroundColor(.secondary)
                 }.font(.caption)
                 Spacer()
@@ -269,7 +269,7 @@ struct ChartsView: View {
                     let value = 100.0 * Double(mapGlucoseAcuteHigh.count) / Double(mapGlucose.count)
                     Text(units == .mmolL ? "> 11.0" : "> 198").font(.caption).foregroundColor(.secondary)
                     Text(value.formatted(.number.precision(.fractionLength(0 ... 1)))).font(.caption)
-                        .foregroundColor(value == 0 ? .green : .orange)
+                        .foregroundColor(value == 0 ? .staticInRange : .staticHigh)
                     Text("%").font(.caption)
                 }
                 Spacer()

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseDailyDistributionChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseDailyDistributionChart.swift
@@ -146,12 +146,12 @@ struct GlucoseDailyDistributionChart: View {
             }
         }
         .chartForegroundStyleScale([
-            legend("veryLow"): .purple,
-            legend("low"): .red,
-            legend("inSmallRange"): .green,
-            legend("inRange"): .darkGreen,
-            legend("high"): .loopYellow,
-            legend("veryHigh"): .orange
+            legend("veryLow"): Color.dynamicRed,
+            legend("low"): Color.dynamicOrange,
+            legend("inSmallRange"): Color.dynamicGreen,
+            legend("inRange"): Color.dynamicTeal,
+            legend("high"): Color.dynamicBlue,
+            legend("veryHigh"): Color.dynamicPurple
         ])
         .chartXSelection(value: $selectedDate.animation(.easeInOut))
         .onChange(of: selectedDate) { _, newValue in

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseDailyPercentileChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseDailyPercentileChart.swift
@@ -329,9 +329,9 @@ struct GlucoseDailyPercentileChart: View {
             "10-90%": .blue.opacity(0.3),
             "25-75%": .blue.opacity(0.5),
             "Median": .blue,
-            "\(timeInRangeType.bottomThreshold.formatted(withUnits: units))": .red,
-            "\(timeInRangeType.topThreshold.formatted(withUnits: units))": .mint,
-            "\(highLimit.formatted(withUnits: units))": .orange
+            "\(timeInRangeType.bottomThreshold.formatted(withUnits: units))": .staticLow,
+            "\(timeInRangeType.topThreshold.formatted(withUnits: units))": .staticInRange,
+            "\(highLimit.formatted(withUnits: units))": .staticHigh
         ])
         .chartScrollableAxes(.horizontal)
         .chartScrollPosition(x: $scrollPosition)

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseDistributionChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseDistributionChart.swift
@@ -25,38 +25,38 @@ struct GlucoseDistributionChart: View {
                 }
             }
             .chartForegroundStyleScale([
-                "<54": .purple.opacity(0.8),
-                "54-\(timeInRangeType.bottomThreshold)": .red.opacity(0.8),
-                "\(timeInRangeType.bottomThreshold)-\(timeInRangeType.topThreshold)": .green.opacity(0.8),
-                "\(timeInRangeType.topThreshold)-180": .darkGreen.opacity(0.8),
-                "180-200": .yellow.opacity(0.8),
-                "200-220": .orange.opacity(0.8),
-                ">220": .darkOrange.opacity(0.8)
+                "<54": Color.dynamicRed.opacity(0.8),
+                "54-\(timeInRangeType.bottomThreshold)": Color.dynamicOrange.opacity(0.8),
+                "\(timeInRangeType.bottomThreshold)-\(timeInRangeType.topThreshold)": Color.dynamicGreen.opacity(0.8),
+                "\(timeInRangeType.topThreshold)-180": Color.dynamicTeal.opacity(0.8),
+                "180-200": Color.dynamicBlue.opacity(0.8),
+                "200-220": Color.dynamicIndigo.opacity(0.8),
+                ">220": Color.dynamicPurple.opacity(0.8)
             ])
             .chartLegend(position: .bottom, alignment: .leading, spacing: 12) {
                 let legendItems: [(String, Color)] = [
-                    ("<\(units == .mgdL ? Decimal(54) : 54.asMmolL)", .purple.opacity(0.8)),
+                    ("<\(units == .mgdL ? Decimal(54) : 54.asMmolL)", .dynamicRed.opacity(0.8)),
                     (
                         "\(units == .mgdL ? Decimal(54) : 54.asMmolL)-\(units == .mgdL ? Decimal(timeInRangeType.bottomThreshold) : timeInRangeType.bottomThreshold.asMmolL)",
-                        .red.opacity(0.8)
+                        .dynamicOrange.opacity(0.8)
                     ),
                     (
                         "\(units == .mgdL ? Decimal(timeInRangeType.bottomThreshold) : timeInRangeType.bottomThreshold.asMmolL)-\(units == .mgdL ? Decimal(timeInRangeType.topThreshold) : timeInRangeType.topThreshold.asMmolL)",
-                        .green.opacity(0.8)
+                        .dynamicGreen.opacity(0.8)
                     ),
                     (
                         "\(units == .mgdL ? Decimal(timeInRangeType.topThreshold) : timeInRangeType.topThreshold.asMmolL)-\(units == .mgdL ? Decimal(180) : 180.asMmolL)",
-                        .darkGreen.opacity(0.8)
+                        .dynamicTeal.opacity(0.8)
                     ),
                     (
                         "\(units == .mgdL ? Decimal(180) : 180.asMmolL)-\(units == .mgdL ? Decimal(200) : 200.asMmolL)",
-                        .yellow.opacity(0.8)
+                        .dynamicBlue.opacity(0.8)
                     ),
                     (
                         "\(units == .mgdL ? Decimal(200) : 200.asMmolL)-\(units == .mgdL ? Decimal(220) : 220.asMmolL)",
-                        .orange.opacity(0.8)
+                        .dynamicIndigo.opacity(0.8)
                     ),
-                    (">\(units == .mgdL ? Decimal(220) : 220.asMmolL)", .darkOrange.opacity(0.8))
+                    (">\(units == .mgdL ? Decimal(220) : 220.asMmolL)", .dynamicPurple.opacity(0.8))
                 ]
 
                 let columns = [GridItem(.adaptive(minimum: 65), spacing: 4)]

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucosePercentileChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucosePercentileChart.swift
@@ -123,18 +123,18 @@ struct GlucosePercentileChart: View {
                 "10-90%": Color.blue.opacity(0.3),
                 "25-75%": Color.blue.opacity(0.5),
                 "Median": Color.blue,
-                "\(timeInRangeType.bottomThreshold.formatted(withUnits: units))": Color.red,
-                "\(timeInRangeType.topThreshold.formatted(withUnits: units))": Color.mint,
-                "\(highLimit.formatted(withUnits: units))": Color.orange
+                "\(timeInRangeType.bottomThreshold.formatted(withUnits: units))": Color.staticLow,
+                "\(timeInRangeType.topThreshold.formatted(withUnits: units))": Color.staticInRange,
+                "\(highLimit.formatted(withUnits: units))": Color.staticHigh
             ])
             .chartLegend(position: .bottom, alignment: .leading, spacing: 12) {
                 let legendItems: [(String, Color)] = [
                     ("10-90%", Color.blue.opacity(0.3)),
                     ("25-75%", Color.blue.opacity(0.5)),
                     (String(localized: "Median"), Color.blue),
-                    (String(localized: "\(timeInRangeType.bottomThreshold.formatted(withUnits: units))"), Color.red),
-                    (String(localized: "\(timeInRangeType.topThreshold.formatted(withUnits: units))"), Color.mint),
-                    (String(localized: "\(highLimit.formatted(withUnits: units))"), Color.orange)
+                    (String(localized: "\(timeInRangeType.bottomThreshold.formatted(withUnits: units))"), Color.staticLow),
+                    (String(localized: "\(timeInRangeType.topThreshold.formatted(withUnits: units))"), Color.staticInRange),
+                    (String(localized: "\(highLimit.formatted(withUnits: units))"), Color.staticHigh)
                 ]
 
                 let columns = [GridItem(.adaptive(minimum: 100), spacing: 4)]

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseSectorChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseSectorChart.swift
@@ -111,7 +111,7 @@ struct GlucoseSectorChart: View {
                             Text("> \(Decimal(220).formatted(for: units))").font(.subheadline)
                                 .foregroundStyle(Color.secondary)
                             Text(formatPercentage(moderatelyHighPercentage, tight: true))
-                                .foregroundStyle(Color.dynamicIndigo)
+                                .foregroundStyle(Color.dynamicBlue)
                         }
 
                         VStack(alignment: .leading, spacing: 5) {

--- a/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseSectorChart.swift
+++ b/Trio/Sources/Modules/Stat/View/ViewElements/Glucose/GlucoseSectorChart.swift
@@ -72,7 +72,7 @@ struct GlucoseSectorChart: View {
                         .font(.subheadline)
                         .foregroundStyle(Color.secondary)
                         Text(formatPercentage(inRangePercentage, tight: true))
-                            .foregroundStyle(Color.loopGreen)
+                            .foregroundStyle(Color.dynamicTeal)
                     }
 
                     VStack(alignment: .leading, spacing: 5) {
@@ -82,7 +82,7 @@ struct GlucoseSectorChart: View {
                         .font(.subheadline)
                         .foregroundStyle(Color.secondary)
                         Text(formatPercentage(tightPercentage, tight: true))
-                            .foregroundStyle(Color.green)
+                            .foregroundStyle(Color.dynamicGreen)
                     }
                 }.padding(.leading, 5)
 
@@ -91,7 +91,7 @@ struct GlucoseSectorChart: View {
                         Text("> \(highLimit.formatted(for: units))").font(.subheadline)
                             .foregroundStyle(Color.secondary)
                         Text(formatPercentage(highPercentage, tight: true))
-                            .foregroundStyle(Color.loopYellow)
+                            .foregroundStyle(showChart ? Color.dynamicPurple : Color.dynamicBlue)
                     }
 
                     VStack(alignment: .leading, spacing: 5) {
@@ -101,7 +101,7 @@ struct GlucoseSectorChart: View {
                         .font(.subheadline)
                         .foregroundStyle(Color.secondary)
                         Text(formatPercentage(lowPercentage, tight: true))
-                            .foregroundStyle(Color.red)
+                            .foregroundStyle(showChart ? Color.dynamicRed : Color.dynamicOrange)
                     }
                 }
                 // If not showing chart, show extra stats
@@ -111,7 +111,7 @@ struct GlucoseSectorChart: View {
                             Text("> \(Decimal(220).formatted(for: units))").font(.subheadline)
                                 .foregroundStyle(Color.secondary)
                             Text(formatPercentage(moderatelyHighPercentage, tight: true))
-                                .foregroundStyle(Color.loopYellow)
+                                .foregroundStyle(Color.dynamicIndigo)
                         }
 
                         VStack(alignment: .leading, spacing: 5) {
@@ -121,7 +121,7 @@ struct GlucoseSectorChart: View {
                             .font(.subheadline)
                             .foregroundStyle(Color.secondary)
                             Text(formatPercentage(moderatelyLowPercentage, tight: true))
-                                .foregroundStyle(Color.red)
+                                .foregroundStyle(Color.dynamicOrange)
                         }
                     }
                     VStack(alignment: .leading, spacing: 10) {
@@ -129,7 +129,7 @@ struct GlucoseSectorChart: View {
                             Text("> \(Decimal(250).formatted(for: units))").font(.subheadline)
                                 .foregroundStyle(Color.secondary)
                             Text(formatPercentage(veryHighPercentage, tight: true))
-                                .foregroundStyle(Color.orange)
+                                .foregroundStyle(Color.dynamicPurple)
                         }
 
                         VStack(alignment: .leading, spacing: 5) {
@@ -139,7 +139,7 @@ struct GlucoseSectorChart: View {
                             .font(.subheadline)
                             .foregroundStyle(Color.secondary)
                             Text(formatPercentage(veryLowPercentage, tight: true))
-                                .foregroundStyle(Color.purple)
+                                .foregroundStyle(Color.dynamicRed)
                         }
                     }
                 }
@@ -230,9 +230,9 @@ struct GlucoseSectorChart: View {
 
         // Return array of tuples with range data
         return [
-            (.high, highCount, Decimal(highCount) / Decimal(total) * 100, .loopYellow),
-            (.inRange, inRangeCount, Decimal(inRangeCount) / Decimal(total) * 100, .green),
-            (.low, lowCount, Decimal(lowCount) / Decimal(total) * 100, .red)
+            (.high, highCount, Decimal(highCount) / Decimal(total) * 100, .dynamicPurple),
+            (.inRange, inRangeCount, Decimal(inRangeCount) / Decimal(total) * 100, .dynamicGreen),
+            (.low, lowCount, Decimal(lowCount) / Decimal(total) * 100, .dynamicRed)
         ]
     }
 
@@ -279,7 +279,7 @@ struct GlucoseSectorChart: View {
 
             return RangeDetail(
                 title: String(localized: "High Glucose"),
-                color: .loopYellow,
+                color: .dynamicPurple,
                 items: [
                     (
                         String(localized: "Very High (>\(Decimal(250).formatted(for: units)))"),
@@ -304,7 +304,7 @@ struct GlucoseSectorChart: View {
 
             return RangeDetail(
                 title: String(localized: "In Range"),
-                color: .green,
+                color: .dynamicGreen,
                 items: [
                     (
                         String(
@@ -334,7 +334,7 @@ struct GlucoseSectorChart: View {
 
             return RangeDetail(
                 title: String(localized: "Low Glucose"),
-                color: .red,
+                color: .dynamicRed,
                 items: [
                     (
                         String(

--- a/Trio/Sources/Modules/Treatments/View/ForecastChart.swift
+++ b/Trio/Sources/Modules/Treatments/View/ForecastChart.swift
@@ -147,11 +147,11 @@ struct ForecastChart: View {
                 .zIndex(-1)
                 .symbolSize(CGSize(width: 15, height: 15))
                 .foregroundStyle(
-                    Decimal(selectedGlucose.glucose) > state.highGlucose ? Color.orange
+                    Decimal(selectedGlucose.glucose) > state.highGlucose ? Color.staticHigh
                         .opacity(0.8) :
                         (
-                            Decimal(selectedGlucose.glucose) < state.lowGlucose ? Color.red.opacity(0.8) : Color.green
-                                .opacity(0.8)
+                            Decimal(selectedGlucose.glucose) < state.lowGlucose ? Color.staticLow.opacity(0.8)
+                                : Color.staticInRange.opacity(0.8)
                         )
                 )
 

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsDataFlow.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsDataFlow.swift
@@ -2,4 +2,6 @@ enum UserInterfaceSettings {
     enum Config {}
 }
 
-protocol UserInterfaceSettingsProvider: Provider {}
+protocol UserInterfaceSettingsProvider: Provider {
+    func getBGTargets() async -> BGTargets
+}

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsProvider.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsProvider.swift
@@ -1,3 +1,9 @@
 extension UserInterfaceSettings {
-    final class Provider: BaseProvider, UserInterfaceSettingsProvider {}
+    final class Provider: BaseProvider, UserInterfaceSettingsProvider {
+        func getBGTargets() async -> BGTargets {
+            await storage.retrieveAsync(OpenAPS.Settings.bgTargets, as: BGTargets.self)
+                ?? BGTargets(from: OpenAPS.defaults(for: OpenAPS.Settings.bgTargets))
+                ?? BGTargets(units: .mgdL, userPreferredUnits: .mgdL, targets: [])
+        }
+    }
 }

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
@@ -11,7 +11,7 @@ extension UserInterfaceSettings {
         @Published var forecastDisplayType: ForecastDisplayType = .cone
         @Published var showCarbsRequiredBadge: Bool = true
         @Published var carbsRequiredThreshold: Decimal = 0
-        @Published var glucoseColorScheme: GlucoseColorScheme = .staticColor
+        @Published var glucoseColorScheme: GlucoseColorScheme = .dynamicColor
         @Published var eA1cDisplayUnit: EstimatedA1cDisplayUnit = .percent
         @Published var timeInRangeType: TimeInRangeType = .timeInTightRange
         @Published var requireAdjustmentsConfirmation: Bool = false

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
@@ -15,6 +15,7 @@ extension UserInterfaceSettings {
         @Published var eA1cDisplayUnit: EstimatedA1cDisplayUnit = .percent
         @Published var timeInRangeType: TimeInRangeType = .timeInTightRange
         @Published var requireAdjustmentsConfirmation: Bool = false
+        @Published var currentGlucoseTarget: Decimal = 100
 
         var units: GlucoseUnits = .mgdL
 
@@ -48,6 +49,53 @@ extension UserInterfaceSettings {
 
             subscribeSetting(\.requireAdjustmentsConfirmation, on: $requireAdjustmentsConfirmation) {
                 requireAdjustmentsConfirmation = $0 }
+
+            Task { await getCurrentGlucoseTarget() }
+        }
+
+        /// Resolves the glucose target active right now from the BG target schedule.
+        /// NOTE: same logic as HomeStateModel/AdjustmentsStateModel — candidate for a shared helper.
+        func getCurrentGlucoseTarget() async {
+            let now = Date()
+            let calendar = Calendar.current
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "HH:mm:ss"
+            dateFormatter.timeZone = TimeZone.current
+
+            let bgTargets = await provider.getBGTargets()
+            let entries: [(start: String, value: Decimal)] = bgTargets.targets.map { ($0.start, $0.low) }
+
+            for (index, entry) in entries.enumerated() {
+                guard let entryTime = dateFormatter.date(from: entry.start) else { continue }
+
+                let entryComponents = calendar.dateComponents([.hour, .minute, .second], from: entryTime)
+                let entryStartTime = calendar.date(
+                    bySettingHour: entryComponents.hour!,
+                    minute: entryComponents.minute!,
+                    second: entryComponents.second!,
+                    of: now
+                )!
+
+                let entryEndTime: Date
+                if index < entries.count - 1,
+                   let nextEntryTime = dateFormatter.date(from: entries[index + 1].start)
+                {
+                    let nextEntryComponents = calendar.dateComponents([.hour, .minute, .second], from: nextEntryTime)
+                    entryEndTime = calendar.date(
+                        bySettingHour: nextEntryComponents.hour!,
+                        minute: nextEntryComponents.minute!,
+                        second: nextEntryComponents.second!,
+                        of: now
+                    )!
+                } else {
+                    entryEndTime = calendar.date(byAdding: .day, value: 1, to: entryStartTime)!
+                }
+
+                if now >= entryStartTime, now < entryEndTime {
+                    await MainActor.run { currentGlucoseTarget = entry.value }
+                    return
+                }
+            }
         }
     }
 }

--- a/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/UserInterfaceSettingsStateModel.swift
@@ -54,47 +54,10 @@ extension UserInterfaceSettings {
         }
 
         /// Resolves the glucose target active right now from the BG target schedule.
-        /// NOTE: same logic as HomeStateModel/AdjustmentsStateModel — candidate for a shared helper.
         func getCurrentGlucoseTarget() async {
-            let now = Date()
-            let calendar = Calendar.current
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "HH:mm:ss"
-            dateFormatter.timeZone = TimeZone.current
-
             let bgTargets = await provider.getBGTargets()
-            let entries: [(start: String, value: Decimal)] = bgTargets.targets.map { ($0.start, $0.low) }
-
-            for (index, entry) in entries.enumerated() {
-                guard let entryTime = dateFormatter.date(from: entry.start) else { continue }
-
-                let entryComponents = calendar.dateComponents([.hour, .minute, .second], from: entryTime)
-                let entryStartTime = calendar.date(
-                    bySettingHour: entryComponents.hour!,
-                    minute: entryComponents.minute!,
-                    second: entryComponents.second!,
-                    of: now
-                )!
-
-                let entryEndTime: Date
-                if index < entries.count - 1,
-                   let nextEntryTime = dateFormatter.date(from: entries[index + 1].start)
-                {
-                    let nextEntryComponents = calendar.dateComponents([.hour, .minute, .second], from: nextEntryTime)
-                    entryEndTime = calendar.date(
-                        bySettingHour: nextEntryComponents.hour!,
-                        minute: nextEntryComponents.minute!,
-                        second: nextEntryComponents.second!,
-                        of: now
-                    )!
-                } else {
-                    entryEndTime = calendar.date(byAdding: .day, value: 1, to: entryStartTime)!
-                }
-
-                if now >= entryStartTime, now < entryEndTime {
-                    await MainActor.run { currentGlucoseTarget = entry.value }
-                    return
-                }
+            if let target = bgTargets.currentTarget() {
+                await MainActor.run { currentGlucoseTarget = target }
             }
         }
     }

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -127,13 +127,7 @@ extension UserInterfaceSettings {
                                                     "Set the color scheme for glucose readings on the main glucose graph, live activities, and bolus calculator. Descriptions for each option found below."
                                                 )
                                                 VStack(alignment: .leading, spacing: 5) {
-                                                    Text("Static:").bold()
-                                                    Text("Red = Below Range")
-                                                    Text("Green = In Range")
-                                                    Text("Yellow = Above Range")
-                                                }
-                                                VStack(alignment: .leading, spacing: 5) {
-                                                    Text("Dynamic:").bold()
+                                                    Text("Dynamic (Default):").bold()
                                                     Text("Green = At Target")
                                                     Text(
                                                         "Gradient Red = As readings approach and exceed below target, they gradually become more red."
@@ -141,6 +135,12 @@ extension UserInterfaceSettings {
                                                     Text(
                                                         "Gradient Purple = As readings approach and exceed above target, they become more purple."
                                                     )
+                                                }
+                                                VStack(alignment: .leading, spacing: 5) {
+                                                    Text("Static:").bold()
+                                                    Text("Red = Below Range")
+                                                    Text("Green = In Range")
+                                                    Text("Yellow = Above Range")
                                                 }
                                             }
                                         )

--- a/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
+++ b/Trio/Sources/Modules/UserInterfaceSettings/View/UserInterfaceSettingsRootView.swift
@@ -132,15 +132,22 @@ extension UserInterfaceSettings {
                                                     Text(
                                                         "Gradient Red = As readings approach and exceed below target, they gradually become more red."
                                                     )
+                                                    .fixedSize(horizontal: false, vertical: true)
                                                     Text(
                                                         "Gradient Purple = As readings approach and exceed above target, they become more purple."
                                                     )
+                                                    .fixedSize(horizontal: false, vertical: true)
+                                                    GlucoseColorGradientPreview(
+                                                        units: state.units,
+                                                        target: state.currentGlucoseTarget
+                                                    )
+                                                    .padding(.top, 6)
                                                 }
                                                 VStack(alignment: .leading, spacing: 5) {
                                                     Text("Static:").bold()
                                                     Text("Red = Below Range")
                                                     Text("Green = In Range")
-                                                    Text("Yellow = Above Range")
+                                                    Text("Purple = Above Range")
                                                 }
                                             }
                                         )
@@ -605,5 +612,90 @@ extension UserInterfaceSettings {
             .navigationBarTitleDisplayMode(.automatic)
             .settingsHighlightScroll()
         }
+    }
+}
+
+/// Illustrative bar that samples `getDynamicGlucoseColor` across the glucose range,
+/// so the hint shows exactly how the dynamic scheme colors readings from low to high.
+private struct GlucoseColorGradientPreview: View {
+    let units: GlucoseUnits
+    // User's current glucose target — the green peak of the dynamic sweep.
+    let target: Decimal
+
+    private let minGlucose: Decimal = 40
+    private let maxGlucose: Decimal = 250
+
+    // Fixed anchors the dynamic scheme uses on the glucose graph: solid red at/below,
+    // solid purple at/above, sweeping red → green → purple between them.
+    private let hardCodedLow: Decimal = 55
+    private let hardCodedHigh: Decimal = 220
+
+    private var markerValues: [Decimal] {
+        [hardCodedLow, target, hardCodedHigh]
+    }
+
+    private var gradientStops: [Gradient.Stop] {
+        let steps = 60
+        return (0 ... steps).map { step in
+            let location = Double(step) / Double(steps)
+            let value = minGlucose + (maxGlucose - minGlucose) * Decimal(location)
+            return Gradient.Stop(
+                color: getDynamicGlucoseColor(
+                    glucoseValue: value,
+                    highGlucoseColorValue: hardCodedHigh,
+                    lowGlucoseColorValue: hardCodedLow,
+                    targetGlucose: target,
+                    glucoseColorScheme: .dynamicColor
+                ),
+                location: location
+            )
+        }
+    }
+
+    private func fraction(of value: Decimal) -> CGFloat {
+        let raw = (value - minGlucose) / (maxGlucose - minGlucose)
+        return min(max(CGFloat(truncating: raw as NSNumber), 0), 1)
+    }
+
+    private func axisValue(_ value: Decimal) -> String {
+        let display = units == .mgdL ? value : value.asMmolL
+        return "\(display)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(LinearGradient(
+                    gradient: Gradient(stops: gradientStops),
+                    startPoint: .leading,
+                    endPoint: .trailing
+                ))
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Color.primary.opacity(0.12), lineWidth: 1))
+                .frame(height: 26)
+                .shadow(color: .black.opacity(0.18), radius: 3, y: 1)
+
+            GeometryReader { geo in
+                ZStack(alignment: .topLeading) {
+                    ForEach(markerValues, id: \.self) { value in
+                        marker(value, at: fraction(of: value), width: geo.size.width)
+                    }
+                }
+            }
+            .frame(height: 22)
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func marker(_ value: Decimal, at fraction: CGFloat, width: CGFloat) -> some View {
+        VStack(spacing: 1) {
+            Image(systemName: "arrowtriangle.up.fill")
+                .font(.system(size: 7))
+                .foregroundColor(.primary.opacity(0.55))
+            Text(axisValue(value))
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .fixedSize()
+        .position(x: min(max(width * fraction, 12), width - 12), y: 11)
     }
 }


### PR DESCRIPTION
Prompted by discussions on https://github.com/nightscout/Trio/pull/1327#discussion_r3607372024, this PR does the following:

1) Changes statistics charts to use dynamic colors
2) Changes Static Glucose Color Scheme's high to purple to match Dynamic
3) Changes default Color Scheme to Dynamic
4) Adds a graphic to the verbose hint so the Color Scheme can be visualized/understood better
5) Consolidates a function needed for # 4 that was already in the code in two separate places

## Screenshots

| description | screenshot new | screenshot old |
|---|---|---|
| Static, Main Chart | <img src="https://github.com/user-attachments/assets/7e9a9bed-f6f1-4e06-8644-b982b912c5fb" /> | <img width="455" height="915" alt="Screenshot 2026-07-24 at 10 05 16" src="https://github.com/user-attachments/assets/6505620c-1048-4930-896d-04ec5cdd1c54" /> |
| Settings | <img width="910" height="1830" alt="image" src="https://github.com/user-attachments/assets/b7e0dc6f-b98a-4784-8902-20bc2ab0df5d" /> | <img src="https://github.com/user-attachments/assets/344ec77d-ba7c-4135-8c55-dff5e8ae75a9" /> |
| Percentile Chart | <img width="455" height="915" alt="Screenshot 2026-07-24 at 09 34 39" src="https://github.com/user-attachments/assets/a1dd2e6a-004b-4c61-88d5-fa971b7b499d" /> | <img width="455" height="915" alt="Screenshot 2026-07-24 at 10 05 22" src="https://github.com/user-attachments/assets/4ca1c3d6-44ce-4d90-b4d4-23a1af9f4a33" /> |
| Distribution Chart | <img width="455" height="915" alt="Screenshot 2026-07-24 at 09 34 48" src="https://github.com/user-attachments/assets/f8783252-cc86-4274-a154-ece3d1fb3cf5" /> | <img width="455" height="915" alt="Screenshot 2026-07-24 at 10 05 27" src="https://github.com/user-attachments/assets/c41e1aab-ee3a-43a9-9527-521751db896c" /> |
| Percentile Daily | <img width="455" height="915" alt="Screenshot 2026-07-24 at 09 34 58" src="https://github.com/user-attachments/assets/6ff2bce5-388b-49d1-b4dd-e5e491c1480e" /> | <img width="455" height="915" alt="Screenshot 2026-07-24 at 10 05 36" src="https://github.com/user-attachments/assets/ec7bb612-1c1f-40d2-b1cb-5c87f5780e41" /> |
| Distribution Daily | <img width="455" height="915" alt="Screenshot 2026-07-24 at 09 35 04" src="https://github.com/user-attachments/assets/cc7f4b52-f541-43df-9789-b4f21095389b" /> | <img width="455" height="915" alt="Screenshot 2026-07-24 at 10 05 42" src="https://github.com/user-attachments/assets/2c32aba6-8178-4548-bbcf-f50308822639" /> |
