### PR TITLE
feat: Add dynamic glucose color and target for Garmin watches

### DIFF
--- a/Trio/Sources/Models/GarminWatchState.swift
+++ b/Trio/Sources/Models/GarminWatchState.swift
@@ -64,6 +64,18 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
     /// Options: "tbr" or "eventualBG"
     var displaySecondaryAttributeChoice: String?
 
+    /// Glucose color scheme configured on the phone: "dynamic" or "static".
+    /// Watch apps that can draw the hue ramp use it to pick the palette; the short
+    /// form is sent rather than the `GlucoseColorScheme` raw value because that is
+    /// what the watchface reads. Optional extension key: receivers that don't know
+    /// it ignore it and keep their own coloring.
+    var glucoseColorScheme: String?
+
+    /// Scheduled glucose target in raw mg/dL (no unit conversion applied), the green
+    /// midpoint of the dynamic hue ramp. Profile target only, matching the Home
+    /// chart — it does not follow overrides or temp targets.
+    var targetGlucose: Int16?
+
     static func == (lhs: GarminWatchState, rhs: GarminWatchState) -> Bool {
         lhs.date == rhs.date &&
             lhs.glucoseDate == rhs.glucoseDate &&
@@ -79,7 +91,9 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
             lhs.isf == rhs.isf &&
             lhs.sensRatio == rhs.sensRatio &&
             lhs.displayPrimaryAttributeChoice == rhs.displayPrimaryAttributeChoice &&
-            lhs.displaySecondaryAttributeChoice == rhs.displaySecondaryAttributeChoice
+            lhs.displaySecondaryAttributeChoice == rhs.displaySecondaryAttributeChoice &&
+            lhs.glucoseColorScheme == rhs.glucoseColorScheme &&
+            lhs.targetGlucose == rhs.targetGlucose
     }
 
     func hash(into hasher: inout Hasher) {
@@ -98,6 +112,8 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
         hasher.combine(sensRatio)
         hasher.combine(displayPrimaryAttributeChoice)
         hasher.combine(displaySecondaryAttributeChoice)
+        hasher.combine(glucoseColorScheme)
+        hasher.combine(targetGlucose)
     }
 
     enum CodingKeys: String, CodingKey {
@@ -116,6 +132,8 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
         case sensRatio
         case displayPrimaryAttributeChoice
         case displaySecondaryAttributeChoice
+        case glucoseColorScheme
+        case targetGlucose
     }
 
     /// Custom encoding that excludes nil values from the JSON output
@@ -138,5 +156,7 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
         try container.encodeIfPresent(sensRatio?.roundedDouble(toPlaces: 2), forKey: .sensRatio)
         try container.encodeIfPresent(displayPrimaryAttributeChoice, forKey: .displayPrimaryAttributeChoice)
         try container.encodeIfPresent(displaySecondaryAttributeChoice, forKey: .displaySecondaryAttributeChoice)
+        try container.encodeIfPresent(glucoseColorScheme, forKey: .glucoseColorScheme)
+        try container.encodeIfPresent(targetGlucose, forKey: .targetGlucose)
     }
 }

