### PR TITLE
Stop Crashlytics Uploads Immediately After Diagnostics Opt-Out

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -785,6 +785,7 @@
 		DD7E1E300000000000000010 /* TelemetryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7E1E30000000000000000F /* TelemetryProvider.swift */; };
 		DD7E1E300000000000000012 /* TelemetryStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7E1E300000000000000011 /* TelemetryStateModel.swift */; };
 		DD7E1E300000000000000014 /* TelemetryAttestor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7E1E300000000000000013 /* TelemetryAttestor.swift */; };
+		DD7E1E300000000000000016 /* CrashReportingGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7E1E300000000000000015 /* CrashReportingGate.swift */; };
 		DD8262CB2D289297009F6F62 /* BolusConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8262CA2D289297009F6F62 /* BolusConfirmationView.swift */; };
 		DD82D4B82DCAB2BA00BAFC77 /* PropertyPersistentFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD82D4B72DCAB2BA00BAFC77 /* PropertyPersistentFlags.swift */; };
 		DD868FD82E381A54005D3308 /* APNSJWTClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD868FD72E381A54005D3308 /* APNSJWTClaims.swift */; };
@@ -1804,6 +1805,7 @@
 		DD7E1E30000000000000000F /* TelemetryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryProvider.swift; sourceTree = "<group>"; };
 		DD7E1E300000000000000011 /* TelemetryStateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryStateModel.swift; sourceTree = "<group>"; };
 		DD7E1E300000000000000013 /* TelemetryAttestor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryAttestor.swift; sourceTree = "<group>"; };
+		DD7E1E300000000000000015 /* CrashReportingGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportingGate.swift; sourceTree = "<group>"; };
 		DD8262CA2D289297009F6F62 /* BolusConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusConfirmationView.swift; sourceTree = "<group>"; };
 		DD82D4B72DCAB2BA00BAFC77 /* PropertyPersistentFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyPersistentFlags.swift; sourceTree = "<group>"; };
 		DD868FD72E381A54005D3308 /* APNSJWTClaims.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNSJWTClaims.swift; sourceTree = "<group>"; };
@@ -4193,6 +4195,7 @@
 		DD7E1E30000000000000000A /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				DD7E1E300000000000000015 /* CrashReportingGate.swift */,
 				DD7E1E300000000000000013 /* TelemetryAttestor.swift */,
 				DD7E1E300000000000000001 /* TelemetryClient.swift */,
 			);
@@ -5059,6 +5062,7 @@
 				58645BA32CA2D325008AFCE7 /* BatterySetup.swift in Sources */,
 				DD82D4B82DCAB2BA00BAFC77 /* PropertyPersistentFlags.swift in Sources */,
 				DD7E1E300000000000000002 /* TelemetryClient.swift in Sources */,
+				DD7E1E300000000000000016 /* CrashReportingGate.swift in Sources */,
 				DD7E1E300000000000000014 /* TelemetryAttestor.swift in Sources */,
 				DD7E1E300000000000000004 /* TelemetryPreviewView.swift in Sources */,
 				DD7E1E300000000000000006 /* TelemetryPrivacyView.swift in Sources */,

--- a/Trio/Sources/Application/AppDelegate.swift
+++ b/Trio/Sources/Application/AppDelegate.swift
@@ -1,5 +1,3 @@
-import FirebaseCore
-import FirebaseCrashlytics
 import SwiftUI
 import UIKit
 import UserNotifications
@@ -9,16 +7,11 @@ class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject, UNUserNoti
         _: UIApplication,
         didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        FirebaseApp.configure()
-
-        // Default to `true` if the key doesn't exist
+        // Default to `true` if the key doesn't exist — Trio is opt-out, not opt-in.
+        // Read before touching Firebase: an explicit opt-out means we never
+        // configure it, so no component can queue or upload anything.
         let crashReportingEnabled: Bool = PropertyPersistentFlags.shared.crashlyticsSharingEnabled ?? true
-
-        // The docs say that changes to this don't take effect until
-        // the next app boot, but this is fine since the app will need
-        // to boot after a crash
-        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(crashReportingEnabled)
-        Crashlytics.crashlytics().setCustomValue(Bundle.main.appDevVersion ?? "unknown", forKey: "app_dev_version")
+        CrashReportingGate.configureAtLaunch(enabled: crashReportingEnabled)
 
         // Telemetry: record this cold launch into the sliding 7-day window,
         // then drive cadence via three layered triggers — listed below in

--- a/Trio/Sources/Modules/AppDiagnostics/AppDiagnosticsStateModel.swift
+++ b/Trio/Sources/Modules/AppDiagnostics/AppDiagnosticsStateModel.swift
@@ -1,4 +1,3 @@
-import FirebaseCrashlytics
 import Observation
 import SwiftUI
 
