### PR TITLE
Show Release Notes for Installed Trio Version

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -841,6 +841,7 @@
 		DDC6CA6D2DD90A2A0060EE25 /* LocalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC6CA6C2DD90A2A0060EE25 /* LocalizationTests.swift */; };
 		DDCAE8332D78D4A800B1BB51 /* TherapySettingsUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCAE8322D78D49C00B1BB51 /* TherapySettingsUtil.swift */; };
 		DDCE790F2D6F97FC000A4D7A /* SubmodulesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCE790E2D6F97F7000A4D7A /* SubmodulesView.swift */; };
+		DB0BB0030000000000000002 /* ReleaseNotesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0BB0030000000000000001 /* ReleaseNotesListView.swift */; };
 		DDCEBF5B2CC1B76400DF4C36 /* LiveActivity+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCEBF5A2CC1B76400DF4C36 /* LiveActivity+Helper.swift */; };
 		DDD163122C4C689900CD525A /* AdjustmentsStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD163112C4C689900CD525A /* AdjustmentsStateModel.swift */; };
 		DDD163142C4C68D300CD525A /* AdjustmentsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD163132C4C68D300CD525A /* AdjustmentsProvider.swift */; };
@@ -1886,6 +1887,7 @@
 		DDC6CA6C2DD90A2A0060EE25 /* LocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationTests.swift; sourceTree = "<group>"; };
 		DDCAE8322D78D49C00B1BB51 /* TherapySettingsUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TherapySettingsUtil.swift; sourceTree = "<group>"; };
 		DDCE790E2D6F97F7000A4D7A /* SubmodulesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmodulesView.swift; sourceTree = "<group>"; };
+		DB0BB0030000000000000001 /* ReleaseNotesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotesListView.swift; sourceTree = "<group>"; };
 		DDCEBF5A2CC1B76400DF4C36 /* LiveActivity+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LiveActivity+Helper.swift"; sourceTree = "<group>"; };
 		DDD163112C4C689900CD525A /* AdjustmentsStateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustmentsStateModel.swift; sourceTree = "<group>"; };
 		DDD163132C4C68D300CD525A /* AdjustmentsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustmentsProvider.swift; sourceTree = "<group>"; };
@@ -4054,6 +4056,7 @@
 			isa = PBXGroup;
 			children = (
 				DDCE790E2D6F97F7000A4D7A /* SubmodulesView.swift */,
+				DB0BB0030000000000000001 /* ReleaseNotesListView.swift */,
 				DD1745122C54169400211FAC /* DevicesView.swift */,
 				DD1745142C54388A00211FAC /* TherapySettingsView.swift */,
 				DD1745162C54389F00211FAC /* FeatureSettingsView.swift */,
@@ -5670,6 +5673,7 @@
 				7F7B756BE8543965D9FDF1A2 /* HistoryDataFlow.swift in Sources */,
 				1D845DF2E3324130E1D95E67 /* HistoryProvider.swift in Sources */,
 				DDCE790F2D6F97FC000A4D7A /* SubmodulesView.swift in Sources */,
+				DB0BB0030000000000000002 /* ReleaseNotesListView.swift in Sources */,
 				19F95FFA29F1102A00314DDC /* StatRootView.swift in Sources */,
 				0D9A5E34A899219C5C4CDFAF /* HistoryStateModel.swift in Sources */,
 				6BCF84DD2B16843A003AD46E /* LiveActitiyAttributes.swift in Sources */,

--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -70,6 +70,9 @@
 		7A11AC0DE000000000000106 /* HomeRootView+Refresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000006 /* HomeRootView+Refresh.swift */; };
 		7A11AC0DE000000000000111 /* HomeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000011 /* HomeLayout.swift */; };
 		7A11AC0DE000000000000113 /* MultiUsePanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000013 /* MultiUsePanelState.swift */; };
+		DB0BB002000000000000000C /* ReleaseNotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0BB002000000000000000B /* ReleaseNotes.swift */; };
+		DB0BB002000000000000000E /* ReleaseNotesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0BB002000000000000000D /* ReleaseNotesService.swift */; };
+		DB0BB0020000000000000010 /* ReleaseNotesSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0BB002000000000000000F /* ReleaseNotesSheetView.swift */; };
 		7A11AC0DE000000000000116 /* GlassChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000016 /* GlassChrome.swift */; };
 		7A11AC0DE000000000000110 /* HomeRootView+BottomControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE000000000000010 /* HomeRootView+BottomControls.swift */; };
 		7A11AC0DE00000000000010E /* HomeRootView+MealPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11AC0DE00000000000000E /* HomeRootView+MealPanel.swift */; };
@@ -1115,6 +1118,9 @@
 		7A11AC0DE000000000000006 /* HomeRootView+Refresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+Refresh.swift"; sourceTree = "<group>"; };
 		7A11AC0DE000000000000011 /* HomeLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeLayout.swift; sourceTree = "<group>"; };
 		7A11AC0DE000000000000013 /* MultiUsePanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiUsePanelState.swift; sourceTree = "<group>"; };
+		DB0BB002000000000000000B /* ReleaseNotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotes.swift; sourceTree = "<group>"; };
+		DB0BB002000000000000000D /* ReleaseNotesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotesService.swift; sourceTree = "<group>"; };
+		DB0BB002000000000000000F /* ReleaseNotesSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleaseNotesSheetView.swift; sourceTree = "<group>"; };
 		7A11AC0DE000000000000016 /* GlassChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassChrome.swift; sourceTree = "<group>"; };
 		7A11AC0DE000000000000010 /* HomeRootView+BottomControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+BottomControls.swift"; sourceTree = "<group>"; };
 		7A11AC0DE00000000000000E /* HomeRootView+MealPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeRootView+MealPanel.swift"; sourceTree = "<group>"; };
@@ -2436,6 +2442,7 @@
 				7A11AC0DE000000000000006 /* HomeRootView+Refresh.swift */,
 				7A11AC0DE000000000000011 /* HomeLayout.swift */,
 				7A11AC0DE000000000000013 /* MultiUsePanelState.swift */,
+				DB0BB002000000000000000F /* ReleaseNotesSheetView.swift */,
 				7A11AC0DE000000000000016 /* GlassChrome.swift */,
 				7A11AC0DE000000000000010 /* HomeRootView+BottomControls.swift */,
 				7A11AC0DE00000000000000E /* HomeRootView+MealPanel.swift */,
@@ -2481,6 +2488,7 @@
 				B015AFE22E500000000D7351 /* BolusSafety */,
 				3862CC2C2743F9DC00BF832C /* Calendar */,
 				E592A37E2CEEC046009A472C /* ContactImage */,
+				DB0BB002000000000000000A /* ReleaseNotes */,
 				F90692A8274B7A980037068D /* HealthKit */,
 				3B506FD72E6352E9000740B9 /* IOB */,
 				6B1A8D2C2B156EC100E76752 /* LiveActivity */,
@@ -4335,6 +4343,15 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		DB0BB002000000000000000A /* ReleaseNotes */ = {
+			isa = PBXGroup;
+			children = (
+				DB0BB002000000000000000B /* ReleaseNotes.swift */,
+				DB0BB002000000000000000D /* ReleaseNotesService.swift */,
+			);
+			path = ReleaseNotes;
+			sourceTree = "<group>";
+		};
 		DDA9AC072D67291600E6F1A9 /* AppVersionChecker */ = {
 			isa = PBXGroup;
 			children = (
@@ -4645,6 +4662,7 @@
 				38E8753D27554D5900975559 /* Embed Watch Content */,
 				6B1A8D122B14D88E00E76752 /* Embed Foundation Extensions */,
 				DD88C8DF2C4D583900F2D558 /* Run Script: Capture Build Details */,
+				DB0BB0020000000000000011 /* Run Script: Capture Release Notes */,
 				3B47C6112DA0A52C00B0E5EF /* Run Script: Copy dSYM to Crashlytics */,
 			);
 			buildRules = (
@@ -4968,6 +4986,25 @@
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n";
 		};
+		DB0BB0020000000000000011 /* Run Script: Capture Release Notes */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: Capture Release Notes";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/scripts/capture-release-notes.sh\"\n";
+		};
 		DD88C8DF2C4D583900F2D558 /* Run Script: Capture Build Details */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -5253,6 +5290,9 @@
 				7A11AC0DE000000000000106 /* HomeRootView+Refresh.swift in Sources */,
 				7A11AC0DE000000000000111 /* HomeLayout.swift in Sources */,
 				7A11AC0DE000000000000113 /* MultiUsePanelState.swift in Sources */,
+				DB0BB002000000000000000C /* ReleaseNotes.swift in Sources */,
+				DB0BB002000000000000000E /* ReleaseNotesService.swift in Sources */,
+				DB0BB0020000000000000010 /* ReleaseNotesSheetView.swift in Sources */,
 				7A11AC0DE000000000000116 /* GlassChrome.swift in Sources */,
 				7A11AC0DE000000000000110 /* HomeRootView+BottomControls.swift in Sources */,
 				7A11AC0DE00000000000010E /* HomeRootView+MealPanel.swift in Sources */,

--- a/Trio/Sources/Localizations/Main/Localizable.xcstrings
+++ b/Trio/Sources/Localizations/Main/Localizable.xcstrings
@@ -87302,6 +87302,9 @@
         }
       }
     },
