### PR TITLE
Fix the mac build script

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,16 +21,11 @@ on:
       - '**.txt'
 
 jobs:
-  # Guards the TrioAlgorithm SPM package declared in Package.swift.
+  # Guards the TrioAlgorithm SPM package declared in AlgorithmPackage/Package.swift.
   #
-  # Package.swift is a "shadow" package: it compiles a hand-enumerated subset of
-  # the app's sources so the oref algorithm builds standalone on macOS, which is
-  # what lets CLI tools replay recorded inputs against it.
-  #
-  # The `test` job below cannot catch drift in that list, because the Xcode
-  # target globs whole directories. Any commit that adds a cross-file dependency
-  # inside an already-listed file breaks `swift test` while `test` stays green.
-  # This job is the only thing that notices.
+  # The `test` job cannot catch drift in that hand-enumerated source list: the
+  # Xcode target globs whole directories, so a new cross-file dependency breaks
+  # `swift test` while `test` stays green. This job is the only thing that notices.
   #
   # Runs in parallel with `test` and needs no simulator, so it reports in well
   # under a minute.
@@ -50,27 +45,29 @@ jobs:
         with:
           fetch-depth: 1
 
+      # `-v2-` is a cache generation marker, not a version of anything.
+      # Bump it again if the cached path ever moves.
       - name: Restore cache
         id: spm-cache-restore
         uses: actions/cache/restore@v5
         with:
-          path: .build
-          key: ${{ runner.os }}-spm-algorithm-${{ hashFiles('Package.swift', 'Trio/Sources/**/*.swift', 'TrioTests/OpenAPSSwiftTests/**/*.swift') }}
+          path: AlgorithmPackage/.build
+          key: ${{ runner.os }}-spm-algorithm-v2-${{ hashFiles('AlgorithmPackage/Package.swift', 'Trio/Sources/**/*.swift', 'TrioTests/OpenAPSSwiftTests/**/*.swift') }}
           restore-keys: |
-            ${{ runner.os }}-spm-algorithm-
+            ${{ runner.os }}-spm-algorithm-v2-
 
       - name: Show Swift version
         run: swift --version
 
       - name: Run algorithm tests
-        run: time swift test
+        run: time swift test --package-path AlgorithmPackage
 
       - name: Save cache
         if: always() && steps.spm-cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
-          path: .build
-          key: ${{ runner.os }}-spm-algorithm-${{ hashFiles('Package.swift', 'Trio/Sources/**/*.swift', 'TrioTests/OpenAPSSwiftTests/**/*.swift') }}
+          path: AlgorithmPackage/.build
+          key: ${{ runner.os }}-spm-algorithm-v2-${{ hashFiles('AlgorithmPackage/Package.swift', 'Trio/Sources/**/*.swift', 'TrioTests/OpenAPSSwiftTests/**/*.swift') }}
 
       - name: Annotate algorithm package results
         if: always()
@@ -83,11 +80,11 @@ jobs:
             {
               echo "## ❌ Algorithm package (\`swift test\`) failed"
               echo ""
-              echo "\`Package.swift\` enumerates its sources by hand, so it drifts when a"
-              echo "listed file gains a dependency on a file that is not listed."
+              echo "\`AlgorithmPackage/Package.swift\` enumerates its sources by hand, so it"
+              echo "drifts when a listed file gains a dependency on a file that is not listed."
               echo ""
               echo "If the error is \`cannot find 'X' in scope\`, add the file declaring \`X\`"
-              echo "to \`algorithmModels\` or \`algorithmHelpers\` in \`Package.swift\`."
+              echo "to \`algorithmModels\` or \`algorithmHelpers\` in that manifest."
             } >> $GITHUB_STEP_SUMMARY
           fi
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ playground.xcworkspace
 # Package.pins
 # Package.resolved
 .build/
+.swiftpm/
 
 # CocoaPods
 #

--- a/AlgorithmPackage/OpenAPSSwiftTests
+++ b/AlgorithmPackage/OpenAPSSwiftTests
@@ -1,0 +1,1 @@
+../TrioTests/OpenAPSSwiftTests

--- a/AlgorithmPackage/Package.swift
+++ b/AlgorithmPackage/Package.swift
@@ -7,11 +7,17 @@ import PackageDescription
 // This is a "shadow" package: it compiles the *existing* files in
 // place rather than owning its own copy, so there is exactly one
 // copy of every source file and the Xcode app target keeps
-// compiling the same ones.
+// compiling the same ones. `Sources` and `OpenAPSSwiftTests` are
+// symlinks back to Trio/Sources and TrioTests/OpenAPSSwiftTests.
+//
+// This lives in a subdirectory, not the repo root, because Xcode
+// prefers a root Package.swift over Trio.xcworkspace when opening
+// a folder — a root manifest makes `xed .` open the package and
+// hides every app scheme.
 //
 // Usage:
