### PR TITLE
Introduce Custom Liquid Glass-Styled Action Sheet as Confirmation Dialog Replacement

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -788,6 +788,7 @@
 		DD4C581F2D73C43D001BFF2C /* LoopStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4C581E2D73C43D001BFF2C /* LoopStatsView.swift */; };
 		DD4FFF332D458EE600B6CFF9 /* GarminWatchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4FFF322D458EE600B6CFF9 /* GarminWatchState.swift */; };
 		DD500A712807000000000101 /* SnoozeAlertsSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD500A712807000000000100 /* SnoozeAlertsSheetView.swift */; };
+		7A11AC0DE000000000000171 /* GlassActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000170 /* GlassActionSheet.swift */; };
 		7A11AC0DE000000000000114 /* ManualGlucoseEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000014 /* ManualGlucoseEntryView.swift */; };
 		DD5DC9F12CF3D97C00AB8703 /* AdjustmentsStateModel+Overrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5DC9F02CF3D96E00AB8703 /* AdjustmentsStateModel+Overrides.swift */; };
 		DD5DC9F32CF3D9DD00AB8703 /* AdjustmentsStateModel+TempTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5DC9F22CF3D9D600AB8703 /* AdjustmentsStateModel+TempTargets.swift */; };
@@ -1840,6 +1841,7 @@
 		DD4C581E2D73C43D001BFF2C /* LoopStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopStatsView.swift; sourceTree = "<group>"; };
 		DD4FFF322D458EE600B6CFF9 /* GarminWatchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GarminWatchState.swift; sourceTree = "<group>"; };
 		DD500A712807000000000100 /* SnoozeAlertsSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnoozeAlertsSheetView.swift; sourceTree = "<group>"; };
+		7A11AC0DE000000000000170 /* GlassActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassActionSheet.swift; sourceTree = "<group>"; };
 		7A11AC0DE000000000000014 /* ManualGlucoseEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualGlucoseEntryView.swift; sourceTree = "<group>"; };
 		DD5DC9F02CF3D96E00AB8703 /* AdjustmentsStateModel+Overrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdjustmentsStateModel+Overrides.swift"; sourceTree = "<group>"; };
 		DD5DC9F22CF3D9D600AB8703 /* AdjustmentsStateModel+TempTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdjustmentsStateModel+TempTargets.swift"; sourceTree = "<group>"; };
@@ -2782,6 +2784,7 @@
 				48B83503461B4F8D97B30115 /* SettingsSearchHighlight.swift */,
 				DD17452A2C556E8100211FAC /* SettingInputHintView.swift */,
 				DD500A712807000000000100 /* SnoozeAlertsSheetView.swift */,
+				7A11AC0DE000000000000170 /* GlassActionSheet.swift */,
 				7A11AC0DE000000000000014 /* ManualGlucoseEntryView.swift */,
 			);
 			path = Views;
@@ -5237,6 +5240,7 @@
 				AC19EF2C94084B5BA0175D1D /* SettingsSearchHighlight.swift in Sources */,
 				DD17452B2C556E8100211FAC /* SettingInputHintView.swift in Sources */,
 				DD500A712807000000000101 /* SnoozeAlertsSheetView.swift in Sources */,
+				7A11AC0DE000000000000171 /* GlassActionSheet.swift in Sources */,
 				7A11AC0DE000000000000114 /* ManualGlucoseEntryView.swift in Sources */,
 				38E44528274E401C00EC9A94 /* Protected.swift in Sources */,
 				DD3F1F8B2D9E08B600DCE7B3 /* NightscoutLoginStepView.swift in Sources */,

--- a/Trio/Sources/Modules/Adjustments/View/AdjustmentsRootView.swift
+++ b/Trio/Sources/Modules/Adjustments/View/AdjustmentsRootView.swift
@@ -151,51 +151,52 @@ extension Adjustments {
                         EditTempTargetForm(tempTargetToEdit: tempTarget, state: state)
                     }
                 }
