### PR TITLE
Exclude the localization catalog from the TrioAlgorithm package

### DIFF
--- a/AlgorithmPackage/Package.swift
+++ b/AlgorithmPackage/Package.swift
@@ -61,6 +61,10 @@ let package = Package(
         .target(
             name: "Trio",
             path: "Sources",
+            // An explicit `sources:` list restricts compilation only — SwiftPM
+            // still auto-discovers resources anywhere under `path`. Keep the
+            // app's localizations out; the algorithm reads no strings.
+            exclude: ["Localizations"],
             sources: [
                 "APS/OpenAPSSwift",
                 "APS/Extensions/DecimalExtensions.swift"


### PR DESCRIPTION
The `Trio` target in `AlgorithmPackage/Package.swift` lists its sources by hand, but `sources:` only restricts what gets *compiled* — SwiftPM still auto-discovers resources anywhere under the target path. So the package picks up `Sources/Localizations/Main`, builds a `TrioAlgorithm_Trio.bundle` (with `el.lproj`/`pt.lproj`) that nothing in the algorithm ever reads, and the 9.4 MB `Localizable.xcstrings` shows up in the unhandled-files warning.

You can see it on current `dev`: `swift build --package-path AlgorithmPackage` produces the bundle plus a generated `resource_bundle_accessor.swift`. With `exclude: ["Localizations"]` both disappear, and the unhandled-files count drops from 600 to 599. Tests are unaffected — `swift test --package-path AlgorithmPackage` passes, 208 tests in 28 suites.

Some background on how I found this: I was on a checkout from before #1353, ran `xed .`, and ended up building the package for an iOS destination — exactly the trap that PR's commit message describes. In that configuration the catalog gets compiled with String Catalog symbol generation on (SwiftPM has no off switch for it, and `Config.xcconfig` doesn't reach package builds), which turns some pre-existing duplicate keys into 20 hard "would generate the same symbol" errors — I've filed the duplicate keys separately as #1360. #1353 already closed off the main way into that trap; this PR just keeps the catalog out of the package entirely. It also explains why #1344 merged green: the macOS `swift test` path never compiles the catalog with symbol generation, so there was nothing for it to catch.

Two smaller things while I'm here:

- Is `unit_tests.yml` (`zzz [DO NOT RUN]`, gated on `repository_owner == 'nightscout'`) intentionally parked for now? Just checking whether the algorithm job is expected to run on PRs yet.
- The manifest still declares `platforms: [.macOS(.v14)]` only, so building the package for an iOS destination also trips over `withoutEscapingSlashes` in `Helpers/JSON.swift` (SwiftPM falls back to its ancient default minimums). If you'd like the package buildable from non-macOS destinations, I'm happy to follow up with `.iOS(.v17), .watchOS(.v10)` to match the app's deployment targets — but if it's meant to be macOS-only by design, ignore this bit.