### PR TITLE
Refresh currentGlucoseTarget so dynamic color follows target edits

### DIFF
--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -919,9 +919,11 @@ extension Home {
         private func setupGlucoseTargets() async {
             let bgTargets = await provider.getBGTargets()
             let targetProfiles = processFetchedTargets(bgTargets, startMarker: startMarker)
+            let currentTarget = bgTargets.currentTarget()
             await MainActor.run {
                 self.bgTargets = bgTargets
                 self.targetProfiles = targetProfiles
+                if let currentTarget { self.currentGlucoseTarget = currentTarget }
             }
         }
 
@@ -931,12 +933,6 @@ extension Home {
                 await MainActor.run {
                     self.reservoir = reservoir
                 }
-            }
-        }
-
-        private func getCurrentGlucoseTarget() async {
-            if let target = bgTargets.currentTarget() {
-                await MainActor.run { currentGlucoseTarget = target }
             }
         }
 
@@ -1027,7 +1023,6 @@ extension Home.StateModel:
         lowGlucose = settingsManager.settings.low
         highGlucose = settingsManager.settings.high
         Task {
-            await getCurrentGlucoseTarget()
             await setupGlucoseTargets()
         }
         eA1cDisplayUnit = settingsManager.settings.eA1cDisplayUnit


### PR DESCRIPTION
Resolves #1355 

## Fix stale glucose target behind the home chart's dynamic color

### Problem

Editing the glucose target profile did not update the dynamic glucose color on the
Home view. Point colors — along with the header glucose reading and the chart
selection popover — kept scoring against the previously configured target.

### Root cause

All three of those read `Home.StateModel.currentGlucoseTarget`, which was only ever
assigned from `getCurrentGlucoseTarget()`. That method had exactly one call site:
`settingsDidChange`. Three consequences:

1. **Target edits never reached it.** BG targets are not part of `TrioSettings` —
   saving the profile notifies `BGTargetsObserver`, so `bgTargetsDidChange` →
   `setupGlucoseTargets()` runs. That path refreshed `bgTargets` and
   `targetProfiles` but never `currentGlucoseTarget`.
2. **When `settingsDidChange` did fire, it read stale data.**
   `getCurrentGlucoseTarget()` ran *before* `setupGlucoseTargets()` reloaded
   `bgTargets`, deriving the current target from the previous profile — always one
   edit behind.
3. **Never initialized at launch.** `setupSettings()` does not assign it, so it sat
   at the hardcoded default of 100 mg/dL until some unrelated setting changed.

### Fix

Derive the current target inside `setupGlucoseTargets()` from the profile it just
loaded, and publish it in the same `MainActor.run` as `bgTargets` and
`targetProfiles`. That single hook covers every path that already reloads targets:
app launch, `bgTargetsDidChange`, and `settingsDidChange`. `getCurrentGlucoseTarget()`
is removed — it had no other callers.

Net −5 lines. Minor side benefit: the `currentTarget()` lookup allocates a
`DateFormatter` per schedule entry via `TherapySettingsUtil.parseTime`, and now runs
off the main actor instead of on it.

### Not included

`BGTargets.currentTarget()` reads the *scheduled* profile only — it does not account
for overrides or temp targets. The Live Activity sources its target from
`determination.currentTarget` (the effective target oref used), so the two can
legitimately disagree while an override is active. Unchanged here; noting it as a
known difference rather than a regression.

`OnboardingStateModel` writes `bg_targets.json` directly without notifying
`BGTargetsObserver`. Harmless in practice (the Home state model is not live during
onboarding) and left alone.

For schedules with more than one target segment, `currentGlucoseTarget` is a single
scalar applied to every point on the chart, so historical readings are colored
against the segment current at the last targets reload rather than the one in effect
at their own timestamp. Nothing refreshes it when the clock crosses a segment
boundary either, so the value can lag until the next reload. Both are pre-existing
and left alone here — per-point coloring would be a visible behavior change, though
`targetProfiles` already carries the per-segment data it would need.