+    "Current release" : {
+      "comment" : "Marks the release notes entry matching the running build"
+    },
     "Current Sensor is Ending soon! Sensor Life left in %@" : {
       "comment" : "Current Sensor is Ending soon! Sensor Life left in %@",
       "extractionState" : "manual",
@@ -144503,7 +144506,7 @@
       }
     },
     "Got it!" : {
-      "comment" : "Dismiss button for Quick-Pick Treatments info sheet",
+      "comment" : "Dismiss button for Quick-Pick Treatments info sheet\nDismiss button for the release notes sheet",
       "localizations" : {
         "bg" : {
           "stringUnit" : {
@@ -191765,6 +191768,9 @@
         }
       }
     },
+    "New Release v%@" : {
+      "comment" : "Home panel title offering the release notes; the placeholder is a version number"
+    },
     "New Sensor Detected" : {
       "comment" : "New Sensor Detected",
       "extractionState" : "manual",
@@ -217618,6 +217624,9 @@
         }
       }
     },
+    "Previous Versions" : {
+
+    },
     "Primary" : {
       "localizations" : {
         "bg" : {
@@ -224527,6 +224536,9 @@
         }
       }
     },
+    "Read the full release notes" : {
+      "comment" : "Link to the complete release notes on GitHub"
+    },
     "Readings" : {
       "comment" : "CGM readings in statView",
       "localizations" : {
@@ -227033,6 +227045,9 @@
           }
         }
       }
+    },
+    "Release Notes" : {
+
     },
     "Remaining Carbs Cap" : {
       "comment" : "Remaining Carbs Cap",
@@ -235715,6 +235730,9 @@
           }
         }
       }
+    },
+    "See what's new in this version." : {
+
     },
     "Select \"Start Override\" to immediately start using the Override, or select \"Save as Preset\" to be able to easily start the Override at a later time." : {
       "localizations" : {
@@ -309815,6 +309833,12 @@
           }
         }
       }
