### PR TITLE
Escape literal percent in Swedish exercise-mode translation

### DIFF
--- a/Trio/Sources/Localizations/Main/Localizable.xcstrings
+++ b/Trio/Sources/Localizations/Main/Localizable.xcstrings
@@ -242019,7 +242019,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inställd till ett glukosvärde, t.ex. 160 (mg/dl = 8,9 mmol/l), vilket innebär att när det temporära målvärdet är 8,9 mmol/l och 'motinsläge' är på, används endast en 50%-ig basal vid detta blodglukosvärde (120 = 75%; 140 = 60%). Detta kan justeras, för att ge dig mer kontroll över dina temporära målvärden vid träning."
+            "value" : "Inställd till ett glukosvärde, t.ex. 160 (mg/dl = 8,9 mmol/l), vilket innebär att när det temporära målvärdet är 8,9 mmol/l och 'motinsläge' är på, används endast en 50%%-ig basal vid detta blodglukosvärde (120 = 75%; 140 = 60%). Detta kan justeras, för att ge dig mer kontroll över dina temporära målvärden vid träning."
           }
         },
         "tr" : {


### PR DESCRIPTION
Xcode fails to compile the string catalog with:

```
Unable to create a Swift type from the format specifier "%-i"
```

It's in the Swedish translation of the exercise-mode help text ("Set to a number, e.g. 160, …"), where "50%-ig" ("fifty-percent") happens to read as a `%-i` format specifier. Escaping the percent as `%%` fixes the parse, and the string renders exactly the same to Swedish users.

The string came in with the "Merge translations into a String Catalog" migration, and it's the only occurrence of the pattern in the catalog — I checked all 2,557 keys across every localization and variation.