### PR TITLE
Fix duplicate remote meal being re-stored on replay

### DIFF
--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
@@ -44,17 +44,15 @@ extension TrioRemoteControl {
             ), key: "date", ascending: false
         )
 
-        await taskContext.perform {
-            guard let recentCarbEntries = results as? [CarbEntryStored] else { return }
-            if !recentCarbEntries.isEmpty {
-                Task {
-                    await self.logError(
-                        "Command rejected: newer carb entries have been logged since the command was sent.",
-                        payload: payload
-                    )
-                    return
-                }
-            }
+        let hasNewerCarbEntries = await taskContext.perform {
+            (results as? [CarbEntryStored])?.isEmpty == false
+        }
+        if hasNewerCarbEntries {
+            await logError(
+                "Command rejected: newer carb entries have been logged since the command was sent.",
+                payload: payload
+            )
+            return
         }
 
         let actualDate = payload.scheduledTime.map { Date(timeIntervalSince1970: $0) }

--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
@@ -37,10 +37,13 @@ extension TrioRemoteControl {
 
         let payloadDate = Date(timeIntervalSince1970: payload.timestamp)
         let taskContext = CoreDataStack.shared.newTaskContext()
+        // Only entries already in the past can indicate a replay; equivalents and scheduled
+        // meals are dated ahead and would otherwise reject every command until their date passed.
         let results = try await CoreDataStack.shared.fetchEntitiesAsync(
             ofType: CarbEntryStored.self, onContext: taskContext, predicate: NSPredicate(
-                format: "date > %@",
-                payloadDate as NSDate
+                format: "date > %@ AND date <= %@",
+                payloadDate as NSDate,
+                Date() as NSDate
             ), key: "date", ascending: false
         )
 


### PR DESCRIPTION
## Summary

The guard in `handleMealCommand` that rejects a remote meal when newer carb entries already exist never actually aborts the handler. Its `return` sits inside a nested `Task {}` inside `taskContext.perform {}`, so it only exits that closure. The handler logs "Command rejected" and then stores the carbs anyway.

This computes the fetch result via `await taskContext.perform { ... }` returning a `Bool` and guards from the handler itself, so the rejection stops storage.

## Background

Noticed while running Trio with LoopFollow remote control for our young daughter. If a meal command is delivered twice (APNs redelivery, or a caregiver resend after an unclear failure), the duplicate carbs are stored and dosed for, while the log claims the command was rejected.

I'm @justmaier on the Trio Discord if it's easier to discuss there.

Fixes #1348