+    },
+    "What's Changed At A Glance" : {
+      "comment" : "Heading above the release note highlights"
+    },
+    "What's New?" : {
+      "comment" : "Navigation title of the release notes sheet"
     },
     "What's NOT limited:" : {
       "localizations" : {

--- a/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+BottomControls.swift
@@ -633,6 +633,7 @@ extension Home.RootView {
             pumpTimeMismatch: state.pumpStatusBadgeImage != nil,
             lastGlucoseDate: state.glucoseFromPersistence.last?.date,
             maxIOB: state.maxIOB,
+            hasUnacknowledgedReleaseNotes: releaseNotesService.hasUnacknowledgedNotes,
             now: state.timerDate
         )
     }
@@ -644,6 +645,9 @@ extension Home.RootView {
         subtitle: String,
         tint: Color,
         isCritical: Bool = false,
+        tintOpacity: Double? = nil,
+        strokeOpacity: Double? = nil,
+        strokeWidth: CGFloat? = nil,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
@@ -671,9 +675,9 @@ extension Home.RootView {
             .frame(height: HomeLayout.statsBannerHeight)
             .glassPanel(
                 tint: tint,
-                tintOpacity: isCritical ? 0.30 : 0.12,
-                strokeOpacity: isCritical ? 0.8 : 0.35,
-                strokeWidth: isCritical ? 1.5 : 1
+                tintOpacity: tintOpacity ?? (isCritical ? 0.30 : 0.12),
+                strokeOpacity: strokeOpacity ?? (isCritical ? 0.8 : 0.35),
+                strokeWidth: strokeWidth ?? (isCritical ? 1.5 : 1)
             )
             .padding(.horizontal, 10)
             .contentShape(Rectangle())
@@ -722,6 +726,21 @@ extension Home.RootView {
                 tint: .orange
             ) {
                 openMaxIOBSetting()
+            }
+        case .whatsNew:
+            panelBanner(
+                systemImage: "sparkles",
+                title: String(
+                    localized: "New Release v\(releaseNotesService.notes?.version ?? "")",
+                    comment: "Home panel title offering the release notes; the placeholder is a version number"
+                ),
+                subtitle: String(localized: "See what's new in this version."),
+                tint: .insulin,
+                tintOpacity: 0.24,
+                strokeOpacity: 0.7,
+                strokeWidth: 1.5
+            ) {
+                showReleaseNotes = true
             }
         case .stats:
             statsBanner()

--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -32,7 +32,9 @@ extension Home {
         @State var showCGMSelection: Bool = false
         @State var showSnoozeSheet: Bool = false
         @State var showManualGlucose: Bool = false
+        @State var showReleaseNotes: Bool = false
         @State var alarmsSnoozeUntil: Date = .distantPast
+        @ObservedObject var releaseNotesService = ReleaseNotesService.shared
         // Pull-down-to-force-loop (see HomeRootView+Refresh.swift)
         @State var pullOffset: CGFloat = 0
         @State var isRefreshArmed = false
@@ -215,6 +217,9 @@ extension Home {
                 configureView()
                 refreshAlarmsSnooze()
             }
+            .task {
+                await releaseNotesService.load()
+            }
             // UserDefaults changes don't invalidate views; refresh on sheet dismissal
             .onChange(of: showSnoozeSheet) {
                 if !showSnoozeSheet { refreshAlarmsSnooze() }
@@ -230,6 +235,13 @@ extension Home {
             }
             .sheet(isPresented: $showSnoozeSheet) {
                 SnoozeAlertsSheetView(resolver: resolver, isPresented: $showSnoozeSheet)
+            }
+            .sheet(isPresented: $showReleaseNotes) {
+                if let notes = releaseNotesService.notes {
+                    ReleaseNotesSheetView(notes: notes) {
+                        releaseNotesService.acknowledge()
+                    }
+                }
             }
             .sheet(isPresented: $showManualGlucose) {
                 ManualGlucoseEntryView(units: state.units, isPresented: $showManualGlucose) { amount in

--- a/Trio/Sources/Modules/Home/View/MultiUsePanelState.swift
+++ b/Trio/Sources/Modules/Home/View/MultiUsePanelState.swift
@@ -6,6 +6,7 @@ enum MultiUsePanelState: Equatable {
     case pumpTimeMismatch
     case cgmStale
     case maxIOBZero
+    case whatsNew
     case stats
 
     /// readings older than this offer manual glucose entry
@@ -16,12 +17,15 @@ enum MultiUsePanelState: Equatable {
         pumpTimeMismatch: Bool,
         lastGlucoseDate: Date?,
         maxIOB: Decimal,
+        hasUnacknowledgedReleaseNotes: Bool,
         now: Date
     ) -> MultiUsePanelState {
         if notificationsDisabled { return .notificationsDisabled }
         if pumpTimeMismatch { return .pumpTimeMismatch }
         if now.timeIntervalSince(lastGlucoseDate ?? .distantPast) > cgmStaleAfter { return .cgmStale }
         if maxIOB <= 0 { return .maxIOBZero }
+        // Informational, so it yields to every warning above but still displaces the stats.
+        if hasUnacknowledgedReleaseNotes { return .whatsNew }
         return .stats
     }
 }

--- a/Trio/Sources/Modules/Home/View/ReleaseNotesSheetView.swift
+++ b/Trio/Sources/Modules/Home/View/ReleaseNotesSheetView.swift
@@ -1,84 +1,54 @@
 import SwiftUI
 
-/// Full-height sheet summarising what changed in the installed release.
-///
-/// Shows the release's own summary, any GitHub alert callouts it carries, and the bullets from
-/// its "What's Changed At A Glance" section. The complete notes, including the pull request
-/// lists, stay on GitHub behind the link at the bottom.
-struct ReleaseNotesSheetView: View {
+/// Body of a release's notes: its summary, any GitHub alert callouts, and the bullets from its
+/// "What's Changed At A Glance" section. The full notes, including the pull request lists, stay on
+/// GitHub behind the link at the bottom.
+struct ReleaseNotesContentView: View {
     let notes: ReleaseNotes
 
-    /// Called when the user dismisses the sheet with the acknowledge button.
-    ///
-    /// Not called when the sheet is swiped away, so the Home panel survives an accidental
-    /// dismissal and the notes can still be found.
-    let onAcknowledge: () -> Void
-
-    @Environment(\.dismiss) private var dismiss
-
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    Text(notes.name)
-                        .font(.largeTitle)
-                        .bold()
-                        .frame(maxWidth: .infinity, alignment: .leading)
-
-                    if !notes.summary.isEmpty {
-                        Text(markdown(notes.summary))
-                            .font(.body)
-                    }
-
-                    ForEach(notes.callouts) { callout in
-                        calloutView(callout)
-                    }
-
-                    if !notes.highlights.isEmpty {
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text("What's Changed At A Glance", comment: "Heading above the release note highlights")
-                                .font(.headline)
-
-                            ForEach(notes.highlights) { highlight in
-                                highlightRow(highlight)
-                            }
-                        }
-                    }
-
-                    Button {
-                        if let url = notes.url {
-                            UIApplication.shared.open(url)
-                        }
-                    } label: {
-                        HStack {
-                            Text("Read the full release notes", comment: "Link to the complete release notes on GitHub")
-                            Spacer()
-                            Image(systemName: "arrow.up.right.square")
-                        }
-                    }
-                    .disabled(notes.url == nil)
-                    .padding(.top, 4)
-                }
+        VStack(alignment: .leading, spacing: 20) {
+            Text(notes.name)
+                .font(.largeTitle)
+                .bold()
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding()
+
+            if !notes.summary.isEmpty {
+                Text(markdown(notes.summary))
+                    .font(.body)
             }
-            .navigationTitle(Text("What's New?", comment: "Navigation title of the release notes sheet"))
-            .navigationBarTitleDisplayMode(.inline)
+
+            ForEach(notes.callouts) { callout in
+                calloutView(callout)
+            }
+
+            if !notes.highlights.isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("What's Changed At A Glance", comment: "Heading above the release note highlights")
+                        .font(.headline)
+
+                    ForEach(notes.highlights) { highlight in
+                        highlightRow(highlight)
+                    }
+                }
+            }
 
             Button {
-                onAcknowledge()
-                dismiss()
+                if let url = notes.url {
+                    UIApplication.shared.open(url)
+                }
             } label: {
-                Text("Got it!", comment: "Dismiss button for the release notes sheet")
-                    .bold()
-                    .frame(maxWidth: .infinity, minHeight: 30, alignment: .center)
+                HStack {
+                    Text("Read the full release notes", comment: "Link to the complete release notes on GitHub")
+                    Spacer()
+                    Image(systemName: "arrow.up.right.square")
+                }
             }
-            .buttonStyle(.bordered)
-            .padding([.horizontal, .bottom])
+            .disabled(notes.url == nil)
             .padding(.top, 4)
         }
-        .presentationDetents([.large])
-        .presentationDragIndicator(.visible)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
     }
 
     // MARK: - Subviews
@@ -116,9 +86,6 @@ struct ReleaseNotesSheetView: View {
     // MARK: - Helpers
 
     /// Renders inline Markdown, falling back to the raw text if it cannot be parsed.
-    ///
-    /// Release notes use inline code spans and links liberally, and an unparsed string is far
-    /// better than a blank row.
     private func markdown(_ text: String) -> AttributedString {
         (try? AttributedString(markdown: text, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
             ?? AttributedString(text)
@@ -142,5 +109,65 @@ struct ReleaseNotesSheetView: View {
         case .warning: return .orange
         case .caution: return .red
         }
+    }
+}
+
+/// Full-height sheet raised from the Home panel, which the user acknowledges to dismiss the panel.
+struct ReleaseNotesSheetView: View {
+    let notes: ReleaseNotes
+
+    /// Called when the user dismisses the sheet with the acknowledge button.
+    ///
+    /// Not called when the sheet is swiped away, so the Home panel survives an accidental
+    /// dismissal and the notes can still be found.
+    let onAcknowledge: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                ReleaseNotesContentView(notes: notes)
+            }
+            .scrollContentBackground(.hidden)
+            .background(appState.trioBackgroundColor(for: colorScheme))
+            .navigationTitle(Text("What's New?", comment: "Navigation title of the release notes sheet"))
+            .navigationBarTitleDisplayMode(.inline)
+
+            Button {
+                onAcknowledge()
+                dismiss()
+            } label: {
+                Text("Got it!", comment: "Dismiss button for the release notes sheet")
+                    .bold()
+                    .frame(maxWidth: .infinity, minHeight: 30, alignment: .center)
+            }
+            .buttonStyle(.bordered)
+            .padding([.horizontal, .bottom])
+            .padding(.top, 4)
+            .background(appState.trioBackgroundColor(for: colorScheme))
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+}
+
+/// Pushed from Settings, where the notes are browsed rather than acknowledged.
+struct ReleaseNotesDetailView: View {
+    let notes: ReleaseNotes
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        ScrollView {
+            ReleaseNotesContentView(notes: notes)
+        }
+        .scrollContentBackground(.hidden)
+        .background(appState.trioBackgroundColor(for: colorScheme))
+        .navigationTitle(notes.name)
+        .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Trio/Sources/Modules/Home/View/ReleaseNotesSheetView.swift
+++ b/Trio/Sources/Modules/Home/View/ReleaseNotesSheetView.swift
@@ -55,12 +55,14 @@ struct ReleaseNotesContentView: View {
 
     @ViewBuilder private func highlightRow(_ highlight: ReleaseNotes.Highlight) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text(verbatim: "•")
+            Text(verbatim: highlight.level > 0 ? "◦" : "•")
                 .foregroundStyle(.secondary)
 
             Group {
                 if highlight.subject.isEmpty {
                     Text(markdown(highlight.detail))
+                } else if highlight.detail.isEmpty {
+                    Text(highlight.subject).bold()
                 } else {
                     Text(highlight.subject).bold() + Text(verbatim: " — ") + Text(markdown(highlight.detail))
                 }
@@ -68,6 +70,7 @@ struct ReleaseNotesContentView: View {
             .font(.body)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .padding(.leading, CGFloat(highlight.level) * 16)
     }
 
     @ViewBuilder private func calloutView(_ callout: ReleaseNotes.Callout) -> some View {

--- a/Trio/Sources/Modules/Home/View/ReleaseNotesSheetView.swift
+++ b/Trio/Sources/Modules/Home/View/ReleaseNotesSheetView.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+/// Full-height sheet summarising what changed in the installed release.
+///
+/// Shows the release's own summary, any GitHub alert callouts it carries, and the bullets from
+/// its "What's Changed At A Glance" section. The complete notes, including the pull request
+/// lists, stay on GitHub behind the link at the bottom.
+struct ReleaseNotesSheetView: View {
+    let notes: ReleaseNotes
+
+    /// Called when the user dismisses the sheet with the acknowledge button.
+    ///
+    /// Not called when the sheet is swiped away, so the Home panel survives an accidental
+    /// dismissal and the notes can still be found.
+    let onAcknowledge: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    Text(notes.name)
+                        .font(.largeTitle)
+                        .bold()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if !notes.summary.isEmpty {
+                        Text(markdown(notes.summary))
+                            .font(.body)
+                    }
+
+                    ForEach(notes.callouts) { callout in
+                        calloutView(callout)
+                    }
+
+                    if !notes.highlights.isEmpty {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("What's Changed At A Glance", comment: "Heading above the release note highlights")
+                                .font(.headline)
+
+                            ForEach(notes.highlights) { highlight in
+                                highlightRow(highlight)
+                            }
+                        }
+                    }
+
+                    Button {
+                        if let url = notes.url {
+                            UIApplication.shared.open(url)
+                        }
+                    } label: {
+                        HStack {
+                            Text("Read the full release notes", comment: "Link to the complete release notes on GitHub")
+                            Spacer()
+                            Image(systemName: "arrow.up.right.square")
+                        }
+                    }
+                    .disabled(notes.url == nil)
+                    .padding(.top, 4)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+            }
+            .navigationTitle(Text("What's New?", comment: "Navigation title of the release notes sheet"))
+            .navigationBarTitleDisplayMode(.inline)
+
+            Button {
+                onAcknowledge()
+                dismiss()
+            } label: {
+                Text("Got it!", comment: "Dismiss button for the release notes sheet")
+                    .bold()
+                    .frame(maxWidth: .infinity, minHeight: 30, alignment: .center)
+            }
+            .buttonStyle(.bordered)
+            .padding([.horizontal, .bottom])
+            .padding(.top, 4)
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
+
+    // MARK: - Subviews
+
+    @ViewBuilder private func highlightRow(_ highlight: ReleaseNotes.Highlight) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(verbatim: "•")
+                .foregroundStyle(.secondary)
+
+            Group {
+                if highlight.subject.isEmpty {
+                    Text(markdown(highlight.detail))
+                } else {
+                    Text(highlight.subject).bold() + Text(verbatim: " — ") + Text(markdown(highlight.detail))
+                }
+            }
+            .font(.body)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder private func calloutView(_ callout: ReleaseNotes.Callout) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: symbol(for: callout.kind))
+                .foregroundStyle(tint(for: callout.kind))
+
+            Text(markdown(callout.text))
+                .font(.body)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(12)
+        .background(tint(for: callout.kind).opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: - Helpers
+
+    /// Renders inline Markdown, falling back to the raw text if it cannot be parsed.
+    ///
+    /// Release notes use inline code spans and links liberally, and an unparsed string is far
+    /// better than a blank row.
+    private func markdown(_ text: String) -> AttributedString {
+        (try? AttributedString(markdown: text, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+            ?? AttributedString(text)
+    }
+
+    private func symbol(for kind: ReleaseNotes.Callout.Kind) -> String {
+        switch kind {
+        case .note: return "info.circle.fill"
+        case .tip: return "lightbulb.fill"
+        case .important: return "exclamationmark.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .caution: return "exclamationmark.octagon.fill"
+        }
+    }
+
+    private func tint(for kind: ReleaseNotes.Callout.Kind) -> Color {
+        switch kind {
+        case .note: return .blue
+        case .tip: return .green
+        case .important: return .purple
+        case .warning: return .orange
+        case .caution: return .red
+        }
+    }
+}

--- a/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -36,6 +36,8 @@ extension Settings {
         )
         @State private var closedLoopDisabled = true
         @State private var showCopiedToast = false
+        @State private var showReleaseNotes = false
+        @ObservedObject private var releaseNotesService = ReleaseNotesService.shared
 
         @Environment(\.colorScheme) var colorScheme
         @EnvironmentObject var appIcons: Icons
@@ -289,6 +291,30 @@ extension Settings {
                         }
                     ).listRowBackground(Color.chart)
 
+                    if let notes = releaseNotesService.notes {
+                        Section(
+                            header: Text("Latest Release"),
+                            content: {
+                                Button {
+                                    showReleaseNotes = true
+                                } label: {
+                                    HStack {
+                                        Text(
+                                            "What's new? v\(notes.version)",
+                                            comment: "Settings row opening the release notes; the placeholder is a version number"
+                                        )
+                                        .foregroundColor(.primary)
+                                        Spacer()
+                                        Image(systemName: "chevron.right")
+                                            .foregroundColor(.secondary)
+                                            .font(.footnote)
+                                    }
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        ).listRowBackground(Color.chart)
+                    }
+
                     Section(
                         header: Text("Trio Backup"),
                         content: {
@@ -356,7 +382,17 @@ extension Settings {
             .sheet(isPresented: $showShareSheet) {
                 ShareSheet(activityItems: state.logItems())
             }
+            .sheet(isPresented: $showReleaseNotes) {
+                if let notes = releaseNotesService.notes {
+                    // Opening from Settings deliberately does not acknowledge: the Home panel is
+                    // dismissed by reading the notes there, not by browsing them later.
+                    ReleaseNotesSheetView(notes: notes) {}
+                }
+            }
             .onAppear(perform: configureView)
+            .task {
+                await releaseNotesService.load()
+            }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.automatic)
             .toolbar {

--- a/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/Trio/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -36,7 +36,6 @@ extension Settings {
         )
         @State private var closedLoopDisabled = true
         @State private var showCopiedToast = false
-        @State private var showReleaseNotes = false
         @ObservedObject private var releaseNotesService = ReleaseNotesService.shared
 
         @Environment(\.colorScheme) var colorScheme
@@ -291,26 +290,42 @@ extension Settings {
                         }
                     ).listRowBackground(Color.chart)
 
-                    if let notes = releaseNotesService.notes {
+                    if !releaseNotesService.releases.isEmpty {
                         Section(
-                            header: Text("Latest Release"),
+                            header: Text("Release Notes"),
                             content: {
-                                Button {
-                                    showReleaseNotes = true
-                                } label: {
-                                    HStack {
-                                        Text(
-                                            "What's new? v\(notes.version)",
-                                            comment: "Settings row opening the release notes; the placeholder is a version number"
-                                        )
-                                        .foregroundColor(.primary)
-                                        Spacer()
-                                        Image(systemName: "chevron.right")
-                                            .foregroundColor(.secondary)
-                                            .font(.footnote)
+                                if let current = releaseNotesService.notes {
+                                    NavigationLink(destination: ReleaseNotesDetailView(notes: current)) {
+                                        HStack {
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(current.name)
+                                                    .foregroundColor(.primary)
+
+                                                Text(
+                                                    "Current release",
+                                                    comment: "Marks the release notes entry matching the running build"
+                                                )
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                            }
+
+                                            Spacer()
+
+                                            Text(current.publishedDateString)
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                        }
                                     }
                                 }
-                                .frame(maxWidth: .infinity, alignment: .leading)
+
+                                if !releaseNotesService.previousReleases.isEmpty {
+                                    NavigationLink(
+                                        destination: ReleaseNotesListView(releases: releaseNotesService.previousReleases)
+                                    ) {
+                                        Text("Previous Versions")
+                                            .foregroundColor(.primary)
+                                    }
+                                }
                             }
                         ).listRowBackground(Color.chart)
                     }
@@ -381,13 +396,6 @@ extension Settings {
             }
             .sheet(isPresented: $showShareSheet) {
                 ShareSheet(activityItems: state.logItems())
-            }
-            .sheet(isPresented: $showReleaseNotes) {
-                if let notes = releaseNotesService.notes {
-                    // Opening from Settings deliberately does not acknowledge: the Home panel is
-                    // dismissed by reading the notes there, not by browsing them later.
-                    ReleaseNotesSheetView(notes: notes) {}
-                }
             }
             .onAppear(perform: configureView)
             .task {

--- a/Trio/Sources/Modules/Settings/View/Subviews/ReleaseNotesListView.swift
+++ b/Trio/Sources/Modules/Settings/View/Subviews/ReleaseNotesListView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Lists the releases preceding this build, each pushing its own notes.
+struct ReleaseNotesListView: View {
+    let releases: [ReleaseNotes]
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        List {
+            Section {
+                ForEach(releases) { release in
+                    NavigationLink(destination: ReleaseNotesDetailView(notes: release)) {
+                        HStack {
+                            Text(release.name)
+                                .foregroundColor(.primary)
+
+                            Spacer()
+
+                            Text(release.publishedDateString)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }.listRowBackground(Color.chart)
+        }
+        .scrollContentBackground(.hidden)
+        .background(appState.trioBackgroundColor(for: colorScheme))
+        .navigationTitle("Previous Versions")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Trio/Sources/Services/ReleaseNotes/ReleaseNotes.swift
+++ b/Trio/Sources/Services/ReleaseNotes/ReleaseNotes.swift
@@ -199,7 +199,7 @@ extension ReleaseNotes {
             guard let kind = currentKind else {
                 return
             }
-            let text = currentLines.joined(separator: " ").trimmingCharacters(in: .whitespaces)
+            let text = currentLines.joined(separator: "\n").trimmingCharacters(in: .whitespaces)
             guard !text.isEmpty else {
                 return
             }

--- a/Trio/Sources/Services/ReleaseNotes/ReleaseNotes.swift
+++ b/Trio/Sources/Services/ReleaseNotes/ReleaseNotes.swift
@@ -91,8 +91,11 @@ extension ReleaseNotes {
         /// The bolded lead-in, for example `MedtrumKit`. Empty when the bullet has none.
         let subject: String
 
-        /// The rest of the bullet.
+        /// The rest of the bullet. Empty when the bullet is only a heading for nested ones.
         let detail: String
+
+        /// Nesting depth, 0 for a top level bullet.
+        let level: Int
     }
 
     /// A GitHub alert callout, for example `> [!IMPORTANT]`.
@@ -122,11 +125,15 @@ extension ReleaseNotes {
     /// set would treat `\r` and `\n` as two separate breaks and yield a spurious blank line
     /// between every real one, which is enough to break multi-line parsing.
     private var bodyLines: [String] {
+        rawBodyLines.map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    /// Body split into lines with leading whitespace intact, so nesting can be measured.
+    private var rawBodyLines: [String] {
         body
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")
             .components(separatedBy: "\n")
-            .map { $0.trimmingCharacters(in: .whitespaces) }
     }
 
     /// The bullets under "What's Changed At A Glance".
@@ -139,7 +146,9 @@ extension ReleaseNotes {
         var result: [Highlight] = []
         var insideSection = false
 
-        for line in bodyLines {
+        for rawLine in rawBodyLines {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+
             if line.hasPrefix("#") {
                 // A heading either opens the section we want or closes it again.
                 let heading = line.drop(while: { $0 == "#" }).trimmingCharacters(in: .whitespaces)
@@ -169,7 +178,7 @@ extension ReleaseNotes {
                 continue
             }
 
-            result.append(Self.parseBullet(bullet, id: result.count))
+            result.append(Self.parseBullet(bullet, id: result.count, level: Self.indentLevel(of: rawLine)))
         }
 
         return result
@@ -247,16 +256,31 @@ extension ReleaseNotes {
         return result
     }
 
+    /// Nesting depth of a bullet, from its leading whitespace. Tabs count as one level.
+    private static func indentLevel(of rawLine: String) -> Int {
+        var spaces = 0
+        for character in rawLine {
+            if character == " " {
+                spaces += 1
+            } else if character == "\t" {
+                spaces += 2
+            } else {
+                break
+            }
+        }
+        return min(spaces / 2, 2)
+    }
+
     /// Splits a bullet into its bolded lead-in and the remaining text.
     ///
     /// Trio writes these as `**Subject** — detail`. Anything that does not follow that shape
     /// is kept whole as the detail, so an unexpected format degrades to plain text rather
     /// than being dropped.
-    private static func parseBullet(_ bullet: String, id: Int) -> Highlight {
+    private static func parseBullet(_ bullet: String, id: Int, level: Int) -> Highlight {
         guard bullet.hasPrefix("**"),
               let closing = bullet.range(of: "**", range: bullet.index(bullet.startIndex, offsetBy: 2) ..< bullet.endIndex)
         else {
-            return Highlight(id: id, subject: "", detail: bullet)
+            return Highlight(id: id, subject: "", detail: bullet, level: level)
         }
 
         let subject = String(bullet[bullet.index(bullet.startIndex, offsetBy: 2) ..< closing.lowerBound])
@@ -268,12 +292,13 @@ extension ReleaseNotes {
             break
         }
 
-        // Some bullets are a bold heading with their detail in nested sub-bullets, which are
-        // not rendered. Promote the subject to the detail so the row is not left blank.
-        guard !detail.isEmpty else {
-            return Highlight(id: id, subject: "", detail: subject.trimmingCharacters(in: CharacterSet(charactersIn: ":")))
-        }
-
-        return Highlight(id: id, subject: subject, detail: detail)
+        // A bold bullet with no detail introduces the nested bullets beneath it, so the
+        // subject stays as the subject and keeps its emphasis.
+        return Highlight(
+            id: id,
+            subject: subject.trimmingCharacters(in: CharacterSet(charactersIn: ":")),
+            detail: detail,
+            level: level
+        )
     }
 }

--- a/Trio/Sources/Services/ReleaseNotes/ReleaseNotes.swift
+++ b/Trio/Sources/Services/ReleaseNotes/ReleaseNotes.swift
@@ -5,9 +5,11 @@ import Foundation
 /// The same shape is written into the app bundle at build time by
 /// `scripts/capture-release-notes.sh`, so the bundled fallback and a live fetch decode
 /// through this one type.
-struct ReleaseNotes: Codable, Equatable {
+struct ReleaseNotes: Codable, Equatable, Identifiable {
     /// Git tag of the release, for example `v0.8.4`.
     let tagName: String
+
+    var id: String { tagName }
 
     /// Human readable release name, for example `Trio v0.8.4`.
     let name: String
@@ -37,6 +39,19 @@ struct ReleaseNotes: Codable, Equatable {
     var url: URL? {
         URL(string: htmlURL)
     }
+
+    /// Publication date, or `nil` when GitHub supplied none.
+    var publishedDate: Date? {
+        publishedAt.isEmpty ? nil : ISO8601DateFormatter().date(from: publishedAt)
+    }
+
+    /// Publication date formatted for display, empty when unavailable.
+    var publishedDateString: String {
+        guard let publishedDate else {
+            return ""
+        }
+        return publishedDate.formatted(date: .abbreviated, time: .omitted)
+    }
 }
 
 extension ReleaseNotes {
@@ -50,18 +65,19 @@ extension ReleaseNotes {
         let publishedAt: String
     }
 
-    /// Decodes the copy written into the app bundle at build time.
+    /// Decodes the releases written into the app bundle at build time, newest first.
     ///
     /// - Parameter data: Contents of `BundledReleaseNotes.json`.
-    static func decodeBundled(from data: Data) throws -> ReleaseNotes {
-        let bundled = try JSONDecoder().decode(Bundled.self, from: data)
-        return ReleaseNotes(
-            tagName: bundled.tagName,
-            name: bundled.name,
-            body: bundled.body,
-            htmlURL: bundled.htmlURL,
-            publishedAt: bundled.publishedAt
-        )
+    static func decodeBundled(from data: Data) throws -> [ReleaseNotes] {
+        try JSONDecoder().decode([Bundled].self, from: data).map {
+            ReleaseNotes(
+                tagName: $0.tagName,
+                name: $0.name,
+                body: $0.body,
+                htmlURL: $0.htmlURL,
+                publishedAt: $0.publishedAt
+            )
+        }
     }
 }
 

--- a/Trio/Sources/Services/ReleaseNotes/ReleaseNotes.swift
+++ b/Trio/Sources/Services/ReleaseNotes/ReleaseNotes.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+/// A published Trio release and its notes, as returned by the GitHub releases API.
+///
+/// The same shape is written into the app bundle at build time by
+/// `scripts/capture-release-notes.sh`, so the bundled fallback and a live fetch decode
+/// through this one type.
+struct ReleaseNotes: Codable, Equatable {
+    /// Git tag of the release, for example `v0.8.4`.
+    let tagName: String
+
+    /// Human readable release name, for example `Trio v0.8.4`.
+    let name: String
+
+    /// Full release body, in GitHub flavoured Markdown.
+    let body: String
+
+    /// Page to open for the complete notes.
+    let htmlURL: String
+
+    /// ISO-8601 publication timestamp. Empty when GitHub did not supply one.
+    let publishedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case tagName = "tag_name"
+        case name
+        case body
+        case htmlURL = "html_url"
+        case publishedAt = "published_at"
+    }
+
+    /// Version without the leading `v`, for comparison against `CFBundleShortVersionString`.
+    var version: String {
+        tagName.hasPrefix("v") ? String(tagName.dropFirst()) : tagName
+    }
+
+    var url: URL? {
+        URL(string: htmlURL)
+    }
+}
+
+extension ReleaseNotes {
+    /// Decoding for the bundled fallback file, which uses camelCase keys rather than the
+    /// GitHub API's snake_case.
+    private struct Bundled: Decodable {
+        let tagName: String
+        let name: String
+        let body: String
+        let htmlURL: String
+        let publishedAt: String
+    }
+
+    /// Decodes the copy written into the app bundle at build time.
+    ///
+    /// - Parameter data: Contents of `BundledReleaseNotes.json`.
+    static func decodeBundled(from data: Data) throws -> ReleaseNotes {
+        let bundled = try JSONDecoder().decode(Bundled.self, from: data)
+        return ReleaseNotes(
+            tagName: bundled.tagName,
+            name: bundled.name,
+            body: bundled.body,
+            htmlURL: bundled.htmlURL,
+            publishedAt: bundled.publishedAt
+        )
+    }
+}
+
+// MARK: - Highlights
+
+extension ReleaseNotes {
+    /// A single bullet from the release's summary section.
+    struct Highlight: Identifiable, Equatable {
+        let id: Int
+
+        /// The bolded lead-in, for example `MedtrumKit`. Empty when the bullet has none.
+        let subject: String
+
+        /// The rest of the bullet.
+        let detail: String
+    }
+
+    /// A GitHub alert callout, for example `> [!IMPORTANT]`.
+    ///
+    /// These carry the "update immediately" style guidance that some releases lead with, so
+    /// they are surfaced rather than dropped along with the rest of the Markdown.
+    struct Callout: Identifiable, Equatable {
+        enum Kind: String {
+            case note = "NOTE"
+            case tip = "TIP"
+            case important = "IMPORTANT"
+            case warning = "WARNING"
+            case caution = "CAUTION"
+        }
+
+        let id: Int
+        let kind: Kind
+        let text: String
+    }
+
+    /// Heading that introduces the summary section in Trio's release notes.
+    private static let highlightsHeading = "What's Changed At A Glance"
+
+    /// Body split into trimmed lines.
+    ///
+    /// GitHub returns release bodies with CRLF endings. Splitting on the newlines character
+    /// set would treat `\r` and `\n` as two separate breaks and yield a spurious blank line
+    /// between every real one, which is enough to break multi-line parsing.
+    private var bodyLines: [String] {
+        body
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+
+    /// The bullets under "What's Changed At A Glance".
+    ///
+    /// Trio's release notes lead with that section, and the rest of the body is a long list
+    /// of pull request links that is not worth rendering in a sheet - the "full release
+    /// notes" link covers those. Returns an empty array when the section is absent, which is
+    /// how a release with a different layout is detected.
+    var highlights: [Highlight] {
+        var result: [Highlight] = []
+        var insideSection = false
+
+        for line in bodyLines {
+            if line.hasPrefix("#") {
+                // A heading either opens the section we want or closes it again.
+                let heading = line.drop(while: { $0 == "#" }).trimmingCharacters(in: .whitespaces)
+                if heading.caseInsensitiveCompare(Self.highlightsHeading) == .orderedSame {
+                    insideSection = true
+                } else if insideSection {
+                    break
+                }
+                continue
+            }
+
+            guard insideSection else {
+                continue
+            }
+
+            // A horizontal rule closes the section too.
+            if line == "---" || line == "***" {
+                break
+            }
+
+            guard line.hasPrefix("- ") || line.hasPrefix("* ") else {
+                continue
+            }
+
+            let bullet = String(line.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+            guard !bullet.isEmpty else {
+                continue
+            }
+
+            result.append(Self.parseBullet(bullet, id: result.count))
+        }
+
+        return result
+    }
+
+    /// The release's opening prose, before the first section heading.
+    ///
+    /// Not every release uses the "What's Changed At A Glance" convention - hotfixes in
+    /// particular lead straight into prose - so this gives the sheet something meaningful to
+    /// show when `highlights` comes back empty.
+    var summary: String {
+        var paragraphs: [String] = []
+
+        for line in bodyLines {
+            // The title heading opens the body; any other heading ends the intro.
+            if line.hasPrefix("##") {
+                break
+            }
+            if line == "---" || line == "***" {
+                break
+            }
+            if line.isEmpty || line.hasPrefix("#") || line.hasPrefix(">") {
+                continue
+            }
+
+            paragraphs.append(line)
+        }
+
+        return paragraphs.joined(separator: "\n\n")
+    }
+
+    /// GitHub alert callouts found anywhere in the release body.
+    var callouts: [Callout] {
+        var result: [Callout] = []
+        var currentKind: Callout.Kind?
+        var currentLines: [String] = []
+
+        func flush() {
+            defer {
+                currentKind = nil
+                currentLines = []
+            }
+            guard let kind = currentKind else {
+                return
+            }
+            let text = currentLines.joined(separator: " ").trimmingCharacters(in: .whitespaces)
+            guard !text.isEmpty else {
+                return
+            }
+            result.append(Callout(id: result.count, kind: kind, text: text))
+        }
+
+        for line in bodyLines {
+            guard line.hasPrefix(">") else {
+                flush()
+                continue
+            }
+
+            let content = String(line.dropFirst()).trimmingCharacters(in: .whitespaces)
+
+            // `> [!IMPORTANT]` opens a new callout; following `>` lines are its body.
+            if content.hasPrefix("[!"), let closing = content.firstIndex(of: "]") {
+                flush()
+                let marker = String(content[content.index(content.startIndex, offsetBy: 2) ..< closing])
+                currentKind = Callout.Kind(rawValue: marker.uppercased())
+                continue
+            }
+
+            if currentKind != nil, !content.isEmpty {
+                currentLines.append(content)
+            }
+        }
+
+        flush()
+        return result
+    }
+
+    /// Splits a bullet into its bolded lead-in and the remaining text.
+    ///
+    /// Trio writes these as `**Subject** — detail`. Anything that does not follow that shape
+    /// is kept whole as the detail, so an unexpected format degrades to plain text rather
+    /// than being dropped.
+    private static func parseBullet(_ bullet: String, id: Int) -> Highlight {
+        guard bullet.hasPrefix("**"),
+              let closing = bullet.range(of: "**", range: bullet.index(bullet.startIndex, offsetBy: 2) ..< bullet.endIndex)
+        else {
+            return Highlight(id: id, subject: "", detail: bullet)
+        }
+
+        let subject = String(bullet[bullet.index(bullet.startIndex, offsetBy: 2) ..< closing.lowerBound])
+        var detail = String(bullet[closing.upperBound...]).trimmingCharacters(in: .whitespaces)
+
+        // Drop the separator Trio uses between subject and detail.
+        for separator in ["—", "-", "–", ":"] where detail.hasPrefix(separator) {
+            detail = String(detail.dropFirst(separator.count)).trimmingCharacters(in: .whitespaces)
+            break
+        }
+
+        // Some bullets are a bold heading with their detail in nested sub-bullets, which are
+        // not rendered. Promote the subject to the detail so the row is not left blank.
+        guard !detail.isEmpty else {
+            return Highlight(id: id, subject: "", detail: subject.trimmingCharacters(in: CharacterSet(charactersIn: ":")))
+        }
+
+        return Highlight(id: id, subject: subject, detail: detail)
+    }
+}

--- a/Trio/Sources/Services/ReleaseNotes/ReleaseNotesService.swift
+++ b/Trio/Sources/Services/ReleaseNotes/ReleaseNotesService.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Supplies the release notes for the version of Trio that is installed, and remembers whether
+/// the user has already seen them.
+///
+/// Notes come from three places, in order of preference:
+///
+/// 1. A live fetch from the GitHub releases API, because notes are sometimes edited after a
+///    release is published.
+/// 2. The copy cached from the last successful fetch.
+/// 3. The copy bundled at build time by `scripts/capture-release-notes.sh`, so a phone that has
+///    never been online still has something to show.
+///
+/// The release is looked up by exact tag, so Trio only ever shows notes for the version actually
+/// installed - never for a newer release the user has not built.
+@MainActor final class ReleaseNotesService: ObservableObject {
+    static let shared = ReleaseNotesService()
+
+    private init() {}
+
+    // MARK: - Constants
+
+    private static let repository = "nightscout/Trio"
+
+    /// How long a successful fetch is trusted before another one is attempted.
+    private static let refreshInterval: TimeInterval = 86400 // 24 hours
+
+    private static let bundledResourceName = "BundledReleaseNotes"
+
+    // MARK: - Persisted State
+
+    /// Notes from the last successful fetch.
+    @Persisted(key: "cachedReleaseNotes") private var cachedNotes: ReleaseNotes? = nil
+
+    /// When `cachedNotes` was fetched.
+    @Persisted(key: "releaseNotesLastFetched") private var lastFetched: Date? = .distantPast
+
+    /// Version whose notes the user has dismissed, for example `0.8.4`.
+    ///
+    /// Stored rather than a plain flag so that installing a newer release surfaces the panel
+    /// again without anything having to reset it.
+    @Persisted(key: "acknowledgedReleaseNotesVersion") private var acknowledgedVersion: String? = nil
+
+    // MARK: - Published State
+
+    /// Notes for the installed version, once resolved. `nil` when none could be found.
+    @Published private(set) var notes: ReleaseNotes?
+
+    // MARK: - Derived State
+
+    /// The installed marketing version, for example `0.8.4`.
+    ///
+    /// Development builds carry a four-part `AppDevVersion` as well, but their
+    /// `CFBundleShortVersionString` still matches the release they were branched from, which is
+    /// the release whose notes apply.
+    var installedVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    }
+
+    /// Whether the Home panel should offer the notes.
+    var hasUnacknowledgedNotes: Bool {
+        guard let notes else {
+            return false
+        }
+        return acknowledgedVersion != notes.version
+    }
+
+    // MARK: - Public Methods
+
+    /// Resolves the notes for the installed version, preferring fresh content.
+    ///
+    /// Safe to call repeatedly; the network is only touched once per `refreshInterval`.
+    func load() async {
+        // Show whatever is already available first, so the panel does not wait on the network.
+        notes = resolveOffline()
+
+        guard shouldRefresh else {
+            return
+        }
+
+        if let fetched = await fetch(version: installedVersion) {
+            cachedNotes = fetched
+            lastFetched = Date()
+            notes = fetched
+        }
+    }
+
+    /// Marks the installed version's notes as seen, which removes the Home panel entry.
+    ///
+    /// The notes stay reachable from Settings afterwards.
+    func acknowledge() {
+        guard let notes else {
+            return
+        }
+        acknowledgedVersion = notes.version
+        objectWillChange.send()
+    }
+
+    // MARK: - Private Methods
+
+    private var shouldRefresh: Bool {
+        Date().timeIntervalSince(lastFetched ?? .distantPast) > Self.refreshInterval
+    }
+
+    /// Best available notes without touching the network.
+    private func resolveOffline() -> ReleaseNotes? {
+        if let cachedNotes, cachedNotes.version == installedVersion {
+            return cachedNotes
+        }
+        if let bundled = loadBundled(), bundled.version == installedVersion {
+            return bundled
+        }
+        return nil
+    }
+
+    /// Reads the copy written into the app bundle at build time.
+    private func loadBundled() -> ReleaseNotes? {
+        guard let url = Bundle.main.url(forResource: Self.bundledResourceName, withExtension: "json"),
+              let data = try? Data(contentsOf: url)
+        else {
+            return nil
+        }
+
+        do {
+            return try ReleaseNotes.decodeBundled(from: data)
+        } catch {
+            debug(.default, "Failed to decode bundled release notes: \(error)")
+            return nil
+        }
+    }
+
+    /// Fetches the release whose tag matches the installed version.
+    ///
+    /// Returns `nil` for any failure, including no release existing for this version, which is
+    /// the normal case for a build made between releases.
+    private func fetch(version: String) async -> ReleaseNotes? {
+        guard !version.isEmpty,
+              let url = URL(string: "https://api.github.com/repos/\(Self.repository)/releases/tags/v\(version)")
+        else {
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 20
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+                debug(.default, "Release notes fetch for v\(version) returned status \(status)")
+                return nil
+            }
+
+            return try JSONDecoder().decode(ReleaseNotes.self, from: data)
+        } catch {
+            debug(.default, "Failed to fetch release notes for v\(version): \(error)")
+            return nil
+        }
+    }
+}

--- a/Trio/Sources/Services/ReleaseNotes/ReleaseNotesService.swift
+++ b/Trio/Sources/Services/ReleaseNotes/ReleaseNotesService.swift
@@ -27,10 +27,14 @@ import Foundation
 
     private static let bundledResourceName = "BundledReleaseNotes"
 
+    /// Oldest release worth showing. Earlier notes describe an app far enough removed from the
+    /// current one that they are more confusing than useful.
+    private static let minimumVersion = [0, 8, 0]
+
     // MARK: - Persisted State
 
-    /// Notes from the last successful fetch.
-    @Persisted(key: "cachedReleaseNotes") private var cachedNotes: ReleaseNotes? = nil
+    /// Releases from the last successful fetch, newest first.
+    @Persisted(key: "cachedReleaseList") private var cachedReleases: [ReleaseNotes]? = nil
 
     /// When `cachedNotes` was fetched.
     @Persisted(key: "releaseNotesLastFetched") private var lastFetched: Date? = .distantPast
@@ -43,8 +47,21 @@ import Foundation
 
     // MARK: - Published State
 
-    /// Notes for the installed version, once resolved. `nil` when none could be found.
-    @Published private(set) var notes: ReleaseNotes?
+    /// Stable releases up to and including this build's version, newest first.
+    @Published private(set) var releases: [ReleaseNotes] = []
+
+    /// Notes matching this build's version. `nil` when none could be found.
+    var notes: ReleaseNotes? {
+        releases.first { $0.version == installedVersion }
+    }
+
+    /// Every release older than this build's, newest first.
+    var previousReleases: [ReleaseNotes] {
+        guard let notes else {
+            return releases
+        }
+        return releases.filter { $0.version != notes.version }
+    }
 
     // MARK: - Derived State
 
@@ -71,18 +88,21 @@ import Foundation
     ///
     /// Safe to call repeatedly; the network is only touched once per `refreshInterval`.
     func load() async {
-        // Show whatever is already available first, so the panel does not wait on the network.
-        notes = resolveOffline()
+        // Show whatever is already available first, so nothing waits on the network.
+        releases = Self.supported(resolveOffline())
 
         guard shouldRefresh else {
             return
         }
 
-        if let fetched = await fetch(version: installedVersion) {
-            cachedNotes = fetched
-            lastFetched = Date()
-            notes = fetched
+        let fetched = Self.supported(await fetchReleases())
+        guard !fetched.isEmpty else {
+            return
         }
+
+        cachedReleases = fetched
+        lastFetched = Date()
+        releases = fetched
     }
 
     /// Marks the installed version's notes as seen, which removes the Home panel entry.
@@ -102,42 +122,38 @@ import Foundation
         Date().timeIntervalSince(lastFetched ?? .distantPast) > Self.refreshInterval
     }
 
-    /// Best available notes without touching the network.
-    private func resolveOffline() -> ReleaseNotes? {
-        if let cachedNotes, cachedNotes.version == installedVersion {
-            return cachedNotes
+    /// Best available releases without touching the network.
+    private func resolveOffline() -> [ReleaseNotes] {
+        if let cachedReleases, !cachedReleases.isEmpty {
+            return cachedReleases
         }
-        if let bundled = loadBundled(), bundled.version == installedVersion {
-            return bundled
-        }
-        return nil
+        return loadBundled()
     }
 
-    /// Reads the copy written into the app bundle at build time.
-    private func loadBundled() -> ReleaseNotes? {
+    /// Reads the releases written into the app bundle at build time.
+    private func loadBundled() -> [ReleaseNotes] {
         guard let url = Bundle.main.url(forResource: Self.bundledResourceName, withExtension: "json"),
               let data = try? Data(contentsOf: url)
         else {
-            return nil
+            return []
         }
 
         do {
             return try ReleaseNotes.decodeBundled(from: data)
         } catch {
             debug(.default, "Failed to decode bundled release notes: \(error)")
-            return nil
+            return []
         }
     }
 
-    /// Fetches the release whose tag matches the installed version.
+    /// Fetches published releases, keeping the stable ones this build has reached.
     ///
-    /// Returns `nil` for any failure, including no release existing for this version, which is
-    /// the normal case for a build made between releases.
-    private func fetch(version: String) async -> ReleaseNotes? {
-        guard !version.isEmpty,
-              let url = URL(string: "https://api.github.com/repos/\(Self.repository)/releases/tags/v\(version)")
-        else {
-            return nil
+    /// Prereleases and drafts are dropped, as is anything newer than the installed version, so
+    /// the list never advertises notes for a release the user is not running yet. Returns an
+    /// empty array on any failure.
+    private func fetchReleases() async -> [ReleaseNotes] {
+        guard let url = URL(string: "https://api.github.com/repos/\(Self.repository)/releases?per_page=100") else {
+            return []
         }
 
         var request = URLRequest(url: url)
@@ -149,14 +165,72 @@ import Foundation
 
             guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
                 let status = (response as? HTTPURLResponse)?.statusCode ?? -1
-                debug(.default, "Release notes fetch for v\(version) returned status \(status)")
-                return nil
+                debug(.default, "Release list fetch returned status \(status)")
+                return []
             }
 
-            return try JSONDecoder().decode(ReleaseNotes.self, from: data)
+            let installed = Self.versionComponents(installedVersion)
+
+            return try JSONDecoder().decode([GitHubRelease].self, from: data)
+                .filter { !$0.draft && !$0.prerelease }
+                .map(\.notes)
+                .filter {
+                    installed.isEmpty || Self.versionComponents($0.version).lexicographicallyPrecedes(installed) || $0
+                        .version == installedVersion }
+                .sorted { Self.versionComponents($1.version).lexicographicallyPrecedes(Self.versionComponents($0.version)) }
         } catch {
-            debug(.default, "Failed to fetch release notes for v\(version): \(error)")
-            return nil
+            debug(.default, "Failed to fetch release list: \(error)")
+            return []
         }
+    }
+
+    /// Drops releases older than `minimumVersion`.
+    private static func supported(_ releases: [ReleaseNotes]) -> [ReleaseNotes] {
+        releases.filter { release in
+            let components = versionComponents(release.version)
+            return !components.isEmpty && !components.lexicographicallyPrecedes(minimumVersion)
+        }
+    }
+
+    /// Numeric components of a version, for ordering. Empty when it is not dotted numerals.
+    private static func versionComponents(_ version: String) -> [Int] {
+        let pieces = version.split(separator: ".").map { Int($0) }
+        guard !pieces.isEmpty, !pieces.contains(nil) else {
+            return []
+        }
+        return pieces.compactMap { $0 }
+    }
+}
+
+// MARK: - GitHub payload
+
+/// Release as returned by the list endpoint, which carries fields the app does not keep.
+private struct GitHubRelease: Decodable {
+    let tagName: String
+    let name: String?
+    let body: String?
+    let htmlURL: String
+    let publishedAt: String?
+    let draft: Bool
+    let prerelease: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case tagName = "tag_name"
+        case name
+        case body
+        case htmlURL = "html_url"
+        case publishedAt = "published_at"
+        case draft
+        case prerelease
+    }
+
+    var notes: ReleaseNotes {
+        ReleaseNotes(
+            tagName: tagName,
+            name: name ?? tagName,
+            body: body ?? "",
+            htmlURL: htmlURL,
+            publishedAt: publishedAt ?? ""
+        )
     }
 }

--- a/TrioTests/CoreDataTests/MultiUsePanelStateTests.swift
+++ b/TrioTests/CoreDataTests/MultiUsePanelStateTests.swift
@@ -12,13 +12,15 @@ import Testing
         notificationsDisabled: Bool = false,
         pumpTimeMismatch: Bool = false,
         lastGlucoseDate: Date?,
-        maxIOB: Decimal = 10
+        maxIOB: Decimal = 10,
+        hasUnacknowledgedReleaseNotes: Bool = false
     ) -> MultiUsePanelState {
         MultiUsePanelState.resolve(
             notificationsDisabled: notificationsDisabled,
             pumpTimeMismatch: pumpTimeMismatch,
             lastGlucoseDate: lastGlucoseDate,
             maxIOB: maxIOB,
+            hasUnacknowledgedReleaseNotes: hasUnacknowledgedReleaseNotes,
             now: now
         )
     }
@@ -54,5 +56,32 @@ import Testing
 
     @Test("MaxIOB zero shows its warning") func testMaxIOBZero() {
         #expect(resolve(lastGlucoseDate: fresh, maxIOB: 0) == .maxIOBZero)
+    }
+
+    @Test("Unacknowledged release notes displace the stats") func testWhatsNewOverStats() {
+        #expect(resolve(lastGlucoseDate: fresh, hasUnacknowledgedReleaseNotes: true) == .whatsNew)
+    }
+
+    @Test("Every warning outranks release notes") func testWhatsNewYieldsToWarnings() {
+        #expect(resolve(
+            notificationsDisabled: true,
+            lastGlucoseDate: fresh,
+            hasUnacknowledgedReleaseNotes: true
+        ) == .notificationsDisabled)
+        #expect(resolve(
+            pumpTimeMismatch: true,
+            lastGlucoseDate: fresh,
+            hasUnacknowledgedReleaseNotes: true
+        ) == .pumpTimeMismatch)
+        #expect(resolve(lastGlucoseDate: stale, hasUnacknowledgedReleaseNotes: true) == .cgmStale)
+        #expect(resolve(
+            lastGlucoseDate: fresh,
+            maxIOB: 0,
+            hasUnacknowledgedReleaseNotes: true
+        ) == .maxIOBZero)
+    }
+
+    @Test("Acknowledged release notes fall back to stats") func testAcknowledgedShowsStats() {
+        #expect(resolve(lastGlucoseDate: fresh, hasUnacknowledgedReleaseNotes: false) == .stats)
     }
 }

--- a/scripts/capture-release-notes.sh
+++ b/scripts/capture-release-notes.sh
@@ -49,15 +49,35 @@ fi
 major_minor=$(echo "${version}" | awk -F. '{print $1"."$2}')
 echo "capture-release-notes: collecting ${REPO} releases in the ${major_minor}.x line up to ${version}"
 
-if ! curl --fail --silent --show-error --location \
-  --connect-timeout 5 --max-time 30 \
-  -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/${REPO}/releases?per_page=100" \
-  -o "${OUTPUT}.raw" 2>/dev/null
-then
-  warn "could not reach GitHub; building without bundled notes"
-  rm -f "${OUTPUT}.raw"
-  exit 0
+# GitHub allows 60 unauthenticated API calls per hour per IP, and CI runners share
+# egress addresses, so an unauthenticated build can be refused because of traffic it
+# has nothing to do with. GH_PAT is already in the workflow environment.
+token="${GH_PAT:-${GITHUB_TOKEN:-}}"
+if [ -n "${token}" ]; then
+  set -- -H "Authorization: Bearer ${token}"
+else
+  set --
+fi
+
+fetch_releases() {
+  curl --fail --silent --show-error --location \
+    --connect-timeout 5 --max-time 30 \
+    -H "Accept: application/vnd.github+json" \
+    "$@" \
+    "https://api.github.com/repos/${REPO}/releases?per_page=100" \
+    -o "${OUTPUT}.raw" 2>/dev/null
+}
+
+if ! fetch_releases "$@"; then
+  # An expired or malformed token would otherwise do worse than no token at all, so
+  # fall back to an unauthenticated call before giving up.
+  if [ "$#" -gt 0 ] && fetch_releases; then
+    warn "token was rejected; fetched release notes unauthenticated"
+  else
+    warn "could not reach GitHub; building without bundled notes"
+    rm -f "${OUTPUT}.raw"
+    exit 0
+  fi
 fi
 
 # Keep only the fields the app reads, so the bundle does not carry whole release objects.

--- a/scripts/capture-release-notes.sh
+++ b/scripts/capture-release-notes.sh
@@ -2,18 +2,15 @@
 #  capture-release-notes.sh
 #  Trio
 #
-#  Bundles the GitHub release notes for the version being built, so the "What's New"
-#  panel has something to show when the device is offline or GitHub is unreachable.
+#  Bundles GitHub release notes for the version line being built, so the release notes
+#  list still works when the device is offline or GitHub is unreachable.
 #
-#  At runtime Trio still prefers a live fetch, because release notes are sometimes
-#  edited after publishing. This is only the fallback.
+#  Every stable release back to the last major or minor bump is kept: building 0.8.4
+#  bundles 0.8.0 through 0.8.4. At runtime Trio still prefers a live fetch, because
+#  release notes are sometimes edited after publishing. This is only the fallback.
 #
-#  The release is looked up by the exact tag "v${APP_VERSION}". Development builds
-#  carry a four-part APP_DEV_VERSION that matches no published release, so nothing is
-#  bundled for them and the panel stays hidden - which is intended.
-#
-#  This never fails the build. No network, no release, no GitHub - the app simply
-#  falls back to a live fetch, and shows nothing if that fails too.
+#  This never fails the build. No network, no releases, no GitHub - the app falls back
+#  to a live fetch, and shows nothing if that fails too.
 
 set -u
 
@@ -43,55 +40,81 @@ fi
 
 # PlistBuddy reports failures on stdout rather than stderr, so an unreadable plist
 # would otherwise be treated as the version string. Insist on a dotted numeric
-# version before it is used to build a URL.
+# version before it is used.
 if ! echo "${version}" | grep -Eq '^[0-9]+(\.[0-9]+)*$'; then
   warn "could not determine a valid app version, skipping"
   exit 0
 fi
 
-tag="v${version}"
-echo "capture-release-notes: looking up ${REPO} release ${tag}"
+major_minor=$(echo "${version}" | awk -F. '{print $1"."$2}')
+echo "capture-release-notes: collecting ${REPO} releases in the ${major_minor}.x line up to ${version}"
 
-# --fail so a 404 (no release for this tag, e.g. a dev build) is not written out as
-# an error payload. Short timeouts so an offline build is not held up.
 if ! curl --fail --silent --show-error --location \
-  --connect-timeout 5 --max-time 20 \
+  --connect-timeout 5 --max-time 30 \
   -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/${REPO}/releases/tags/${tag}" \
+  "https://api.github.com/repos/${REPO}/releases?per_page=100" \
   -o "${OUTPUT}.raw" 2>/dev/null
 then
-  warn "no published release found for ${tag} (or GitHub unreachable); building without bundled notes"
+  warn "could not reach GitHub; building without bundled notes"
   rm -f "${OUTPUT}.raw"
   exit 0
 fi
 
-# Reduce the API payload to just the fields the app reads, so the bundle does not
-# carry the entire release object.
-if ! /usr/bin/python3 - "${OUTPUT}.raw" "${OUTPUT}" <<'PY'
+# Keep only the fields the app reads, so the bundle does not carry whole release objects.
+if ! /usr/bin/python3 - "${OUTPUT}.raw" "${OUTPUT}" "${version}" <<'PY'
 import json, sys
 
-src, dst = sys.argv[1], sys.argv[2]
+src, dst, version = sys.argv[1], sys.argv[2], sys.argv[3]
+
+
+def parts(tag):
+    return [int(piece) for piece in tag.lstrip("v").split(".")]
+
+
 try:
     with open(src, encoding="utf-8") as handle:
-        release = json.load(handle)
-    payload = {
-        "tagName": release["tag_name"],
-        "name": release.get("name") or release["tag_name"],
-        "body": release.get("body") or "",
-        "htmlURL": release["html_url"],
-        "publishedAt": release.get("published_at") or "",
-    }
+        releases = json.load(handle)
+
+    current = parts(version)
+    line = current[:2]
+    kept = []
+
+    for release in releases:
+        if release.get("draft") or release.get("prerelease"):
+            continue
+        tag = release.get("tag_name") or ""
+        try:
+            numbers = parts(tag)
+        except ValueError:
+            continue
+        if numbers[:2] != line or numbers > current:
+            continue
+        kept.append({
+            "tagName": tag,
+            "name": release.get("name") or tag,
+            "body": release.get("body") or "",
+            "htmlURL": release["html_url"],
+            "publishedAt": release.get("published_at") or "",
+        })
+
+    if not kept:
+        raise SystemExit(2)
+
+    kept.sort(key=lambda item: parts(item["tagName"]), reverse=True)
     with open(dst, "w", encoding="utf-8") as handle:
-        json.dump(payload, handle, ensure_ascii=False)
+        json.dump(kept, handle, ensure_ascii=False)
+    print("kept " + ", ".join(item["tagName"] for item in kept), file=sys.stderr)
+except SystemExit:
+    raise
 except Exception as error:  # noqa: BLE001 - build step must never hard-fail
     print(f"could not parse release payload: {error}", file=sys.stderr)
     raise SystemExit(1)
 PY
 then
-  warn "could not parse release payload; building without bundled notes"
+  warn "no published releases found in the ${major_minor}.x line; building without bundled notes"
   rm -f "${OUTPUT}" "${OUTPUT}.raw"
   exit 0
 fi
 
 rm -f "${OUTPUT}.raw"
-echo "capture-release-notes: bundled release notes for ${tag}"
+echo "capture-release-notes: bundled release notes for the ${major_minor}.x line"

--- a/scripts/capture-release-notes.sh
+++ b/scripts/capture-release-notes.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+#  capture-release-notes.sh
+#  Trio
+#
+#  Bundles the GitHub release notes for the version being built, so the "What's New"
+#  panel has something to show when the device is offline or GitHub is unreachable.
+#
+#  At runtime Trio still prefers a live fetch, because release notes are sometimes
+#  edited after publishing. This is only the fallback.
+#
+#  The release is looked up by the exact tag "v${APP_VERSION}". Development builds
+#  carry a four-part APP_DEV_VERSION that matches no published release, so nothing is
+#  bundled for them and the panel stays hidden - which is intended.
+#
+#  This never fails the build. No network, no release, no GitHub - the app simply
+#  falls back to a live fetch, and shows nothing if that fails too.
+
+set -u
+
+RESOURCE_DIR="${BUILT_PRODUCTS_DIR:-}/${UNLOCALIZED_RESOURCES_FOLDER_PATH:-}"
+OUTPUT="${RESOURCE_DIR}/BundledReleaseNotes.json"
+REPO="nightscout/Trio"
+
+warn() {
+  echo "warning: capture-release-notes: ${*}" >&2
+}
+
+# Always start from a clean slate so a stale file from a previous version cannot
+# survive into this build.
+rm -f "${OUTPUT}"
+
+if [ ! -d "${RESOURCE_DIR}" ]; then
+  warn "resource directory not found, skipping"
+  exit 0
+fi
+
+# APP_VERSION comes from Config.xcconfig. Fall back to the built Info.plist value.
+version="${APP_VERSION:-}"
+if [ -z "${version}" ]; then
+  version=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" \
+    "${BUILT_PRODUCTS_DIR:-}/${INFOPLIST_PATH:-}" 2>/dev/null || echo "")
+fi
+
+# PlistBuddy reports failures on stdout rather than stderr, so an unreadable plist
+# would otherwise be treated as the version string. Insist on a dotted numeric
+# version before it is used to build a URL.
+if ! echo "${version}" | grep -Eq '^[0-9]+(\.[0-9]+)*$'; then
+  warn "could not determine a valid app version, skipping"
+  exit 0
+fi
+
+tag="v${version}"
+echo "capture-release-notes: looking up ${REPO} release ${tag}"
+
+# --fail so a 404 (no release for this tag, e.g. a dev build) is not written out as
+# an error payload. Short timeouts so an offline build is not held up.
+if ! curl --fail --silent --show-error --location \
+  --connect-timeout 5 --max-time 20 \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${REPO}/releases/tags/${tag}" \
+  -o "${OUTPUT}.raw" 2>/dev/null
+then
+  warn "no published release found for ${tag} (or GitHub unreachable); building without bundled notes"
+  rm -f "${OUTPUT}.raw"
+  exit 0
+fi
+
+# Reduce the API payload to just the fields the app reads, so the bundle does not
+# carry the entire release object.
+if ! /usr/bin/python3 - "${OUTPUT}.raw" "${OUTPUT}" <<'PY'
+import json, sys
+
+src, dst = sys.argv[1], sys.argv[2]
+try:
+    with open(src, encoding="utf-8") as handle:
+        release = json.load(handle)
+    payload = {
+        "tagName": release["tag_name"],
+        "name": release.get("name") or release["tag_name"],
+        "body": release.get("body") or "",
+        "htmlURL": release["html_url"],
+        "publishedAt": release.get("published_at") or "",
+    }
+    with open(dst, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False)
+except Exception as error:  # noqa: BLE001 - build step must never hard-fail
+    print(f"could not parse release payload: {error}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+  warn "could not parse release payload; building without bundled notes"
+  rm -f "${OUTPUT}" "${OUTPUT}.raw"
+  exit 0
+fi
+
+rm -f "${OUTPUT}.raw"
+echo "capture-release-notes: bundled release notes for ${tag}"


### PR DESCRIPTION
## Summary

Surfaces Trio's release notes in two places:

- **Home** — a "New Release" entry in the multi-use panel, opening a sheet the user acknowledges to dismiss it
- **Settings → Release Notes** — the current release, plus a **Previous Versions** screen for earlier ones

## Where the notes come from

Three sources, in order of preference:

1. A live fetch of the GitHub releases API, since notes are sometimes edited after publishing
2. The last successful fetch, cached
3. A copy bundled at build time by `scripts/capture-release-notes.sh`

The bundle covers **every stable release back to the last major or minor bump**, building `0.8.4` embeds `0.8.0` through `0.8.4`, so the list still works on a phone that has never been online.

That script can never fail a build. A missing release, an unreachable GitHub, an unparseable version or an empty environment all simply leave the fallback out; every path exits 0, and a stale bundle from a previous version is removed rather than left behind.

Drafts, prereleases, anything newer than the running build, and anything before `0.8.0` are all excluded. Sorting is by version.

## What the sheet renders

The release's opening prose, its GitHub alert callouts, and the bullets under **"What's Changed At A Glance"**. The full notes, including the pull request lists, stay on GitHub behind a link.

Two things worth knowing, both found by testing the parser against real releases rather than assuming a format:

- **The "At A Glance" heading is not universal.** Five of the six most recent releases have it; the `0.8.3` hotfix used "What happened" / "What's fixed" instead. Relying on that heading alone would have produced an empty sheet on exactly the kind of urgent hotfix people most need to read, so the parser falls back to the release's opening prose.
- **Releases carry `[!IMPORTANT]` callouts with safety-relevant content** — *"If you are using Medtrum Nano please update at your earliest convenience"*, *"your active Pod will be automatically transitioned"*. A bullets-only sheet would have hidden these behind a browser link, so they are parsed and shown.

## Acknowledgement

Stored per version, so installing a newer release surfaces the panel again with nothing needing to reset it. Only the sheet's button acknowledges — swiping it away, or browsing notes from Settings, leaves the panel in place.

The panel ranks below every warning state and above the stats. `MultiUsePanelState.resolve` gained a parameter, so its existing tests were updated and three added for the new ordering; all 10 pass.

### Screenshots

| ☾ Release Panel | ☀ Release Panel | Settings Row | Release Notes |
|--------|--------|--------|--------|
| <img width="766" height="1666" alt="image" src="https://github.com/user-attachments/assets/7f395211-2f20-4d55-94d2-82834bb106e1" /> | <img width="766" height="1666" alt="image" src="https://github.com/user-attachments/assets/01913811-ca33-4100-87fa-dc9befeff5e1" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/be368aeb-9211-4698-8cd3-5c9ae62b26e2" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/f13619d9-708b-4f1f-b30f-4c9a827824fb" /> |



