### PR TITLE
Show Dev Branch Warning Popup

### DIFF
--- a/.github/workflows/build_trio.yml
+++ b/.github/workflows/build_trio.yml
@@ -238,6 +238,20 @@ jobs:
           # Several patches may be added per submodule.
           # Adding comments (#) is strongly recommended to easily tell the individual patches apart.
 
+      # Optional: silence the startup warning shown on builds made from a branch other
+      # than main. Off unless you deliberately set the repository variable
+      # DEV_BRANCH_WARNING_DISABLED to true (Settings > Secrets and variables > Actions
+      # > Variables). Intended for forks and redistributions that always build from
+      # their own branch - if you are testing dev, leave this alone and keep the warning.
+      - name: Configure Dev Branch Warning
+        if: vars.DEV_BRANCH_WARNING_DISABLED == 'true'
+        run: |
+          # ConfigOverride.xcconfig is gitignored and is included by Config.xcconfig,
+          # so writing it here feeds the flag into the Release build without touching
+          # any tracked file.
+          echo 'SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) DEV_BRANCH_WARNING_DISABLED' >> ConfigOverride.xcconfig
+          echo "::warning::Development branch warning disabled for this build."
+
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: |

--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -826,6 +826,7 @@
 		DDA6E3202D258E0500C2988C /* OverrideHelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA6E31F2D258E0500C2988C /* OverrideHelpView.swift */; };
 		DDA6E3222D25901100C2988C /* TempTargetHelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA6E3212D25901100C2988C /* TempTargetHelpView.swift */; };
 		DDA6E3572D25988500C2988C /* ContactImageHelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA6E3562D25988500C2988C /* ContactImageHelpView.swift */; };
+		DB0BA0010000000000000003 /* DevelopmentBranchAlerter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0BA0010000000000000002 /* DevelopmentBranchAlerter.swift */; };
 		DDA9AC092D672CF100E6F1A9 /* AppVersionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDA9AC082D672CEB00E6F1A9 /* AppVersionChecker.swift */; };
 		DDAA29832D2D1D93006546A1 /* AdjustmentsRootView+Overrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAA29822D2D1D7B006546A1 /* AdjustmentsRootView+Overrides.swift */; };
 		DDAA29852D2D1D9E006546A1 /* AdjustmentsRootView+TempTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDAA29842D2D1D98006546A1 /* AdjustmentsRootView+TempTargets.swift */; };
@@ -1865,6 +1866,7 @@
 		DDA6E31F2D258E0500C2988C /* OverrideHelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverrideHelpView.swift; sourceTree = "<group>"; };
 		DDA6E3212D25901100C2988C /* TempTargetHelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempTargetHelpView.swift; sourceTree = "<group>"; };
 		DDA6E3562D25988500C2988C /* ContactImageHelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactImageHelpView.swift; sourceTree = "<group>"; };
+		DB0BA0010000000000000002 /* DevelopmentBranchAlerter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevelopmentBranchAlerter.swift; sourceTree = "<group>"; };
 		DDA9AC082D672CEB00E6F1A9 /* AppVersionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionChecker.swift; sourceTree = "<group>"; };
 		DDA9AC0A2D678DAD00E6F1A9 /* blacklisted-versions.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "blacklisted-versions.json"; sourceTree = "<group>"; };
 		DDAA29822D2D1D7B006546A1 /* AdjustmentsRootView+Overrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AdjustmentsRootView+Overrides.swift"; sourceTree = "<group>"; };
@@ -2481,6 +2483,7 @@
 				B015AFE22E500000000D7351 /* BolusSafety */,
 				3862CC2C2743F9DC00BF832C /* Calendar */,
 				E592A37E2CEEC046009A472C /* ContactImage */,
+				DB0BA0010000000000000001 /* DevelopmentBranchAlerter */,
 				F90692A8274B7A980037068D /* HealthKit */,
 				3B506FD72E6352E9000740B9 /* IOB */,
 				6B1A8D2C2B156EC100E76752 /* LiveActivity */,
