### PR TITLE
Fix archive failure from missing time-sensitive notifications capability

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -183,7 +183,8 @@ platform :ios do
       Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
       Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT,
       Spaceship::ConnectAPI::BundleIdCapability::Type::NFC_TAG_READING,
-      Spaceship::ConnectAPI::BundleIdCapability::Type::PUSH_NOTIFICATIONS
+      Spaceship::ConnectAPI::BundleIdCapability::Type::PUSH_NOTIFICATIONS,
+      Spaceship::ConnectAPI::BundleIdCapability::Type::USERNOTIFICATIONS_TIMESENSITIVE
     ])
 
     configure_bundle_id("Trio Watch Complication", "#{BUNDLE_ID}.watchkitapp.TrioWatchComplication", [


### PR DESCRIPTION
## What changed

Adds `USERNOTIFICATIONS_TIMESENSITIVE` to the capabilities configured for the main Trio App ID in the `identifiers` fastlane lane.

## Why

`Trio/Resources/Trio.entitlements` has requested `com.apple.developer.usernotifications.time-sensitive` since a74533e ("Add time-sensitive UN entitlement so alerts pierce Focus modes", 2026-06-19), but the `identifiers` lane was never updated to enable the matching capability on the App ID. `fastlane/Fastfile` hasn't been touched since 03810d1 (2025-12-05).

The result is that the App ID has no Time Sensitive Notifications capability, `match` generates an App Store profile without it, and browser builds fail at archive time:

```
error: Provisioning profile "match AppStore org.nightscout.<team>.trio" doesn't
include the com.apple.developer.usernotifications.time-sensitive entitlement.
(in target 'Trio' from project 'Trio')
** ARCHIVE FAILED **
```

This is not obvious from the log, because the `match` step itself succeeds — it authenticates and returns a full profile mapping. Only `gym` fails, ~100s later, when `xcodebuild` compares the entitlements file against the profile.

Anyone whose App ID was created before the entitlement landed hits this and stays stuck, since nothing in the pipeline retrofits the capability. Re-running **2. Add Identifiers** doesn't help today — that's the lane with the gap.

## Notes for reviewers

- Only the main Trio App ID needs this. `Trio.entitlements` is the only entitlements file in the repo, and the watch app, complication, and LiveActivity targets don't request the entitlement — adding it to them would invalidate their profiles for no benefit.
- `configure_bundle_id` already diffs requested capabilities against `bundle_id.get_capabilities`, so this is idempotent. Users who re-run **2. Add Identifiers** get the capability added; users who already have it see no change.
- `Spaceship::ConnectAPI::BundleIdCapability::Type::USERNOTIFICATIONS_TIMESENSITIVE` exists in fastlane 2.236.1, the version pinned in `Gemfile.lock`.

## Existing users still need one manual step

This fixes new setups and anyone who re-runs **2. Add Identifiers**, but for already-broken installs the stale profile also has to be regenerated. The `certs` lane calls `match(force: false)`, so it can reuse the cached profile from Match-Secrets. Deleting `profiles/appstore/AppStore_<bundle-id>.mobileprovision` from the Match-Secrets repo and re-running **3. Create Certificates** forces a fresh one. Might be worth a docs note; happy to add one if you'd like it in this PR.

I verified this end to end on my own fork — capability enabled, stale profile deleted, certs re-run, profile regenerated with the entitlement.