--- a/Trio/Sources/Models/GarminWatchState.swift
+++ b/Trio/Sources/Models/GarminWatchState.swift
@@ -36,44 +36,39 @@ struct GarminWatchState: Hashable, Equatable, Sendable, Encodable {
     /// Unit hint for the watchface ("mgdl" or "mmol")
     var units_hint: String?
 
-    /// Insulin on board as a decimal value (only in first array entry)
+    /// Insulin on board as a decimal value
     var iob: Double?
 
-    /// Current temp basal rate in U/hr (only in first array entry)
+    /// Current temp basal rate in U/hr
     var tbr: Double?
 
-    /// Carbs on board as a decimal value (only in first array entry)
+    /// Carbs on board as a decimal value
     var cob: Double?
 
-    /// Predicted eventual blood glucose (excluded if data type 2 is set to TBR)
+    /// Predicted eventual blood glucose
     var eventualBG: Int16?
 
     /// Current insulin sensitivity factor as an integer (only in first array entry)
     var isf: Int16?
 
-    /// AutoISF sensitivity ratio (included only if data type 1 is set to sensRatio)
+    /// Sensitivity ratio 
     var sensRatio: Double?
 
     // MARK: - Display Configuration Fields
 
-    /// Specifies which primary attribute to display
+    /// Primary attribute to display
     /// Options: "cob", "isf", or "sensRatio"
     var displayPrimaryAttributeChoice: String?
 
-    /// Specifies which secondary attribute to display
+    /// secondary attribute to display
     /// Options: "tbr" or "eventualBG"
     var displaySecondaryAttributeChoice: String?
 
-    /// Glucose color scheme configured on the phone: "dynamic" or "static".
-    /// Watch apps that can draw the hue ramp use it to pick the palette; the short
-    /// form is sent rather than the `GlucoseColorScheme` raw value because that is
-    /// what the watchface reads. Optional extension key: receivers that don't know
-    /// it ignore it and keep their own coloring.
+    /// Trio color scheme for BG curve currently used
+    /// Options: "dynamic" or "static"
     var glucoseColorScheme: String?
 
-    /// Scheduled glucose target in raw mg/dL (no unit conversion applied), the green
-    /// midpoint of the dynamic hue ramp. Profile target only, matching the Home
-    /// chart — it does not follow overrides or temp targets.
+    /// Scheduled Profile target currently active
     var targetGlucose: Int16?
 
     static func == (lhs: GarminWatchState, rhs: GarminWatchState) -> Bool {

--- a/Trio/Sources/Services/WatchManager/GarminManager.swift
+++ b/Trio/Sources/Services/WatchManager/GarminManager.swift
@@ -54,6 +54,9 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
     /// Stores, retrieves, and updates insulin dose determinations in CoreData.
     @Injected() private var determinationStorage: DeterminationStorage!
 
+    /// JSON settings store, used here to read the glucose target profile.
+    @Injected() private var fileStorage: FileStorage!
+
     @Injected() private var iobService: IOBService!
     @Injected() private var trioAlertManager: TrioAlertManager!
 
@@ -80,6 +83,10 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
 
     /// Current glucose units, either mg/dL or mmol/L, read from user settings.
     private var units: GlucoseUnits = .mgdL
+
+    /// Glucose color scheme, read from user settings and forwarded to watch apps
+    /// that can color glucose themselves.
+    private var glucoseColorScheme: GlucoseColorScheme = .staticColor
 
     // MARK: - Debug Logging
 
@@ -190,9 +197,13 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
         subscribeToWatchState()
 
         units = settingsManager.settings.units
+        glucoseColorScheme = settingsManager.settings.glucoseColorScheme
         previousGarminSettings = settingsManager.settings.garminSettings
 
         broadcaster.register(SettingsObserver.self, observer: self)
+        // Glucose targets are not part of TrioSettings, so editing the target profile
+        // notifies this observer rather than firing settingsDidChange.
+        broadcaster.register(BGTargetsObserver.self, observer: self)
 
         coreDataPublisher =
             CoreDataStack.shared.entityChangePublisher
@@ -550,12 +561,23 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
 
         let tempBasalIds = try await fetchTempBasals()
 
+        // Glucose target for watch apps that color glucose on a hue ramp. Read fresh on
+        // every build rather than cached, so a target profile edit is picked up here.
+        // Scheduled profile target only, matching the Home chart -- overrides and temp
+        // targets are not reflected (see nightscout/Trio#1357).
+        let bgTargets = await fileStorage.retrieveAsync(OpenAPS.Settings.bgTargets, as: BGTargets.self)
+            ?? BGTargets(from: OpenAPS.defaults(for: OpenAPS.Settings.bgTargets))
+            ?? BGTargets(units: .mgdL, userPreferredUnits: .mgdL, targets: [])
+        let targetGlucoseValue = bgTargets.currentTarget().map { Int16(truncating: $0 as NSDecimalNumber) }
+
         // Extract all needed values from self before entering perform block (Sendable compliance)
         let unitsValue = units
         let iobValue = formatIOB(iobService.currentIOB ?? Decimal(0))
         let basalProfile = settingsManager.preferences.basalProfile as? [BasalProfileEntry] ?? []
         let displayPrimaryChoice = settingsManager.settings.garminSettings.primaryAttributeChoice.rawValue
         let displaySecondaryChoice = settingsManager.settings.garminSettings.secondaryAttributeChoice.rawValue
+        // Short form, not the enum raw value: this is the wire format the watchface reads.
+        let colorSchemeValue = glucoseColorScheme == .dynamicColor ? "dynamic" : "static"
         let needsHistoricalData = needsHistoricalGlucoseData
         let shouldDebug = debugWatchState
         let previousHash = lastPreparedDataHash
@@ -672,6 +694,8 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
                     watchState.sensRatio = sensRatioValue
                     watchState.displayPrimaryAttributeChoice = displayPrimaryChoice
                     watchState.displaySecondaryAttributeChoice = displaySecondaryChoice
+                    watchState.glucoseColorScheme = colorSchemeValue
+                    watchState.targetGlucose = targetGlucoseValue
                 }
 
                 watchStates.append(watchState)
@@ -691,9 +715,10 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
                 let cobFormatted = String(format: "%.0f", watchStates.first?.cob ?? 0)
                 let tbrFormatted = String(format: "%.2f", watchStates.first?.tbr ?? 0)
                 let sensRatioFormatted = String(format: "%.2f", watchStates.first?.sensRatio ?? 0)
+                let targetFormatted = watchStates.first?.targetGlucose.map { "\($0)" } ?? "none"
                 debug(
                     .watchManager,
-                    "Garmin: Prepared \(watchStates.count) entries - sgv: \(watchStates.first?.sgv ?? 0), iob: \(iobFormatted), cob: \(cobFormatted), tbr: \(tbrFormatted), eventualBG: \(watchStates.first?.eventualBG ?? 0), sensRatio: \(sensRatioFormatted)"
+                    "Garmin: Prepared \(watchStates.count) entries - sgv: \(watchStates.first?.sgv ?? 0), iob: \(iobFormatted), cob: \(cobFormatted), tbr: \(tbrFormatted), eventualBG: \(watchStates.first?.eventualBG ?? 0), sensRatio: \(sensRatioFormatted), colorScheme: \(watchStates.first?.glucoseColorScheme ?? "none"), target: \(targetFormatted)"
                 )
             }
 