@@ -31,7 +30,10 @@ extension AppDiagnostics {
 
             PropertyPersistentFlags.shared.crashlyticsSharingEnabled = diagnosticsSharingOption.crashlyticsEnabled
             PropertyPersistentFlags.shared.telemetrySharingEnabled = diagnosticsSharingOption.telemetryEnabled
-            Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(diagnosticsSharingOption.crashlyticsEnabled)
+
+            // Opting out also drops whatever GoogleDataTransport already queued,
+            // so no crash-reporting upload survives the switch.
+            CrashReportingGate.setEnabled(diagnosticsSharingOption.crashlyticsEnabled)
 
             // Fire an inaugural send on a fresh re-opt-in so the first data
             // point arrives immediately rather than 24h later.

--- a/Trio/Sources/Services/Telemetry/CrashReportingGate.swift
+++ b/Trio/Sources/Services/Telemetry/CrashReportingGate.swift
@@ -1,0 +1,97 @@
+import FirebaseCore
+import FirebaseCrashlytics
+import Foundation
+
+/// Enforces the App Diagnostics opt-out for the Crashlytics data stream.
+///
+/// Trio is opt-out, not opt-in, so on an untouched install Firebase is
+/// configured at launch and FirebaseSessions (a transitive dependency of
+/// FirebaseCrashlytics) hands a session-start event to GoogleDataTransport.
+/// That is intended. The problem this type solves is what happens *after* the
+/// user opts out:
+///
+///   * `setCrashlyticsCollectionEnabled(false)` only gates *future* events. It
+///     does not touch the batch GoogleDataTransport already wrote to disk, and
+///     GDT retries queued events for up to seven days on its own timer — which
+///     is why a connection to `firebaselogging-pa.googleapis.com` still shows up
+///     in Apple's App Privacy Report minutes after switching sharing off.
+///   * On every later launch, `FirebaseApp.configure()` would start the whole
+///     stack again before anything consults the user's choice.
+///
+/// So opting out purges GDT's store, and subsequent launches skip Firebase
+/// initialization entirely — no Firebase component exists to queue or upload.
+enum CrashReportingGate {
+    /// GoogleDataTransport's on-disk event store. Mirrors `GDTCORRootDirectory()`,
+    /// which is `<container>/Library/Caches/google-sdks-events`.
+    private static var transportStorageURL: URL? {
+        FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("google-sdks-events", isDirectory: true)
+    }
+
+    /// Launch-time entry point. Configures Firebase only when the user has not
+    /// opted out; when they have, nothing is configured and any events left over
+    /// from before the opt-out are dropped so a later re-opt-in can't flush them.
+    static func configureAtLaunch(enabled: Bool) {
+        guard enabled else {
+            purgeQueuedTransportEvents()
+            return
+        }
+
+        FirebaseApp.configure()
+
+        // The docs say that changes to this don't take effect until
+        // the next app boot, but this is fine since the app will need
+        // to boot after a crash
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
+        Crashlytics.crashlytics().setCustomValue(Bundle.main.appDevVersion ?? "unknown", forKey: "app_dev_version")
+    }
+
+    /// Runtime entry point for the App Diagnostics setting.
+    ///
+    /// Turning sharing back on configures Firebase if `configureAtLaunch` skipped
+    /// it, so the choice takes effect without waiting for a restart.
+    static func setEnabled(_ enabled: Bool) {
+        guard enabled else {
+            // Firebase may never have been configured this launch; only reach for
+            // Crashlytics if it exists, otherwise there is nothing to switch off.
+            if FirebaseApp.app() != nil {
+                Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
+                Crashlytics.crashlytics().deleteUnsentReports()
+            }
+            purgeQueuedTransportEvents()
+            return
+        }
+
+        if FirebaseApp.app() == nil {
+            FirebaseApp.configure()
+        }
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(true)
+        Crashlytics.crashlytics().setCustomValue(Bundle.main.appDevVersion ?? "unknown", forKey: "app_dev_version")
+    }
+
+    /// Deletes GoogleDataTransport's queued events and batches.
+    ///
+    /// GDT exposes no public purge API, so this removes its cache directory
+    /// outright. Safe to do at any point: `GDTCORRootDirectory()` recreates the
+    /// directory on next access, and the only thing lost is unsent diagnostics —
+    /// exactly what the user asked us to stop sending.
+    static func purgeQueuedTransportEvents() {
+        guard let transportStorageURL,
+              FileManager.default.fileExists(atPath: transportStorageURL.path)
+        else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: transportStorageURL)
+            debug(.default, "Purged queued GoogleDataTransport events after diagnostics opt-out.")
+        } catch {
+            debug(
+                .default,
+                "\(DebuggingIdentifiers.failed) failed to purge queued GoogleDataTransport events: \(error)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
`setCrashlyticsCollectionEnabled(false)` only gates future events. The FirebaseSessions event GoogleDataTransport already queued stays on disk and GDT retries it for seven days, so firebaselogging-pa.googleapis.com still shows up in App Privacy Report minutes after opting out.

Route both call sites through `CrashReportingGate: purge` GDT's store when a Trio user opts out, and skip `FirebaseApp.configure()` on any later launches so nothing can re-queue or upload queued sessions. 

Trio’s opt-out-by-default stays unchanged.

Fixes #1372.