### PR TITLE
Do not enact a meal's explicit bolus when the meal is rejected

### DIFF
--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
@@ -68,12 +68,15 @@ extension TrioRemoteControl {
 
         try await carbsStorage.storeCarbs([mealEntry], areFetchedFromRemote: false)
 
-        if payload.bolusAmount == nil {
-            await logSuccess(
-                "Remote command processed successfully. \(payload.humanReadableDescription())",
-                payload: payload,
-                customNotificationMessage: "Meal logged"
-            )
+        if payload.bolusAmount != nil {
+            try await handleBolusCommand(payload)
+            return
         }
+
+        await logSuccess(
+            "Remote command processed successfully. \(payload.humanReadableDescription())",
+            payload: payload,
+            customNotificationMessage: "Meal logged"
+        )
     }
 }

--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl.swift
@@ -80,9 +80,6 @@ class TrioRemoteControl: Injectable {
             await cancelTempTarget(commandPayload)
         case .meal:
             try await handleMealCommand(commandPayload)
-            if commandPayload.bolusAmount != nil {
-                try await handleBolusCommand(commandPayload)
-            }
         case .startOverride:
             await handleStartOverrideCommand(commandPayload)
         case .cancelOverride:


### PR DESCRIPTION
## Summary

For a remote meal command with `bolusAmount`, the `.meal` dispatch calls `handleMealCommand` and then enacts the bolus whenever `bolusAmount != nil`. Since `handleMealCommand` reports validation failures by logging and returning (it doesn't throw), a rejected meal still delivers its bolus. Carbs over the configured max is the easiest way to hit it.

This moves the bolus decision inside `handleMealCommand`, after the meal has validated and stored, so an early return also suppresses the bolus. The standalone `bolus` command is unchanged.

## Background

The max-carbs check exists to catch fat-fingered remote entries, but today it rejects the carbs and delivers the insulin anyway. The caregiver sees a rejection notification and has no reason to think a bolus went through. Found while reviewing the remote meal path for our daughter's caregiver setup.

I'm @justmaier on the Trio Discord if it's easier to discuss there.

Fixes #1349