@@ -4335,6 +4338,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		DB0BA0010000000000000001 /* DevelopmentBranchAlerter */ = {
+			isa = PBXGroup;
+			children = (
+				DB0BA0010000000000000002 /* DevelopmentBranchAlerter.swift */,
+			);
+			path = DevelopmentBranchAlerter;
+			sourceTree = "<group>";
+		};
 		DDA9AC072D67291600E6F1A9 /* AppVersionChecker */ = {
 			isa = PBXGroup;
 			children = (
@@ -5195,6 +5206,7 @@
 				38FE826D25CC8461001FF17A /* NightscoutAPI.swift in Sources */,
 				388358C825EEF6D200E024B2 /* BasalProfileEntry.swift in Sources */,
 				DDA9AC092D672CF100E6F1A9 /* AppVersionChecker.swift in Sources */,
+				DB0BA0010000000000000003 /* DevelopmentBranchAlerter.swift in Sources */,
 				3811DE0B25C9D32F00A708ED /* BaseView.swift in Sources */,
 				3BAC929D2E56A85400B853DA /* TempBasalFunctions.swift in Sources */,
 				3811DE3225C9D49500A708ED /* HomeDataFlow.swift in Sources */,
@@ -5967,7 +5979,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};

--- a/Trio/Sources/Application/TrioApp.swift
+++ b/Trio/Sources/Application/TrioApp.swift
@@ -35,6 +35,7 @@ extension Notification.Name {
     let initState = InitState()
 
     @State private var appState = AppState()
+    @StateObject private var developmentBranchAlerter = DevelopmentBranchAlerter.shared
     @State private var showLoadingView = true
     @State private var showLoadingError = false
     @State private var showOnboardingCompletedSplash = false
@@ -346,6 +347,15 @@ extension Notification.Name {
                     self.showOnboardingCompletedSplash = true
                 }
             }
+            // The scene is already active by the time Core Data finishes loading, so the scene
+            // phase change below cannot carry the warning on a cold launch. Fire it here instead,
+            // as the loading screen gives way to the app itself.
+            .onChange(of: showLoadingView) { _, isLoading in
+                if !isLoading {
+                    presentDevelopmentBranchWarningIfNeeded()
+                }
+            }
+            .developmentBranchWarning(developmentBranchAlerter)
         }
         .onChange(of: scenePhase) { _, newScenePhase in
             debug(.default, "APPLICATION PHASE: \(newScenePhase)")
@@ -362,11 +372,24 @@ extension Notification.Name {
                     rootVC.excludeKeyboardFromSafeAreaTree()
                     AppVersionChecker.shared.checkAndNotifyVersionStatus(in: rootVC)
                 }
+                presentDevelopmentBranchWarningIfNeeded()
                 if initState.complete {
                     performCleanupIfNecessary()
                 }
             }
         }
+    }
+
+    /// Warns the user if this build did not come from the released `main` branch.
+    ///
+    /// Held back until Core Data has loaded and onboarding is behind us, so the warning never lands
+    /// on the launch splash or interrupts first-time setup.
+    @MainActor private func presentDevelopmentBranchWarningIfNeeded() {
+        guard initState.complete, !onboardingManager.shouldShowOnboarding else {
+            return
+        }
+
+        developmentBranchAlerter.alertIfNeeded()
     }
 
     func configureTabBarAppearance() {

--- a/Trio/Sources/Application/TrioApp.swift
+++ b/Trio/Sources/Application/TrioApp.swift
@@ -355,6 +355,13 @@ extension Notification.Name {
                     presentDevelopmentBranchWarningIfNeeded()
                 }
             }
+            // A first-time user is still in onboarding when the loading screen goes away, so the
+            // warning is held back there. Raise it as the completion splash gives way to the app.
+            .onChange(of: showOnboardingCompletedSplash) { _, isShowingSplash in
+                if !isShowingSplash {
+                    presentDevelopmentBranchWarningIfNeeded()
+                }
+            }
             .developmentBranchWarning(developmentBranchAlerter)
         }
         .onChange(of: scenePhase) { _, newScenePhase in

--- a/Trio/Sources/Localizations/Main/Localizable.xcstrings
+++ b/Trio/Sources/Localizations/Main/Localizable.xcstrings
@@ -147158,6 +147158,9 @@
         }
       }
     },
+    "Hey Trioneer, watch out!" : {
+      "comment" : "Title of the warning shown on builds that are not from the main branch"
+    },
     "Hi there!" : {
       "localizations" : {
         "bg" : {
@@ -151587,6 +151590,9 @@
         }
       }
     },
+    "How to Return to Main" : {
+      "comment" : "Button on the non-release build warning that opens documentation about returning to main"
+    },
     "How Trio Manages Contact Images" : {
       "localizations" : {
         "bg" : {
@@ -152208,6 +152214,9 @@
           }
         }
       }
+    },
+    "I'm a Tester" : {
+      "comment" : "Button that dismisses the non-release build warning"
     },
     "If \"Display IOB and COB\" is also enabled, \"IOB\" and \"COB\" will be replaced with the following emojis:" : {
       "localizations" : {
@@ -277592,6 +277601,9 @@
         }
       }
     },