-                .confirmationDialog("Override to Stop", isPresented: $showCancelOverrideConfirmDialog) {
-                    Button("Stop", role: .destructive) {
-                        Task {
-                            // Save cancelled Override in OverrideRunStored Entity
-                            // Cancel ALL active Override
-                            await state.disableAllActiveOverrides(createOverrideRunEntry: true)
+                .glassActionSheet(
+                    "Override to Stop",
+                    message: Text("Stop the Override \"\(state.currentActiveOverride?.name ?? "")\"?"),
+                    isPresented: $showCancelOverrideConfirmDialog,
+                    actions: [
+                        GlassSheetAction("Stop", role: .destructive) {
+                            Task {
+                                // Save cancelled Override in OverrideRunStored Entity
+                                // Cancel ALL active Override
+                                await state.disableAllActiveOverrides(createOverrideRunEntry: true)
+                            }
                         }
-                    }
-                    Button("Cancel", role: .cancel) {}
-                } message: {
-                    Text("Stop the Override \"\(state.currentActiveOverride?.name ?? "")\"?")
-                }
-                .confirmationDialog("Temp Target to Stop", isPresented: $showCancelTempTargetConfirmDialog) {
-                    Button("Stop", role: .destructive) {
-                        Task {
-                            // Save cancelled Temp Targets in TempTargetRunStored Entity
-                            // Cancel ALL active Temp Targets
-                            await state.disableAllActiveTempTargets(createTempTargetRunEntry: true)
-                            // Update View
-                            state.updateLatestTempTargetConfiguration()
+                    ]
+                )
+                .glassActionSheet(
+                    "Temp Target to Stop",
+                    message: Text("Stop the Temp Target \"\(state.currentActiveTempTarget?.name ?? "")\"?"),
+                    isPresented: $showCancelTempTargetConfirmDialog,
+                    actions: [
+                        GlassSheetAction("Stop", role: .destructive) {
+                            Task {
+                                // Save cancelled Temp Targets in TempTargetRunStored Entity
+                                // Cancel ALL active Temp Targets
+                                await state.disableAllActiveTempTargets(createTempTargetRunEntry: true)
+                                // Update View
+                                state.updateLatestTempTargetConfiguration()
+                            }
                         }
-                    }
-                    Button("Cancel", role: .cancel) {}
-                } message: {
-                    Text("Stop the Temp Target \"\(state.currentActiveTempTarget?.name ?? "")\"?")
-                }
-                .confirmationDialog(
+                    ]
+                )
+                .glassActionSheet(
                     "Activate Preset",
-                    isPresented: presetActivationConfirmationBinding
-                ) {
-                    Button("Activate") {
-                        if let activation = pendingPresetActivation {
-                            activatePreset(activation)
+                    message: pendingPresetActivation.map { Text($0.confirmationMessage) },
+                    isPresented: presetActivationConfirmationBinding,
+                    actions: [
+                        GlassSheetAction("Activate") {
+                            if let activation = pendingPresetActivation {
+                                activatePreset(activation)
+                            }
                         }
-                    }
-
-                    Button("Cancel", role: .cancel) {
+                    ],
+                    onCancel: {
                         state.shouldDisplayPresetStartConfirmDialog = false
                         pendingPresetActivation = nil
                     }
-                } message: {
-                    if let activation = pendingPresetActivation {
-                        Text(activation.confirmationMessage)
-                    }
-                }
+                )
             }).background(appState.trioBackgroundColor(for: colorScheme))
         }
 

--- a/Trio/Sources/Modules/Adjustments/View/Overrides/AdjustmentsRootView+Overrides.swift
+++ b/Trio/Sources/Modules/Adjustments/View/Overrides/AdjustmentsRootView+Overrides.swift
@@ -39,34 +39,33 @@ extension Adjustments.RootView {
     }
 
     func overrideDeleteConfirmation(_ content: some View) -> some View {
-        content.confirmationDialog(
-            "Delete the Override Preset \"\(overrideToDelete?.name ?? "")\"?",
+        let target = overrideToDelete
+        let isRunning = target != nil && state.currentActiveOverride == target
+
+        return content.glassActionSheet(
+            "Delete the Override Preset \"\(target?.name ?? "")\"?",
+            message: isRunning ? Text("This override preset is currently running. Deleting will stop it.") : nil,
             isPresented: Binding(
                 get: { overrideToDelete != nil },
                 set: { if !$0 { overrideToDelete = nil } }
             ),
-            titleVisibility: .visible,
-            presenting: overrideToDelete
-        ) { target in
-            Button(
-                state.currentActiveOverride == target ? "Stop and Delete" : "Delete",
-                role: .destructive
-            ) {
-                if state.currentActiveOverride == target {
+            actions: [
+                GlassSheetAction(
+                    isRunning ? "Stop and Delete" : "Delete",
+                    role: .destructive
+                ) {
+                    guard let target else { return }
+                    if isRunning {
+                        Task {
+                            await state.disableAllActiveOverrides(createOverrideRunEntry: true)
+                        }
+                    }
                     Task {
-                        await state.disableAllActiveOverrides(createOverrideRunEntry: true)
+                        await state.invokeOverridePresetDeletion(target.objectID)
                     }
                 }
-                Task {
-                    await state.invokeOverridePresetDeletion(target.objectID)
-                }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: { target in
-            if state.currentActiveOverride == target {
-                Text("This override preset is currently running. Deleting will stop it.")
-            }
-        }
+            ]
+        )
     }
 
     private func requestOverridePresetActivation(_ preset: OverrideStored) {

--- a/Trio/Sources/Modules/Adjustments/View/TempTargets/AdjustmentsRootView+TempTargets.swift
+++ b/Trio/Sources/Modules/Adjustments/View/TempTargets/AdjustmentsRootView+TempTargets.swift
@@ -87,37 +87,33 @@ extension Adjustments.RootView {
     }
 
     func tempTargetDeleteConfirmation(_ content: some View) -> some View {
-        content.confirmationDialog(
-            String(
-                localized: "Delete the Temp Target Preset \"\(tempTargetToDelete?.name ?? "")\"?",
-                comment: "Delete confirmation title for temporary target presets"
-            ),
+        let target = tempTargetToDelete
+        let isRunning = target != nil && state.currentActiveTempTarget == target
+
+        return content.glassActionSheet(
+            "Delete the Temp Target Preset \"\(target?.name ?? "")\"?",
+            message: isRunning ? Text("This Temp Target preset is currently running. Deleting will stop it.") : nil,
             isPresented: Binding(
                 get: { tempTargetToDelete != nil },
                 set: { if !$0 { tempTargetToDelete = nil } }
             ),
-            titleVisibility: .visible,
-            presenting: tempTargetToDelete
-        ) { target in
-            Button(
-                state.currentActiveTempTarget == target ? "Stop and Delete" : "Delete",
-                role: .destructive
-            ) {
-                if state.currentActiveTempTarget == target {
+            actions: [
+                GlassSheetAction(
+                    isRunning ? "Stop and Delete" : "Delete",
+                    role: .destructive
+                ) {
+                    guard let target else { return }
+                    if isRunning {
+                        Task {
+                            await state.disableAllActiveTempTargets(createTempTargetRunEntry: true)
+                        }
+                    }
                     Task {
-                        await state.disableAllActiveTempTargets(createTempTargetRunEntry: true)
+                        await state.invokeTempTargetPresetDeletion(target.objectID)
                     }
                 }
-                Task {
-                    await state.invokeTempTargetPresetDeletion(target.objectID)
-                }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: { target in
-            if state.currentActiveTempTarget == target {
-                Text("This Temp Target preset is currently running. Deleting will stop it.")
-            }
-        }
+            ]
+        )
     }
 
     var stickyStopTempTargetButton: some View {

--- a/Trio/Sources/Modules/CGMSettings/View/CustomCGMOptionsView.swift
+++ b/Trio/Sources/Modules/CGMSettings/View/CustomCGMOptionsView.swift
@@ -130,15 +130,16 @@ extension CGMSettings {
                 }
                 .scrollContentBackground(.hidden)
                 .background(appState.trioBackgroundColor(for: colorScheme))
-                .confirmationDialog("Delete CGM", isPresented: $shouldDisplayDeletionConfirmation) {
-                    Button(role: .destructive) {
-                        deleteCGM()
-                    } label: {
-                        Text("Delete \(cgmCurrent.displayName)")
-                            .font(.headline)
-                            .tint(.red)
-                    }
-                } message: { Text("Are you sure you want to delete \(cgmCurrent.displayName)?") }
+                .glassActionSheet(
+                    "Delete CGM",
+                    message: Text("Are you sure you want to delete \(cgmCurrent.displayName)?"),
+                    isPresented: $shouldDisplayDeletionConfirmation,
+                    actions: [
+                        GlassSheetAction("Delete \(cgmCurrent.displayName)", role: .destructive) {
+                            deleteCGM()
+                        }
+                    ]
+                )
                 .onAppear {
                     if cgmCurrent.type == .simulator {
                         initializeSimulatorSettings()

--- a/Trio/Sources/Modules/History/View/HistoryRootView+Confirmations.swift
+++ b/Trio/Sources/Modules/History/View/HistoryRootView+Confirmations.swift
@@ -6,35 +6,34 @@ extension History.RootView {
     }
 
     @ViewBuilder func historyConfirmations(_ content: some View) -> some View {
+        let target = deletionTarget
+
         content
-            .confirmationDialog(
-                deletionTarget?.title(units: state.units) ?? "",
+            .glassActionSheet(
+                Text(target?.title(units: state.units) ?? ""),
+                message: target?.message(units: state.units).map { Text($0) },
                 isPresented: Binding(
                     get: { deletionTarget != nil },
                     set: { if !$0 { deletionTarget = nil } }
                 ),
-                titleVisibility: .visible,
-                presenting: deletionTarget
-            ) { target in
-                Button("Delete", role: .destructive) {
-                    switch target {
-                    case let .glucose(glucose):
-                        state.invokeGlucoseDeletionTask(glucose.objectID)
-                    case let .insulin(pumpEvent):
-                        state.invokeInsulinDeletionTask(pumpEvent.objectID)
-                    case let .carbs(carbEntry):
-                        state.invokeCarbDeletionTask(
-                            carbEntry.objectID,
-                            isFpuOrComplexMeal: carbEntry.isFPU || carbEntry.fat > 0 || carbEntry.protein > 0
-                        )
+                actions: [
+                    GlassSheetAction("Delete", role: .destructive) {
+                        switch target {
+                        case let .glucose(glucose):
+                            state.invokeGlucoseDeletionTask(glucose.objectID)
+                        case let .insulin(pumpEvent):
+                            state.invokeInsulinDeletionTask(pumpEvent.objectID)
+                        case let .carbs(carbEntry):
+                            state.invokeCarbDeletionTask(
+                                carbEntry.objectID,
+                                isFpuOrComplexMeal: carbEntry.isFPU || carbEntry.fat > 0 || carbEntry.protein > 0
+                            )
+                        case .none:
+                            break
+                        }
                     }
-                }
-                Button("Cancel", role: .cancel) {}
-            } message: { target in
-                if let message = target.message(units: state.units) {
-                    Text(message)
-                }
-            }
+                ]
+            )
             .alert("Error", isPresented: $showErrorAlert) {
                 Button("OK", role: .cancel) {}
             } message: {

--- a/Trio/Sources/Modules/Home/View/GlassChrome.swift
+++ b/Trio/Sources/Modules/Home/View/GlassChrome.swift
@@ -9,6 +9,10 @@ enum GlassChrome {
     static var panelShape: RoundedRectangle {
         RoundedRectangle(cornerRadius: panelCornerRadius, style: .continuous)
     }
+
+    /// Stand-in for glass/material when Reduce Transparency is on: no blur, so
+    /// nothing behind the panel bleeds through.
+    static let opaqueFill = Color(.secondarySystemGroupedBackground)
 }
 
 /// Glass panel background with optional tint; pre-26 falls back to
@@ -20,9 +24,16 @@ struct GlassPanelBackground: ViewModifier {
     var strokeWidth: CGFloat = 1
 
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    /// Opaque when Reduce Transparency is on, blurred material otherwise.
+    private var baseFill: AnyShapeStyle {
+        reduceTransparency ? AnyShapeStyle(GlassChrome.opaqueFill) : AnyShapeStyle(.ultraThinMaterial)
+    }
 
     func body(content: Content) -> some View {
-        if #available(iOS 26.0, *) {
+        // Reduce Transparency skips the glass path entirely; it cannot be made opaque.
+        if !reduceTransparency, #available(iOS 26.0, *) {
             content
                 .glassEffect(
                     tint.map { Glass.regular.tint($0.opacity(tintOpacity)) } ?? .regular,
@@ -37,7 +48,7 @@ struct GlassPanelBackground: ViewModifier {
             content
                 .background(
                     GlassChrome.panelShape
-                        .fill(.ultraThinMaterial)
+                        .fill(baseFill)
                         .overlay(GlassChrome.panelShape.fill((tint ?? .clear).opacity(tintOpacity)))
                         .overlay(GlassChrome.panelShape.strokeBorder(
                             (tint ?? Color.primary).opacity(strokeOpacity),

--- a/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
@@ -233,19 +233,18 @@ extension Home.RootView {
     @ViewBuilder func adjustmentsCancelTempTargetView() -> some View {
         Image(systemName: "xmark.app")
             .font(.title)
-            .confirmationDialog(
+            .glassActionSheet(
                 "Stop the Temp Target \"\(latestTempTarget.first?.name ?? "")\"?",
                 isPresented: $isConfirmStopTempTargetShown,
-                titleVisibility: .visible
-            ) {
-                Button("Stop", role: .destructive) {
-                    Task {
-                        guard let objectID = latestTempTarget.first?.objectID else { return }
-                        await state.cancelTempTarget(withID: objectID)
+                actions: [
+                    GlassSheetAction("Stop", role: .destructive) {
+                        Task {
+                            guard let objectID = latestTempTarget.first?.objectID else { return }
+                            await state.cancelTempTarget(withID: objectID)
+                        }
                     }
-                }
-                Button("Cancel", role: .cancel) {}
-            }
+                ]
+            )
             .padding(.trailing, 8)
             .onTapGesture {
                 if !latestTempTarget.isEmpty {
@@ -257,19 +256,18 @@ extension Home.RootView {
     @ViewBuilder func adjustmentsCancelOverrideView() -> some View {
         Image(systemName: "xmark.app")
             .font(.title)
-            .confirmationDialog(
+            .glassActionSheet(
                 "Stop the Override \"\(latestOverride.first?.name ?? "")\"?",
                 isPresented: $isConfirmStopOverridePresented,
-                titleVisibility: .visible
-            ) {
-                Button("Stop", role: .destructive) {
-                    Task {
-                        guard let objectID = latestOverride.first?.objectID else { return }
-                        await state.cancelOverride(withID: objectID)
+                actions: [
+                    GlassSheetAction("Stop", role: .destructive) {
+                        Task {
+                            guard let objectID = latestOverride.first?.objectID else { return }
+                            await state.cancelOverride(withID: objectID)
+                        }
                     }
-                }
-                Button("Cancel", role: .cancel) {}
-            }
+                ]
+            )
             .padding(.trailing, 8)
             .onTapGesture {
                 if !latestOverride.isEmpty {
@@ -372,31 +370,34 @@ extension Home.RootView {
                     noActiveAdjustmentsView()
                 }
             }.padding(.horizontal, 10)
-                .confirmationDialog("Adjustment to Stop", isPresented: $showCancelConfirmDialog) {
-                    Button("Stop Override", role: .destructive) {
-                        Task {
-                            guard let objectID = latestOverride.first?.objectID else { return }
-                            await state.cancelOverride(withID: objectID)
-                        }
-                    }
-                    Button("Stop Temp Target", role: .destructive) {
-                        Task {
-                            guard let objectID = latestTempTarget.first?.objectID else { return }
-                            await state.cancelTempTarget(withID: objectID)
-                        }
-                    }
-                    Button("Stop All Adjustments", role: .destructive) {
-                        Task {
-                            guard let overrideObjectID = latestOverride.first?.objectID else { return }
-                            await state.cancelOverride(withID: overrideObjectID)
+                .glassActionSheet(
+                    "Adjustment to Stop",
+                    message: Text("Select Adjustment"),
+                    isPresented: $showCancelConfirmDialog,
+                    actions: [
+                        GlassSheetAction("Stop Override", role: .destructive) {
+                            Task {
+                                guard let objectID = latestOverride.first?.objectID else { return }
+                                await state.cancelOverride(withID: objectID)
+                            }
+                        },
+                        GlassSheetAction("Stop Temp Target", role: .destructive) {
+                            Task {
+                                guard let objectID = latestTempTarget.first?.objectID else { return }
+                                await state.cancelTempTarget(withID: objectID)
+                            }
+                        },
+                        GlassSheetAction("Stop All Adjustments", role: .destructive) {
+                            Task {
+                                guard let overrideObjectID = latestOverride.first?.objectID else { return }
+                                await state.cancelOverride(withID: overrideObjectID)
 
-                            guard let tempTargetObjectID = latestTempTarget.first?.objectID else { return }
-                            await state.cancelTempTarget(withID: tempTargetObjectID)
+                                guard let tempTargetObjectID = latestTempTarget.first?.objectID else { return }
+                                await state.cancelTempTarget(withID: tempTargetObjectID)
+                            }
                         }
-                    }
-                } message: {
-                    Text("Select Adjustment")
-                }
+                    ]
+                )
         }
         .frame(height: HomeLayout.bottomPanelHeight)
         .glassPanel(

--- a/Trio/Sources/Modules/LiveActivitySettings/View/LiveActivityWidgetConfiguration.swift
+++ b/Trio/Sources/Modules/LiveActivitySettings/View/LiveActivityWidgetConfiguration.swift
@@ -131,15 +131,17 @@ struct LiveActivityWidgetConfiguration: BaseView {
             }
             loadOrder() // Load the saved order when the view appears
         }
-        .confirmationDialog("Add Widget", isPresented: $showAddItemDialog, titleVisibility: .visible) {
-            ForEach(LiveActivityItem.allCases.filter { !selectedItems.contains($0) }, id: \.self) { item in
-                Button(item.displayName) {
+        .glassActionSheet(
+            "Add Widget",
+            isPresented: $showAddItemDialog,
+            actions: LiveActivityItem.allCases.filter { !selectedItems.contains($0) }.map { item in
+                GlassSheetAction(item.displayName) {
                     if let index = buttonIndexToUpdate {
                         addItem(item, at: index)
                     }
                 }
             }
-        }
+        )
     }
 
     @ViewBuilder private func widgetButton(for index: Int) -> some View {
@@ -166,13 +168,16 @@ struct LiveActivityWidgetConfiguration: BaseView {
                         .font(.title3)
                 }
                 .offset(x: 10, y: -10)
-                .confirmationDialog("Remove Widget", isPresented: $isRemovalConfirmationPresented, titleVisibility: .hidden) {
-                    Button("Remove Widget", role: .destructive) {
-                        if let itemToRemove = itemToRemove {
-                            removeItem(itemToRemove)
+                .glassActionSheet(
+                    isPresented: $isRemovalConfirmationPresented,
+                    actions: [
+                        GlassSheetAction("Remove Widget", role: .destructive) {
+                            if let itemToRemove = itemToRemove {
+                                removeItem(itemToRemove)
+                            }
                         }
-                    }
-                }
+                    ]
+                )
             }
         } else {
             // Show "+" symbol for empty slots

--- a/Trio/Sources/Modules/LiveActivitySettings/View/LiveActivityWidgetConfiguration.swift
+++ b/Trio/Sources/Modules/LiveActivitySettings/View/LiveActivityWidgetConfiguration.swift
@@ -135,7 +135,7 @@ struct LiveActivityWidgetConfiguration: BaseView {
             "Add Widget",
             isPresented: $showAddItemDialog,
             actions: LiveActivityItem.allCases.filter { !selectedItems.contains($0) }.map { item in
-                GlassSheetAction(item.displayName) {
+                GlassSheetAction(verbatim: item.displayName) {
                     if let index = buttonIndexToUpdate {
                         addItem(item, at: index)
                     }

--- a/Trio/Sources/Modules/Telemetry/View/TelemetryPreviewView.swift
+++ b/Trio/Sources/Modules/Telemetry/View/TelemetryPreviewView.swift
@@ -50,22 +50,20 @@ struct TelemetryPreviewView: View {
         .navigationTitle("What's sent")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear { jsonText = Self.renderPayload() }
-        .confirmationDialog(
+        .glassActionSheet(
             "Reset App Attest state?",
-            isPresented: $showResetConfirm,
-            titleVisibility: .visible
-        ) {
-            Button("Reset and retry send", role: .destructive) {
-                TelemetryAttestor.shared.resetAttestState()
-                resetStatus = "Reset done — attempting a fresh send. Check logs for status."
-                Task { await TelemetryClient.shared.maybeSend() }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text(
+            message: Text(
                 "Clears the local App Attest key, registered flag, and forbidden flag. The next telemetry send will re-attest from scratch. Use only if telemetry is stuck."
-            )
-        }
+            ),
+            isPresented: $showResetConfirm,
+            actions: [
+                GlassSheetAction("Reset and retry send", role: .destructive) {
+                    TelemetryAttestor.shared.resetAttestState()
+                    resetStatus = "Reset done — attempting a fresh send. Check logs for status."
+                    Task { await TelemetryClient.shared.maybeSend() }
+                }
+            ]
+        )
     }
 
     private static func renderPayload() -> String {

--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -526,20 +526,20 @@ extension Treatments {
                     .listRowBackground(treatmentButtonBackground)
                     .shadow(radius: 3)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .confirmationDialog(
-                        bolusWarning.warningMessage + " Bolus \(state.amount.description) U?",
+                    .glassActionSheet(
+                        Text(bolusWarning.warningMessage + " Bolus \(state.amount.description) U?"),
                         isPresented: $showConfirmDialogForBolusing,
-                        titleVisibility: .visible
-                    ) {
-                        Button("Cancel", role: .cancel) {}
-                        Button(
-                            bolusWarning.warningMessage
-                                .isEmpty ? String(localized: "Enact Bolus") : String(localized: "Ignore Warning and Enact Bolus"),
-                            role: bolusWarning.warningMessage.isEmpty ? nil : .destructive
-                        ) {
-                            state.invokeTreatmentsTask()
-                        }
-                    }
+                        actions: [
+                            GlassSheetAction(
+                                bolusWarning.warningMessage
+                                    .isEmpty ? String(localized: "Enact Bolus") :
+                                    String(localized: "Ignore Warning and Enact Bolus"),
+                                role: bolusWarning.warningMessage.isEmpty ? nil : .destructive
+                            ) {
+                                state.invokeTreatmentsTask()
+                            }
+                        ]
+                    )
                 }
             } header: {
                 if !bolusWarning.warningMessage.isEmpty {

--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -531,7 +531,7 @@ extension Treatments {
                         isPresented: $showConfirmDialogForBolusing,
                         actions: [
                             GlassSheetAction(
-                                bolusWarning.warningMessage
+                                verbatim: bolusWarning.warningMessage
                                     .isEmpty ? String(localized: "Enact Bolus") :
                                     String(localized: "Ignore Warning and Enact Bolus"),
                                 role: bolusWarning.warningMessage.isEmpty ? nil : .destructive

--- a/Trio/Sources/Modules/WatchConfig/View/WatchConfigGarminAppConfigView.swift
+++ b/Trio/Sources/Modules/WatchConfig/View/WatchConfigGarminAppConfigView.swift
@@ -262,14 +262,17 @@ struct WatchConfigGarminAppConfigView: View {
                 sheetTitle: String(localized: "Help", comment: "Help sheet title")
             )
         }
-        .confirmationDialog("Watchface Changed", isPresented: $shouldShowWatchfaceSwitchConfirmDialog) {
-            Button("Resume Data Transmission") {
-                state.resumeDataTransmission()
-            }
-        } message: {
-            Text(
+        .glassActionSheet(
+            "Watchface Changed",
+            message: Text(
                 "Data transmission has been disabled. Now select the new watchface on your Garmin device and resume data transmission once done."
-            )
-        }
+            ),
+            isPresented: $shouldShowWatchfaceSwitchConfirmDialog,
+            actions: [
+                GlassSheetAction("Resume Data Transmission") {
+                    state.resumeDataTransmission()
+                }
+            ]
+        )
     }
 }

--- a/Trio/Sources/Views/GlassActionSheet.swift
+++ b/Trio/Sources/Views/GlassActionSheet.swift
@@ -117,7 +117,7 @@ private struct GlassActionSheetView: View {
 
     var body: some View {
         ZStack(alignment: .bottom) {
-            Color.black.opacity(dimmed ? 0.25 : 0)
+            Color.black.opacity(dimmed ? (reduceTransparency ? 0.4 : 0.25) : 0)
                 .ignoresSafeArea()
                 .onTapGesture { dismiss(then: onCancel) }
 
@@ -190,7 +190,7 @@ private struct GlassActionSheetView: View {
 
     @ViewBuilder private var panelBackground: some View {
         if reduceTransparency {
-            panelShape.fill(Color(.secondarySystemGroupedBackground))
+            panelShape.fill(GlassChrome.opaqueFill)
         } else if #available(iOS 26.0, *) {
             panelShape.fill(.clear).glassEffect(.regular, in: panelShape)
         } else {

--- a/Trio/Sources/Views/GlassActionSheet.swift
+++ b/Trio/Sources/Views/GlassActionSheet.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+
+/// One tappable row of a `glassActionSheet`.
+struct GlassSheetAction: Identifiable {
+    let id = UUID()
+    let label: Text
+    let role: ButtonRole?
+    let handler: () -> Void
+
+    init(_ title: LocalizedStringKey, role: ButtonRole? = nil, handler: @escaping () -> Void = {}) {
+        label = Text(title)
+        self.role = role
+        self.handler = handler
+    }
+
+    /// Verbatim title, e.g. device or preset names that are not localization keys.
+    init(_ title: String, role: ButtonRole? = nil, handler: @escaping () -> Void = {}) {
+        label = Text(title)
+        self.role = role
+        self.handler = handler
+    }
+}
+
+extension View {
+    /// Bottom action sheet in the classic pre-iOS 26 style with Liquid Glass
+    /// chrome: floating rounded panels, glass/material background (opaque when
+    /// Reduce Transparency is on) and a detached bold Cancel button.
+    /// Replaces `confirmationDialog`, which iOS 26 renders as an anchored
+    /// popover with low-contrast capsule buttons.
+    func glassActionSheet(
+        _ title: LocalizedStringKey? = nil,
+        message: Text? = nil,
+        isPresented: Binding<Bool>,
+        actions: [GlassSheetAction],
+        onCancel: (() -> Void)? = nil
+    ) -> some View {
+        modifier(GlassActionSheetModifier(
+            isPresented: isPresented,
+            title: title.map { Text($0) },
+            message: message,
+            actions: actions,
+            onCancel: onCancel
+        ))
+    }
+
+    /// Variant for dynamic (pre-localized) titles.
+    func glassActionSheet(
+        _ title: Text,
+        message: Text? = nil,
+        isPresented: Binding<Bool>,
+        actions: [GlassSheetAction],
+        onCancel: (() -> Void)? = nil
+    ) -> some View {
+        modifier(GlassActionSheetModifier(
+            isPresented: isPresented,
+            title: title,
+            message: message,
+            actions: actions,
+            onCancel: onCancel
+        ))
+    }
+}
+
+private struct GlassActionSheetModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    let title: Text?
+    let message: Text?
+    let actions: [GlassSheetAction]
+    let onCancel: (() -> Void)?
+
+    // Shadow state so the cover is always presented/dismissed without its own
+    // slide animation; the sheet animates internally.
+    @State private var coverShown = false
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isPresented) { _, show in
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                if show {
+                    // next runloop: presenting inside a swipe-action's row
+                    // transaction (e.g. delete confirmations) gets swallowed
+                    DispatchQueue.main.async {
+                        withTransaction(transaction) { coverShown = true }
+                    }
+                } else {
+                    withTransaction(transaction) { coverShown = false }
+                }
+            }
+            .fullScreenCover(isPresented: $coverShown) {
+                GlassActionSheetView(
+                    title: title,
+                    message: message,
+                    actions: actions,
+                    onCancel: onCancel,
+                    isPresented: $isPresented
+                )
+                .presentationBackground(.clear)
+            }
+    }
+}
+
+private struct GlassActionSheetView: View {
+    let title: Text?
+    let message: Text?
+    let actions: [GlassSheetAction]
+    let onCancel: (() -> Void)?
+    @Binding var isPresented: Bool
+
+    @State private var visible = false
+    @State private var dimmed = false
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    private let panelShape = RoundedRectangle(cornerRadius: GlassChrome.panelCornerRadius, style: .continuous)
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color.black.opacity(dimmed ? 0.25 : 0)
+                .ignoresSafeArea()
+                .onTapGesture { dismiss(then: onCancel) }
+
+            if visible {
+                VStack(spacing: 10) {
+                    actionsPanel
+                    cancelPanel
+                }
+                .padding(.horizontal, 10)
+                .padding(.bottom, 6)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .onAppear {
+            // dim snaps in; only the panel slides
+            dimmed = true
+            withAnimation(.snappy(duration: 0.28)) { visible = true }
+        }
+    }
+
+    private var actionsPanel: some View {
+        VStack(spacing: 0) {
+            if title != nil || message != nil {
+                VStack(spacing: 4) {
+                    if let title { title.font(.footnote).fontWeight(.semibold) }
+                    if let message { message.font(.footnote) }
+                }
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+
+                Divider()
+            }
+
+            ForEach(Array(actions.enumerated()), id: \.element.id) { index, action in
+                if index > 0 { Divider() }
+                Button {
+                    dismiss(then: action.handler)
+                } label: {
+                    action.label
+                        .font(.title3)
+                        .foregroundStyle(action.role == .destructive ? Color.red : Color.accentColor)
+                        .frame(maxWidth: .infinity, minHeight: 57)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .background(panelBackground)
+        .clipShape(panelShape)
+    }
+
+    private var cancelPanel: some View {
+        Button {
+            dismiss(then: onCancel)
+        } label: {
+            Text("Cancel")
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundStyle(Color.accentColor)
+                .frame(maxWidth: .infinity, minHeight: 57)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(panelBackground)
+        .clipShape(panelShape)
+    }
+
+    @ViewBuilder private var panelBackground: some View {
+        if reduceTransparency {
+            panelShape.fill(Color(.secondarySystemGroupedBackground))
+        } else if #available(iOS 26.0, *) {
+            panelShape.fill(.clear).glassEffect(.regular, in: panelShape)
+        } else {
+            panelShape.fill(.regularMaterial)
+        }
+    }
+
+    /// Slide out, run the chosen action, then tear down the cover.
+    /// Handler runs first so bindings that clear `presenting`-style state on
+    /// dismissal don't wipe the data the action still needs.
+    private func dismiss(then handler: (() -> Void)?) {
+        withAnimation(.snappy(duration: 0.22)) {
+            visible = false
+            dimmed = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.24) {
+            handler?()
+            isPresented = false
+        }
+    }
+}

--- a/Trio/Sources/Views/GlassActionSheet.swift
+++ b/Trio/Sources/Views/GlassActionSheet.swift
@@ -13,9 +13,11 @@ struct GlassSheetAction: Identifiable {
         self.handler = handler
     }
 
-    /// Verbatim title, e.g. device or preset names that are not localization keys.
-    init(_ title: String, role: ButtonRole? = nil, handler: @escaping () -> Void = {}) {
-        label = Text(title)
+    /// Titles that must not be looked up: dynamic names, or strings already
+    /// resolved via `String(localized:)`. Deliberately labelled `verbatim:` so a
+    /// plain literal can never bind here and silently skip localization.
+    init(verbatim title: String, role: ButtonRole? = nil, handler: @escaping () -> Void = {}) {
+        label = Text(verbatim: title)
         self.role = role
         self.handler = handler
     }


### PR DESCRIPTION
Add glass action sheet, replace confirmation dialogs:

- classic bottom action sheet with Liquid Glass panels
- opaque fallback when Reduce Transparency is on
- dim shows instantly, only the sheet slides
- converts all 15 confirmationDialog call sites

| Header | Header | Header |
|--------|--------|--------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e2516866-0df6-4b36-a33d-973a09a190f8" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/2869f4bc-c7be-48ee-9766-842a480cb3b2" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/fbf6c8dd-57bf-431e-b007-d294bb04630f" /> |

Fixes #1386