@@ -1067,9 +1092,11 @@ extension BaseGarminManager: SettingsObserver {
     func settingsDidChange(_: TrioSettings) {
         let currentGarminSettings = settingsManager.settings.garminSettings
         let currentUnits = settingsManager.settings.units
+        let currentColorScheme = settingsManager.settings.glucoseColorScheme
 
         // Detect what specifically changed
         let unitsChanged = currentUnits != units
+        let colorSchemeChanged = currentColorScheme != glucoseColorScheme
         let watchfaceChanged = currentGarminSettings.watchface != previousGarminSettings.watchface
         let datafieldChanged = currentGarminSettings.datafield != previousGarminSettings.datafield
         let watchfaceDataEnabledChanged = currentGarminSettings.isWatchfaceDataEnabled != previousGarminSettings
@@ -1080,6 +1107,7 @@ extension BaseGarminManager: SettingsObserver {
 
         // Update stored values
         units = currentUnits
+        glucoseColorScheme = currentColorScheme
 
         // Re-register devices only if watchface/datafield configuration changed
         if watchfaceChanged || datafieldChanged || watchfaceDataEnabledChanged {
@@ -1100,7 +1128,7 @@ extension BaseGarminManager: SettingsObserver {
                 debug(.watchManager, "Garmin: Watchface data enabled - sending update immediately")
             }
             triggerWatchStateUpdate(triggeredBy: "Settings")
-        } else if unitsChanged || displayAttributesChanged {
+        } else if unitsChanged || displayAttributesChanged || colorSchemeChanged {
             // Throttle other settings changes in case user makes multiple changes
             if debugWatchState {
                 debug(.watchManager, "Garmin: Settings changed - scheduling throttled update")
@@ -1110,5 +1138,19 @@ extension BaseGarminManager: SettingsObserver {
 
         // Store current Garmin settings for next comparison
         previousGarminSettings = currentGarminSettings
+    }
+}
+
+extension BaseGarminManager: BGTargetsObserver {
+    /// Called when the glucose target profile is edited. Targets live in their own JSON
+    /// store rather than in TrioSettings, so this is the only notification for them.
+    /// The new target is read inside `setupGarminWatchState`; this just prompts a rebuild
+    /// so the watch does not wait for the next glucose reading to see it.
+    /// - Parameter _: The updated targets, re-read from storage during preparation.
+    func bgTargetsDidChange(_: BGTargets) {
+        if debugWatchState {
+            debug(.watchManager, "Garmin: Glucose targets changed - scheduling throttled update")
+        }
+        sendSettingsUpdateThrottled()
     }
 }

--- a/Trio/Sources/Services/WatchManager/GarminManager.swift
+++ b/Trio/Sources/Services/WatchManager/GarminManager.swift
@@ -561,10 +561,8 @@ final class BaseGarminManager: NSObject, GarminManager, Injectable {
 
         let tempBasalIds = try await fetchTempBasals()
 
-        // Glucose target for watch apps that color glucose on a hue ramp. Read fresh on
-        // every build rather than cached, so a target profile edit is picked up here.
         // Scheduled profile target only, matching the Home chart -- overrides and temp
-        // targets are not reflected (see nightscout/Trio#1357).
+        // targets are not reflected.
         let bgTargets = await fileStorage.retrieveAsync(OpenAPS.Settings.bgTargets, as: BGTargets.self)
             ?? BGTargets(from: OpenAPS.defaults(for: OpenAPS.Settings.bgTargets))
             ?? BGTargets(units: .mgdL, userPreferredUnits: .mgdL, targets: [])
@@ -1142,10 +1140,7 @@ extension BaseGarminManager: SettingsObserver {
 }
 
 extension BaseGarminManager: BGTargetsObserver {
-    /// Called when the glucose target profile is edited. Targets live in their own JSON
-    /// store rather than in TrioSettings, so this is the only notification for them.
-    /// The new target is read inside `setupGarminWatchState`; this just prompts a rebuild
-    /// so the watch does not wait for the next glucose reading to see it.
+    /// Called when the glucose target profile is edited.
     /// - Parameter _: The updated targets, re-read from storage during preparation.
     func bgTargetsDidChange(_: BGTargets) {
         if debugWatchState {


### PR DESCRIPTION
Transmits the configured glucose color scheme and scheduled target glucose to Garmin watch apps. This allows compatible watch apps to render glucose values with dynamic coloring, adapting to the user's settings and target range. Updates are triggered when the color scheme or target profile changes.

Support [PR to Swissalpine Watchface](https://github.com/mountrcg/Trio-Swissalpine-Watchface/pull/1) by @MikePlante1 .

```
GarminManager.swift - setupGarminWatchState(triggeredBy:) - 719 DEV: Garmin: Prepared 24 entries - sgv: 150, iob: 0.0, cob: 0, tbr: 0.00, eventualBG: 146, sensRatio: 1.00, colorScheme: static, target: 100
GarminManager.swift - settingsDidChange(_:) - 1134 DEV: Garmin: Settings changed - scheduling throttled update
GarminManager.swift - sendSettingsUpdateThrottled() - 457 DEV: Garmin: Settings throttle timer started (10s)
GarminManager.swift - sendSettingsUpdateThrottled() - 435 DEV: Garmin: Settings throttle timer fired - sending update
GarminManager.swift - setupGarminWatchState(triggeredBy:) - 551 DEV: Garmin: Preparing watch state [Trigger: Settings]
GarminManager.swift - setupGarminWatchState(triggeredBy:) - 719 DEV: Garmin: Prepared 24 entries - sgv: 150, iob: 0.0, cob: 0, tbr: 0.00, eventualBG: 146, sensRatio: 1.00, colorScheme: dynamic, target: 100
GarminManager.swift - debugGarmin(_:) - 112 DEV: Garmin: Skipping watchface:Swissalpine - device not ready
GarminManager.swift - bgTargetsDidChange(_:) - 1152 DEV: Garmin: Glucose targets changed - scheduling throttled update
GarminManager.swift - sendSettingsUpdateThrottled() - 457 DEV: Garmin: Settings throttle timer started (10s)
GarminManager.swift - sendSettingsUpdateThrottled() - 435 DEV: Garmin: Settings throttle timer fired - sending update
GarminManager.swift - setupGarminWatchState(triggeredBy:) - 551 DEV: Garmin: Preparing watch state [Trigger: Settings]
GarminManager.swift - setupGarminWatchState(triggeredBy:) - 719 DEV: Garmin: Prepared 24 entries - sgv: 150, iob: 0.0, cob: 0, tbr: 0.00, eventualBG: 146, sensRatio: 1.00, colorScheme: dynamic, target: 120
GarminManager.swift - debugGarmin(_:) - 112 DEV: Garmin: Skipping watchface:Swissalpine - device not ready
```
Future state to be seen on [Garmin ConnectIQ](https://apps.garmin.com/apps/8b99bdbc-16c6-483f-ac8b-04f117915bee)