-//   swift test                            # whole algorithm suite
-//   swift test --filter IobGenerateTests  # one suite
+//   swift test --package-path AlgorithmPackage
+//   swift test --package-path AlgorithmPackage --filter IobGenerateTests
 
 let algorithmModels = [
     "Autosens",
@@ -54,7 +60,7 @@ let package = Package(
     targets: [
         .target(
             name: "Trio",
-            path: "Trio/Sources",
+            path: "Sources",
             sources: [
                 "APS/OpenAPSSwift",
                 "APS/Extensions/DecimalExtensions.swift"
@@ -64,7 +70,7 @@ let package = Package(
         .testTarget(
             name: "OpenAPSSwiftTests",
             dependencies: ["Trio"],
-            path: "TrioTests/OpenAPSSwiftTests",
+            path: "OpenAPSSwiftTests",
             resources: [.copy("json")],
             swiftSettings: [.define("TRIO_ALGORITHM_PACKAGE")]
         )

--- a/AlgorithmPackage/Sources
+++ b/AlgorithmPackage/Sources
@@ -1,0 +1,1 @@
+../Trio/Sources

--- a/Trio/Sources/APS/OpenAPSSwift/AlgorithmLoggingShim.swift
+++ b/Trio/Sources/APS/OpenAPSSwift/AlgorithmLoggingShim.swift
@@ -3,10 +3,10 @@ import Foundation
 // MARK: - Package-only logging shim
 
 //
-// This file exists solely for the `Trio` SPM target declared in the repo-root
-// `Package.swift`, which compiles the oref algorithm (plus its models) as a
-// standalone macOS-capable module so `swift test` can run the algorithm suite
-// without building the iOS app or booting a simulator.
+// This file exists solely for the `Trio` SPM target declared in
+// `AlgorithmPackage/Package.swift`, which compiles the oref algorithm (plus its
+// models) as a standalone macOS-capable module so `swift test` can run the
+// algorithm suite without building the iOS app or booting a simulator.
 //
 
 #if TRIO_ALGORITHM_PACKAGE

--- a/Trio/Sources/Models/BloodGlucose+LoopKit.swift
+++ b/Trio/Sources/Models/BloodGlucose+LoopKit.swift
@@ -5,7 +5,7 @@ import LoopKit
 // LoopKit/HealthKit adapter for `BloodGlucose`.
 //
 // Kept out of `BloodGlucose.swift` so that the model itself stays Foundation-only and can be
-// compiled by the algorithm package (see the repo-root `Package.swift`). Consumed by
+// compiled by the algorithm package (see `AlgorithmPackage/Package.swift`). Consumed by
 // `GlucoseStorage`.
 extension BloodGlucose {
     func convertStoredGlucoseSample(isManualGlucose: Bool) -> StoredGlucoseSample {

--- a/Trio/Sources/Models/CarbsEntry+LoopKit.swift
+++ b/Trio/Sources/Models/CarbsEntry+LoopKit.swift
@@ -4,7 +4,7 @@ import LoopKit
 // LoopKit adapter for `CarbsEntry`.
 //
 // Kept out of `CarbsEntry.swift` so that the model itself stays Foundation-only and can be
-// compiled by the algorithm package (see the repo-root `Package.swift`). Consumed by
+// compiled by the algorithm package (see `AlgorithmPackage/Package.swift`). Consumed by
 // `TidepoolManager`.
 extension CarbsEntry {
     func convertSyncCarb(operation: LoopKit.Operation = .create) -> SyncCarbObject {

--- a/Trio/Sources/Models/PumpHistoryEvent+LoopKit.swift
+++ b/Trio/Sources/Models/PumpHistoryEvent+LoopKit.swift
@@ -4,7 +4,7 @@ import LoopKit
 // LoopKit adapter for `EventType`.
 //
 // Kept out of `PumpHistoryEvent.swift` so that the model itself stays Foundation-only and can be
-// compiled by the algorithm package (see the repo-root `Package.swift`). Consumed by
+// compiled by the algorithm package (see `AlgorithmPackage/Package.swift`). Consumed by
 // `TidepoolManager`.
 extension EventType {
     func mapEventTypeToPumpEventType() -> PumpEventType? {


### PR DESCRIPTION
Previously there was a Package.swift file at the root directory of the
repo, so calling `xed .` opened that package instead of
Trio.xcworkspace, causing issues for the build script. This change
moves the package to a directory.

This commit was done collaboratively with @dnxzy
