### PR TITLE
Match Chart Glossary Button to Alarm Button Style in Meal Panel

### DIFF
--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -84,7 +84,7 @@ extension Home {
             .frame(height: chartHeight)
             .overlay(alignment: .bottomTrailing) {
                 chartInfoButton
-                    .offset(x: 0, y: -10)
+                    .offset(x: 0, y: -18)
             }
             .overlay(alignment: .topTrailing) {
                 // borderless capsule (not a control); centered in the basal

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -113,13 +113,18 @@ extension Home {
             Button {
                 state.isLegendPresented.toggle()
             } label: {
+                // styled to match the alarm bell pill in the meal row
                 Image(systemName: "info")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.primary)
                     .frame(width: 32, height: 32)
-                    .background(Circle().fill(.ultraThinMaterial))
-                    .overlay(Circle().strokeBorder(Color.primary.opacity(0.12), lineWidth: 1))
+                    .overlay(
+                        Circle()
+                            .stroke(Color.primary.opacity(0.4), lineWidth: 2)
+                    )
             }
+            .buttonStyle(.plain)
             .contentShape(Circle())
             .padding(.bottom, 6)
             // same trailing inset as the alarm bell in the meal row


### PR DESCRIPTION
## Summary

The info button in the bottom-right of the main chart was styled independently of the alarm bell in the meal row directly below it, building on liquid-glass-esque material style. Especially on light mode this made it quite indistinguishable from the chart background. This PR aligns the glossary button to the bell button and moves it up slightly, to stay fully clear of char x-axis.

No behavior change. The button still toggles `state.isLegendPresented`.