+    "This is the development version of Trio, built from the dev branch.\n\nAny updates on this branch may contain new, lightly tested features, and may be unsafe. If you are not a tester, please do not use this branch, and switch to main." : {
+      "comment" : "Body of the warning shown on builds from the dev branch"
+    },
     "This is the fraction of carbs we’ll assume will absorb over 4h if we don’t yet see carb absorption." : {
       "comment" : "\"Remaining Carbs Fraction\"",
       "extractionState" : "manual",
@@ -280845,6 +280857,9 @@
           }
         }
       }
+    },
+    "This version of Trio was built from '%@', not the released main branch.\n\nAny updates on this branch may contain new, lightly tested features, and may be unsafe. If you are not a tester, please do not use this branch, and switch to main." : {
+      "comment" : "Body of the warning shown on builds from a branch other than main or dev; the placeholder is the branch name"
     },
     "This will add your current glucose on the top right of your Trio icon as a red notification badge. Changing setting takes effect on next Glucose reading." : {
       "localizations" : {

--- a/Trio/Sources/Services/AppVersionChecker/AppVersionChecker.swift
+++ b/Trio/Sources/Services/AppVersionChecker/AppVersionChecker.swift
@@ -89,7 +89,7 @@ import UIKit
             if isBlacklisted {
                 let lastShown = self.lastBlacklistNotificationShown ?? .distantPast
                 if now.timeIntervalSince(lastShown) > 86400 { // 24 hours
-                    self.showAlert(
+                    let shown = self.showAlert(
                         on: viewController,
                         title: String(localized: "Update Required", comment: "Title for critical update alert"),
                         message: String(
@@ -97,8 +97,10 @@ import UIKit
                             comment: "Message for critical update alert"
                         )
                     )
-                    self.lastBlacklistNotificationShown = now
-                    self.lastVersionUpdateNotificationShown = now
+                    if shown {
+                        self.lastBlacklistNotificationShown = now
+                        self.lastVersionUpdateNotificationShown = now
+                    }
                 }
             }
             // Otherwise, if a newer version is available, show an update alert if not shown in the last 2 weeks.
@@ -106,7 +108,7 @@ import UIKit
                 let lastShown = self.lastVersionUpdateNotificationShown ?? .distantPast
                 if now.timeIntervalSince(lastShown) > 1_209_600 { // 2 weeks
                     let versionText = latestVersion ?? String(localized: "Unknown", comment: "Fallback text for unknown version")
-                    self.showAlert(
+                    let shown = self.showAlert(
                         on: viewController,
                         title: String(localized: "Update Available", comment: "Title for update available alert"),
                         message: String(
@@ -114,7 +116,9 @@ import UIKit
                             comment: "Message for update available alert"
                         )
                     )
-                    self.lastVersionUpdateNotificationShown = now
+                    if shown {
+                        self.lastVersionUpdateNotificationShown = now
+                    }
                 }
             }
         }
@@ -483,13 +487,24 @@ import UIKit
     //
     // The alert is dispatched to the main thread to ensure UI updates occur correctly.
     //
+    // Presentation is skipped when the view controller is already showing something - for example
+    // the non-release build warning from DevelopmentBranchAlerter, which runs just before this.
+    // UIKit drops a second presentation silently, so the caller is told whether the alert actually
+    // appeared and can leave its throttle untouched to retry on the next foreground.
+    //
     // - Parameters:
     // - viewController: The UIViewController on which the alert should be presented.
     // - title: The title text for the alert.
     // - message: The body message of the alert.
-    private func showAlert(on viewController: UIViewController, title: String, message: String) {
+    // - Returns: `true` if the alert was presented; `false` if another alert was already showing.
+    private func showAlert(on viewController: UIViewController, title: String, message: String) -> Bool {
+        guard viewController.presentedViewController == nil else {
+            return false
+        }
+
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         viewController.present(alert, animated: true)
+        return true
     }
 }

--- a/Trio/Sources/Services/DevelopmentBranchAlerter/DevelopmentBranchAlerter.swift
+++ b/Trio/Sources/Services/DevelopmentBranchAlerter/DevelopmentBranchAlerter.swift
@@ -31,7 +31,7 @@ import SwiftUI
     private(set) var branch = ""
 
     /// Reset with the process, so every launch warns again as Loop's does.
-    private var hasShownThisLaunch = false
+    private var hasBeenAcknowledgedThisLaunch = false
 
     // MARK: - Public
 
@@ -40,7 +40,7 @@ import SwiftUI
         #if DEV_BRANCH_WARNING_DISABLED
             return
         #else
-            guard !hasShownThisLaunch else {
+            guard !hasBeenAcknowledgedThisLaunch else {
                 return
             }
 
@@ -50,9 +50,16 @@ import SwiftUI
             }
 
             self.branch = branch
-            hasShownThisLaunch = true
             isPresented = true
         #endif
+    }
+
+    /// Marks the warning as dealt with for this launch.
+    ///
+    /// Called when the user dismisses the alert, so that a request which never reached the screen
+    /// is not counted as one the user actually saw.
+    func acknowledge() {
+        hasBeenAcknowledgedThisLaunch = true
     }
 
     /// Warning body for the branch this build came from.
@@ -92,12 +99,15 @@ extension View {
             Button(String(
                 localized: "I'm a Tester",
                 comment: "Button that dismisses the non-release build warning"
-            )) {}
+            )) {
+                alerter.acknowledge()
+            }
 
             Button(String(
                 localized: "How to Return to Main",
                 comment: "Button on the non-release build warning that opens documentation about returning to main"
             )) {
+                alerter.acknowledge()
                 UIApplication.shared.open(DevelopmentBranchAlerter.returnToReleaseURL)
             }
         } message: {

--- a/Trio/Sources/Services/DevelopmentBranchAlerter/DevelopmentBranchAlerter.swift
+++ b/Trio/Sources/Services/DevelopmentBranchAlerter/DevelopmentBranchAlerter.swift
@@ -69,13 +69,13 @@ import SwiftUI
     var message: String {
         if branch == Self.developmentBranchName {
             return String(
-                localized: "This is the development version of Trio, built from the dev branch.\n\nIt may contain changes that have not been fully tested, which might affect how Trio calculates and delivers insulin. If you are not a tester, please do not use this branch, and switch to main.",
+                localized: "This is the development version of Trio, built from the dev branch.\n\nAny updates on this branch may contain new, lightly tested features, and may be unsafe. If you are not a tester, please do not use this branch, and switch to main.",
                 comment: "Body of the warning shown on builds from the dev branch"
             )
         }
 
         return String(
-            localized: "This version of Trio was built from '\(branch)', not the released main branch.\n\nIt may contain changes that have not been fully tested, which might affect how Trio calculates and delivers insulin. If you are not a tester, please switch to main.",
+            localized: "This version of Trio was built from '\(branch)', not the released main branch.\n\nAny updates on this branch may contain new, lightly tested features, and may be unsafe. If you are not a tester, please do not use this branch, and switch to main.",
             comment: "Body of the warning shown on builds from a branch other than main or dev; the placeholder is the branch name"
         )
     }

--- a/Trio/Sources/Services/DevelopmentBranchAlerter/DevelopmentBranchAlerter.swift
+++ b/Trio/Sources/Services/DevelopmentBranchAlerter/DevelopmentBranchAlerter.swift
@@ -1,0 +1,107 @@
+import Foundation
+import SwiftUI
+
+/// Drives the startup warning shown when Trio was built from anything other than the released
+/// `main` branch.
+///
+/// The branch name is recorded at build time by `scripts/capture-build-details.sh` and read back
+/// through `BuildDetails.trioBranch`. That value is the branch name, an exact tag when the build
+/// came from a detached checkout, or the literal `detached` - so anything other than `main` is
+/// treated as a build the average user should not be running.
+///
+/// Compile with `DEV_BRANCH_WARNING_DISABLED` to suppress the warning.
+@MainActor final class DevelopmentBranchAlerter: ObservableObject {
+    static let shared = DevelopmentBranchAlerter()
+
+    private init() {}
+
+    // MARK: - Constants
+
+    private static let releaseBranchName = "main"
+    private static let developmentBranchName = "dev"
+
+    static let returnToReleaseURL = URL(string: "https://triodocs.org/install/return-to-main/")!
+
+    // MARK: - State
+
+    /// Whether the warning should currently be on screen.
+    @Published var isPresented = false
+
+    /// Branch the running build came from, resolved when the warning is raised.
+    private(set) var branch = ""
+
+    /// Reset with the process, so every launch warns again as Loop's does.
+    private var hasShownThisLaunch = false
+
+    // MARK: - Public
+
+    /// Raises the warning if this build did not come from `main`, at most once per launch.
+    func alertIfNeeded() {
+        #if DEV_BRANCH_WARNING_DISABLED
+            return
+        #else
+            guard !hasShownThisLaunch else {
+                return
+            }
+
+            let branch = BuildDetails.shared.trioBranch
+            guard branch != Self.releaseBranchName else {
+                return
+            }
+
+            self.branch = branch
+            hasShownThisLaunch = true
+            isPresented = true
+        #endif
+    }
+
+    /// Warning body for the branch this build came from.
+    ///
+    /// The `dev` branch is named directly, because that is the branch testers opt into and the one
+    /// the documentation describes. Any other value names whatever was actually built.
+    var message: String {
+        if branch == Self.developmentBranchName {
+            return String(
+                localized: "This is the development version of Trio, built from the dev branch.\n\nIt may contain changes that have not been fully tested, which might affect how Trio calculates and delivers insulin. If you are not a tester, please do not use this branch, and switch to main.",
+                comment: "Body of the warning shown on builds from the dev branch"
+            )
+        }
+
+        return String(
+            localized: "This version of Trio was built from '\(branch)', not the released main branch.\n\nIt may contain changes that have not been fully tested, which might affect how Trio calculates and delivers insulin. If you are not a tester, please switch to main.",
+            comment: "Body of the warning shown on builds from a branch other than main or dev; the placeholder is the branch name"
+        )
+    }
+}
+
+// MARK: - Presentation
+
+extension View {
+    /// Presents the non-release build warning.
+    ///
+    /// The alert offers no cancel: the user either acknowledges that they are testing, or opens the
+    /// documentation on returning to the released version.
+    func developmentBranchWarning(_ alerter: DevelopmentBranchAlerter) -> some View {
+        alert(
+            Text("Hey Trioneer, watch out!", comment: "Title of the warning shown on builds that are not from the main branch"),
+            isPresented: Binding(
+                get: { alerter.isPresented },
+                set: { alerter.isPresented = $0 }
+            )
+        ) {
+            Button(String(
+                localized: "I'm a Tester",
+                comment: "Button that dismisses the non-release build warning"
+            )) {}
+
+            Button(String(
+                localized: "How to Return to Main",
+                comment: "Button on the non-release build warning that opens documentation about returning to main"
+            )) {
+                UIApplication.shared.open(DevelopmentBranchAlerter.returnToReleaseURL)
+            }
+        } message: {
+            Text(alerter.message)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a startup warning, modelled on Loop's dev-branch alert, shown once per launch when the build's branch is anything other than main.

> [!IMPORTANT]
> Blocked by an update to TrioDocs.
> See `trio-docs` PR https://github.com/nightscout/trio-docs/pull/257

The branch is already recorded in `BuildDetails.plist` by `capture-build-details.sh` and read back through `BuildDetails.trioBranch`, so no new build-time plumbing is needed. Wording adapts: the dev branch is named directly, anything else names the branch that was actually built.

Suppressed while Core Data is loading and during onboarding. The scene phase hook alone cannot carry the warning on a cold launch, because the scene is already active by the time Core Data finishes, so it is also triggered as the loading screen gives way to the app.

Compile with `DEV_BRANCH_WARNING_DISABLED` to suppress it. The project-level Debug configuration hardcoded `SWIFT_ACTIVE_COMPILATION_CONDITIONS` without `$(inherited)`, which silently discarded the flag for Debug builds; adding `$(inherited)` makes `ConfigOverride.xcconfig` behave the same in Debug and Release. Browser builds can set the repository variable `DEV_BRANCH_WARNING_DISABLED` instead.

`AppVersionChecker` presents from the same root view controller on the same scene phase change, and UIKit drops a second presentation silently. showAlert now skips when another alert is already showing and reports whether it appeared, so its callers no longer burn their 24 hour and 2 week throttles on an alert that was never displayed.

### Screenshots

| ☀ feature branch | ☀ dev | ☾ feature branch | ☾ dev |
|--------|--------|--------|--------|
| <img width="1206" height="2622" alt="feature-branch-light" src="https://github.com/user-attachments/assets/be70edd0-147b-4946-837e-7219747f4a57" /> | <img width="1206" height="2622" alt="dev-branch-light" src="https://github.com/user-attachments/assets/3478008e-dd37-4443-8dad-1e32e919246e" /> | <img width="1206" height="2622" alt="feature-branch-dark" src="https://github.com/user-attachments/assets/9b36ae45-d7c6-4670-9ab8-77b0ca53e102" /> | <img width="1206" height="2622" alt="dev-branch-dark" src="https://github.com/user-attachments/assets/f62975b4-0f8d-4015-abbc-017857c49ece" /> |
