### PR TITLE
LoopFollow Remote meal edit

### DIFF
--- a/Trio/Sources/APS/Storage/CarbsStorage.swift
+++ b/Trio/Sources/APS/Storage/CarbsStorage.swift
@@ -8,6 +8,135 @@ protocol CarbsObserver {
     func carbsDidUpdate(_ carbs: [CarbsEntry])
 }
 
+let remoteMealMutationMaximumAge: TimeInterval = 12 * 60 * 60
+
+private struct RemoteMealImportSuppression: Codable {
+    let date: Date
+    let expiresAt: Date
+}
+
+private final class RemoteMealImportSuppressionStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private let defaults = UserDefaults.standard
+    private let key = "trio.remoteMealImportSuppressions.v1"
+    private let maximumCount = 500
+
+    func record(dates: [Date], now: Date) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var suppressions = load().filter { $0.expiresAt >= now }
+        for date in dates {
+            suppressions.removeAll { abs($0.date.timeIntervalSince(date)) <= 1 }
+            suppressions.append(
+                RemoteMealImportSuppression(
+                    date: date,
+                    expiresAt: date.addingTimeInterval(24 * 60 * 60)
+                )
+            )
+        }
+        suppressions.sort { $0.expiresAt < $1.expiresAt }
+        save(Array(suppressions.suffix(maximumCount)))
+    }
+
+    func activeDates(now: Date) -> [Date] {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let stored = load()
+        let active = stored.filter { $0.expiresAt >= now }
+        if active.count != stored.count {
+            save(active)
+        }
+        return active.map(\.date)
+    }
+
+    private func load() -> [RemoteMealImportSuppression] {
+        guard let data = defaults.data(forKey: key),
+              let suppressions = try? JSONDecoder().decode([RemoteMealImportSuppression].self, from: data)
+        else { return [] }
+        return suppressions
+    }
+
+    private func save(_ suppressions: [RemoteMealImportSuppression]) {
+        guard let data = try? JSONEncoder().encode(suppressions) else { return }
+        defaults.set(data, forKey: key)
+    }
+}
+
+struct MealMutationValues: Codable, Equatable, Sendable {
+    let date: Date
+    let carbs: Decimal
+    let fat: Decimal
+    let protein: Decimal
+}
+
+struct MealFPUEntrySnapshot: Codable, Equatable, Sendable {
+    let id: UUID
+    let date: Date
+    let carbs: Decimal
+}
+
+struct MealMutationSnapshot: Codable, Equatable, Sendable {
+    let id: UUID
+    let fpuID: UUID?
+    let values: MealMutationValues
+    let note: String?
+    let fpuEntries: [MealFPUEntrySnapshot]
+}
+
+enum MealMutation: Equatable, Sendable {
+    case edit(MealMutationValues)
+    case delete
+}
+
+enum MealMutationDisposition: String, Codable, Equatable, Sendable {
+    case unchanged
+    case edited
+    case deleted
+}
+
+struct MealMutationResult: Equatable, Sendable {
+    let disposition: MealMutationDisposition
+    let before: MealMutationSnapshot
+    let after: MealMutationSnapshot?
+}
+
+enum MealMutationError: LocalizedError, Equatable {
+    case invalidExpectedValues
+    case invalidReplacementValues
+    case notFound
+    case ambiguousIdentifier
+    case targetIsFPU
+    case invalidStoredEntry
+    case outsideEditWindow
+    case replacementOutsideEditWindow
+    case stale(current: MealMutationValues)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidExpectedValues:
+            return "The expected meal values are incomplete or invalid."
+        case .invalidReplacementValues:
+            return "The replacement meal values are incomplete or invalid."
+        case .notFound:
+            return "The meal entry was not found."
+        case .ambiguousIdentifier:
+            return "The meal identifier matched more than one entry."
+        case .targetIsFPU:
+            return "Generated FPU entries cannot be edited directly."
+        case .invalidStoredEntry:
+            return "The stored meal entry is incomplete or invalid."
+        case .outsideEditWindow:
+            return "The meal entry is outside the 12-hour edit window."
+        case .replacementOutsideEditWindow:
+            return "The replacement meal time is outside the 12-hour edit window."
+        case .stale:
+            return "The meal entry changed after LoopFollow loaded it. Refresh the entry and try again."
+        }
+    }
+}
+
 protocol CarbsStorage {
     var updatePublisher: AnyPublisher<Void, Never> { get }
     func storeCarbs(_ carbs: [CarbsEntry], areFetchedFromRemote: Bool) async throws
@@ -20,9 +149,19 @@ protocol CarbsStorage {
     func getFPUsNotYetUploadedToNightscout() async throws -> [NightscoutTreatment]
     func getCarbsNotYetUploadedToHealth() async throws -> [CarbsEntry]
     func getCarbsNotYetUploadedToTidepool() async throws -> [CarbsEntry]
+    func mealSnapshot(id: UUID, now: Date) async throws -> MealMutationSnapshot
+    func mutateMeal(
+        id: UUID,
+        expected: MealMutationValues,
+        mutation: MealMutation,
+        now: Date
+    ) async throws -> MealMutationResult
+    func markMealForUpload(id: UUID) async throws
 }
 
 final class BaseCarbsStorage: CarbsStorage, Injectable {
+    private static let remoteImportSuppressions = RemoteMealImportSuppressionStore()
+
     private let processQueue = DispatchQueue(label: "BaseCarbsStorage.processQueue")
     @Injected() private var storage: FileStorage!
     @Injected() private var broadcaster: Broadcaster!
@@ -37,10 +176,291 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
     }
 
     private let makeContext: () -> NSManagedObjectContext
+    private let mutationContext: NSManagedObjectContext
 
     init(resolver: Resolver, contextProvider: (() -> NSManagedObjectContext)? = nil) {
-        makeContext = contextProvider ?? { CoreDataStack.shared.newTaskContext() }
+        let makeContext = contextProvider ?? { CoreDataStack.shared.newTaskContext() }
+        self.makeContext = makeContext
+        mutationContext = makeContext()
+        mutationContext.name = "mutateMeal"
+        mutationContext.mergePolicy = NSErrorMergePolicy
         injectServices(resolver)
+    }
+
+    func mealSnapshot(id: UUID, now: Date) async throws -> MealMutationSnapshot {
+        try await mutationContext.perform {
+            self.mutationContext.reset()
+            let (root, children) = try self.mutationTarget(id: id, now: now, in: self.mutationContext)
+            return try Self.snapshot(root: root, children: children)
+        }
+    }
+
+    func mutateMeal(
+        id: UUID,
+        expected: MealMutationValues,
+        mutation: MealMutation,
+        now: Date
+    ) async throws -> MealMutationResult {
+        guard Self.hasValidMacros(expected) else {
+            throw MealMutationError.invalidExpectedValues
+        }
+
+        let result = try await mutationContext.perform {
+            self.mutationContext.reset()
+            do {
+                let (root, children) = try self.mutationTarget(id: id, now: now, in: self.mutationContext)
+                let before = try Self.snapshot(root: root, children: children)
+
+                switch mutation {
+                case let .edit(replacement):
+                    guard Self.hasValidMacros(replacement) else {
+                        throw MealMutationError.invalidReplacementValues
+                    }
+
+                    let replacementAge = now.timeIntervalSince(replacement.date)
+                    guard replacementAge >= 0, replacementAge <= remoteMealMutationMaximumAge else {
+                        throw MealMutationError.replacementOutsideEditWindow
+                    }
+
+                    if Self.matches(before.values, replacement) {
+                        return MealMutationResult(
+                            disposition: .unchanged,
+                            before: before,
+                            after: before
+                        )
+                    }
+
+                    guard Self.matches(before.values, expected) else {
+                        throw MealMutationError.stale(current: before.values)
+                    }
+
+                    Self.suppressRemoteImports(for: before, now: now)
+                    children.forEach(self.mutationContext.delete)
+
+                    root.date = replacement.date
+                    root.carbs = Self.double(replacement.carbs)
+                    root.fat = Self.double(replacement.fat)
+                    root.protein = Self.double(replacement.protein)
+                    // Keep the replacement hidden from automatic upload observers until the
+                    // handler has requested deletion of the previous remote representation.
+                    root.isUploadedToNS = true
+                    root.isUploadedToHealth = true
+                    root.isUploadedToTidepool = true
+
+                    var replacementChildren: [CarbEntryStored] = []
+                    if replacement.fat > 0 || replacement.protein > 0 {
+                        let fpuID = UUID()
+                        root.fpuID = fpuID
+
+                        let entry = CarbsEntry(
+                            id: id.uuidString,
+                            createdAt: now,
+                            actualDate: replacement.date,
+                            carbs: replacement.carbs,
+                            fat: replacement.fat,
+                            protein: replacement.protein,
+                            note: root.note,
+                            enteredBy: CarbsEntry.local,
+                            isFPU: false,
+                            fpuID: fpuID.uuidString
+                        )
+                        let (futureEntries, _) = self.processFPU(
+                            entries: [entry],
+                            fat: replacement.fat,
+                            protein: replacement.protein,
+                            createdAt: now,
+                            actualDate: replacement.date
+                        )
+
+                        for futureEntry in futureEntries {
+                            guard let childID = futureEntry.id.flatMap(UUID.init(uuidString:)),
+                                  let childDate = futureEntry.actualDate
+                            else {
+                                throw MealMutationError.invalidStoredEntry
+                            }
+
+                            let child = CarbEntryStored(context: self.mutationContext)
+                            child.id = childID
+                            child.fpuID = fpuID
+                            child.date = childDate
+                            child.carbs = Self.double(futureEntry.carbs)
+                            child.fat = 0
+                            child.protein = 0
+                            child.isFPU = true
+                            child.isUploadedToNS = true
+                            // FPU carb equivalents are Nightscout-only. Leaving the Health and
+                            // Tidepool flags nil matches the existing batch-insert behavior.
+                            replacementChildren.append(child)
+                        }
+                    } else {
+                        root.fpuID = nil
+                    }
+
+                    try self.mutationContext.save()
+                    let after = try Self.snapshot(root: root, children: replacementChildren)
+                    return MealMutationResult(disposition: .edited, before: before, after: after)
+
+                case .delete:
+                    guard Self.matches(before.values, expected) else {
+                        throw MealMutationError.stale(current: before.values)
+                    }
+
+                    Self.suppressRemoteImports(for: before, now: now)
+                    children.forEach(self.mutationContext.delete)
+                    self.mutationContext.delete(root)
+                    try self.mutationContext.save()
+                    return MealMutationResult(disposition: .deleted, before: before, after: nil)
+                }
+            } catch {
+                self.mutationContext.rollback()
+                throw error
+            }
+        }
+
+        if result.disposition != .unchanged {
+            updateSubject.send(())
+        }
+        return result
+    }
+
+    func markMealForUpload(id: UUID) async throws {
+        try await mutationContext.perform {
+            self.mutationContext.reset()
+            do {
+                let request: NSFetchRequest<CarbEntryStored> = CarbEntryStored.fetchRequest()
+                request.predicate = NSPredicate(format: "id == %@ AND isFPU == NO", id as CVarArg)
+                request.fetchLimit = 2
+
+                let matches = try self.mutationContext.fetch(request)
+                guard matches.isNotEmpty else {
+                    throw MealMutationError.notFound
+                }
+                guard matches.count == 1 else {
+                    throw MealMutationError.ambiguousIdentifier
+                }
+                let root = matches[0]
+
+                root.isUploadedToNS = false
+                root.isUploadedToHealth = false
+                root.isUploadedToTidepool = false
+                for child in try self.fpuEntries(for: root.fpuID, in: self.mutationContext) {
+                    child.isUploadedToNS = false
+                }
+
+                if self.mutationContext.hasChanges {
+                    try self.mutationContext.save()
+                }
+            } catch {
+                self.mutationContext.rollback()
+                throw error
+            }
+        }
+    }
+
+    private func mutationTarget(
+        id: UUID,
+        now: Date,
+        in context: NSManagedObjectContext
+    ) throws -> (root: CarbEntryStored, children: [CarbEntryStored]) {
+        let request: NSFetchRequest<CarbEntryStored> = CarbEntryStored.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        request.fetchLimit = 2
+
+        let matches = try context.fetch(request)
+        guard matches.isNotEmpty else {
+            throw MealMutationError.notFound
+        }
+        guard matches.count == 1 else {
+            throw MealMutationError.ambiguousIdentifier
+        }
+
+        let root = matches[0]
+        guard !root.isFPU else {
+            throw MealMutationError.targetIsFPU
+        }
+        guard root.id == id, let rootDate = root.date else {
+            throw MealMutationError.invalidStoredEntry
+        }
+
+        let age = now.timeIntervalSince(rootDate)
+        guard age >= 0, age <= remoteMealMutationMaximumAge else {
+            throw MealMutationError.outsideEditWindow
+        }
+
+        return (root, try fpuEntries(for: root.fpuID, in: context))
+    }
+
+    private func fpuEntries(
+        for fpuID: UUID?,
+        in context: NSManagedObjectContext
+    ) throws -> [CarbEntryStored] {
+        guard let fpuID else { return [] }
+
+        let request: NSFetchRequest<CarbEntryStored> = CarbEntryStored.fetchRequest()
+        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "fpuID == %@", fpuID as CVarArg),
+            NSPredicate(format: "isFPU == YES")
+        ])
+        request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: true)]
+        return try context.fetch(request)
+    }
+
+    private static func snapshot(
+        root: CarbEntryStored,
+        children: [CarbEntryStored]
+    ) throws -> MealMutationSnapshot {
+        guard let id = root.id, let date = root.date else {
+            throw MealMutationError.invalidStoredEntry
+        }
+
+        let childSnapshots = try children.map { child in
+            guard let childID = child.id, let childDate = child.date else {
+                throw MealMutationError.invalidStoredEntry
+            }
+            return MealFPUEntrySnapshot(
+                id: childID,
+                date: childDate,
+                carbs: Decimal(algorithmValue: child.carbs)
+            )
+        }
+
+        return MealMutationSnapshot(
+            id: id,
+            fpuID: root.fpuID,
+            values: MealMutationValues(
+                date: date,
+                carbs: Decimal(algorithmValue: root.carbs),
+                fat: Decimal(algorithmValue: root.fat),
+                protein: Decimal(algorithmValue: root.protein)
+            ),
+            note: root.note,
+            fpuEntries: childSnapshots
+        )
+    }
+
+    private static func hasValidMacros(_ values: MealMutationValues) -> Bool {
+        let macros = [values.carbs, values.fat, values.protein]
+        return values.date.timeIntervalSinceReferenceDate.isFinite &&
+            macros.allSatisfy { $0 >= 0 && NSDecimalNumber(decimal: $0).doubleValue.isFinite } &&
+            macros.contains(where: { $0 > 0 })
+    }
+
+    private static func suppressRemoteImports(for snapshot: MealMutationSnapshot, now: Date) {
+        remoteImportSuppressions.record(
+            dates: [snapshot.values.date] + snapshot.fpuEntries.map(\.date),
+            now: now
+        )
+    }
+
+    private static func matches(_ lhs: MealMutationValues, _ rhs: MealMutationValues) -> Bool {
+        lhs.carbs == rhs.carbs &&
+            lhs.fat == rhs.fat &&
+            lhs.protein == rhs.protein &&
+            abs(lhs.date.timeIntervalSince(rhs.date)) <= 1
+    }
+
+    private static func double(_ value: Decimal) -> Double {
+        Double(truncating: NSDecimalNumber(decimal: value))
     }
 
     func storeCarbs(_ entries: [CarbsEntry], areFetchedFromRemote: Bool) async throws {
@@ -95,12 +515,15 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
         // Extract dates into a set for efficient lookup
         // Since we are not dealing with NSManagedObjects directly it is safe to pass properties between threads
         let existingTimestamps = Set(existing24hCarbEntries.compactMap { $0["date"] as? Date })
+        let suppressedTimestamps = Self.remoteImportSuppressions.activeDates(now: Date())
 
-        // Remove all entries that have a matching date in existingTimestamps
+        // A remote mutation can remove the old local timestamp before Nightscout has
+        // processed its deletion. Keep that stale treatment from being re-imported.
         var filteredEntries = entries
         filteredEntries.removeAll { entry in
             let entryDate = entry.actualDate ?? entry.createdAt
-            return existingTimestamps.contains(entryDate)
+            return existingTimestamps.contains(entryDate) ||
+                suppressedTimestamps.contains { abs($0.timeIntervalSince(entryDate)) <= 1 }
         }
 
         return filteredEntries
@@ -491,7 +914,15 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
         let results = try await CoreDataStack.shared.fetchEntitiesAsync(
             ofType: CarbEntryStored.self,
             onContext: context,
-            predicate: NSPredicate.carbsNotYetUploadedToNightscout,
+            // Include fat/protein-only roots so Nightscout (and therefore LoopFollow) exposes
+            // the stable Trio meal UUID needed for a later edit or deletion.
+            predicate: NSPredicate(
+                format: "date >= %@ AND isUploadedToNS == %@ AND isFPU == %@ AND " +
+                    "(carbs > 0 OR fat > 0 OR protein > 0)",
+                Date.oneDayAgo as NSDate,
+                false as NSNumber,
+                false as NSNumber
+            ),
             key: "date",
             ascending: false
         )

--- a/Trio/Sources/APS/Storage/CarbsStorage.swift
+++ b/Trio/Sources/APS/Storage/CarbsStorage.swift
@@ -951,7 +951,8 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
                     foodType: result.note,
                     targetTop: nil,
                     targetBottom: nil,
-                    id: result.id?.uuidString
+                    id: result.id?.uuidString,
+                    fpuID: result.fpuID?.uuidString
                 )
             }
         }
@@ -992,7 +993,8 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
                     foodType: result.note,
                     targetTop: nil,
                     targetBottom: nil,
-                    id: result.fpuID?.uuidString
+                    id: result.fpuID?.uuidString,
+                    fpuID: result.fpuID?.uuidString
                 )
             }
         }

--- a/Trio/Sources/APS/Storage/CarbsStorage.swift
+++ b/Trio/Sources/APS/Storage/CarbsStorage.swift
@@ -218,7 +218,7 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
                     }
 
                     let replacementAge = now.timeIntervalSince(replacement.date)
-                    guard replacementAge >= 0, replacementAge <= remoteMealMutationMaximumAge else {
+                    guard abs(replacementAge) <= remoteMealMutationMaximumAge else {
                         throw MealMutationError.replacementOutsideEditWindow
                     }
 
@@ -383,7 +383,7 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
         }
 
         let age = now.timeIntervalSince(rootDate)
-        guard age >= 0, age <= remoteMealMutationMaximumAge else {
+        guard abs(age) <= remoteMealMutationMaximumAge else {
             throw MealMutationError.outsideEditWindow
         }
 

--- a/Trio/Sources/Models/CommandPayload.swift
+++ b/Trio/Sources/Models/CommandPayload.swift
@@ -20,6 +20,12 @@ struct CommandPayload: Decodable, Sendable {
     var fat: Int?
     var overrideName: String?
     var scheduledTime: TimeInterval?
+    var commandID: String?
+    var mealID: String?
+    var expectedCarbs: Int?
+    var expectedFat: Int?
+    var expectedProtein: Int?
+    var expectedMealTime: TimeInterval?
     var returnNotification: ReturnNotificationInfo?
 
     struct ReturnNotificationInfo: Decodable, Sendable {
@@ -52,6 +58,12 @@ struct CommandPayload: Decodable, Sendable {
         case commandType = "command_type"
         case bolusAmount = "bolus_amount"
         case scheduledTime = "scheduled_time"
+        case commandID = "command_id"
+        case mealID = "meal_id"
+        case expectedCarbs = "expected_carbs"
+        case expectedFat = "expected_fat"
+        case expectedProtein = "expected_protein"
+        case expectedMealTime = "expected_meal_time"
         case returnNotification = "return_notification"
     }
 
@@ -80,6 +92,10 @@ struct CommandPayload: Decodable, Sendable {
             let fatDesc = fat != nil ? "\(fat!)g fat" : "unknown fat"
             let proteinDesc = protein != nil ? "\(protein!)g protein" : "unknown protein"
             description += "Meal with \(carbsDesc), \(fatDesc), \(proteinDesc)."
+        case .editMeal:
+            description += "Edit meal \(mealID ?? "with unknown ID")."
+        case .deleteMeal:
+            description += "Delete meal \(mealID ?? "with unknown ID")."
         case .startOverride:
             if let override = overrideName {
                 description += "Start Override: \(override)."
@@ -109,6 +125,8 @@ extension TrioRemoteControl {
         case tempTarget = "temp_target"
         case cancelTempTarget = "cancel_temp_target"
         case meal
+        case editMeal = "edit_meal"
+        case deleteMeal = "delete_meal"
         case startOverride = "start_override"
         case cancelOverride = "cancel_override"
 
@@ -122,6 +140,10 @@ extension TrioRemoteControl {
                 return "Cancel Temporary Target"
             case .meal:
                 return "Meal"
+            case .editMeal:
+                return "Edit Meal"
+            case .deleteMeal:
+                return "Delete Meal"
             case .startOverride:
                 return "Start Override"
             case .cancelOverride:

--- a/Trio/Sources/Services/Network/TidepoolManager.swift
+++ b/Trio/Sources/Services/Network/TidepoolManager.swift
@@ -14,6 +14,7 @@ protocol TidepoolManager {
     func getTidepoolServiceUI() -> ServiceUI?
     func getTidepoolPluginHost() -> PluginHost?
     func uploadCarbs() async
+    func waitForCarbUploads() async -> Bool
     func deleteCarbs(withSyncId id: UUID, carbs: Decimal, at: Date, enteredBy: String)
     func uploadInsulin() async
     func deleteInsulin(withSyncId id: String, amount: Decimal, at: Date)
@@ -267,6 +268,15 @@ extension BaseTidepoolManager {
         await uploadSerializer.enqueue(.carbs) { [weak self] generation in
             await self?.performCarbsUpload(generation: generation)
         }
+    }
+
+    func waitForCarbUploads() async -> Bool {
+        let result = await TidepoolUploadSerializer.awaitUpload("carbs-barrier") { completion in
+            Task { [uploadSerializer] in
+                await uploadSerializer.enqueue(.carbsDelete) { _ in completion(.success(true)) }
+            }
+        }
+        return (try? result.get()) == true
     }
 
     /// Runs inside the serializer; fetches pending carbs at run time so coalesced requests lose nothing.

--- a/Trio/Sources/Services/RemoteControl/RemoteNotificationResponseManager.swift
+++ b/Trio/Sources/Services/RemoteControl/RemoteNotificationResponseManager.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+enum MealMutationResponseResult: String, Codable, Sendable {
+    case updated
+    case deleted
+    case alreadyApplied = "already_applied"
+    case rejected
+    case inProgress = "in_progress"
+}
+
+enum MealMutationSyncStatus: String, Codable, Sendable {
+    case requested
+    case notRequested = "not_requested"
+}
+
 class RemoteNotificationResponseManager {
     static let shared = RemoteNotificationResponseManager()
 
@@ -10,18 +23,33 @@ class RemoteNotificationResponseManager {
         let commandStatus: String
         let commandType: String
         let timestamp: TimeInterval
+        let commandID: String?
+        let mealID: String?
+        let result: MealMutationResponseResult?
+        let syncStatus: MealMutationSyncStatus?
 
         enum CodingKeys: String, CodingKey {
             case aps
             case commandStatus = "command_status"
             case commandType = "command_type"
             case timestamp
+            case commandID = "command_id"
+            case mealID = "meal_id"
+            case result
+            case syncStatus = "sync_status"
         }
     }
 
     struct APSPayload: Encodable {
         let alert: Alert
         let sound: String = "default"
+        let contentAvailable: Int = 1
+
+        enum CodingKeys: String, CodingKey {
+            case alert
+            case sound
+            case contentAvailable = "content-available"
+        }
     }
 
     struct Alert: Encodable {
@@ -33,7 +61,11 @@ class RemoteNotificationResponseManager {
         to returnInfo: CommandPayload.ReturnNotificationInfo?,
         commandType: TrioRemoteControl.CommandType,
         success: Bool,
-        message: String
+        message: String,
+        commandID: String? = nil,
+        mealID: String? = nil,
+        result: MealMutationResponseResult? = nil,
+        syncStatus: MealMutationSyncStatus? = nil
     ) async {
         guard let returnInfo = returnInfo,
               !returnInfo.deviceToken.isEmpty
@@ -51,7 +83,11 @@ class RemoteNotificationResponseManager {
             ),
             commandStatus: success ? "success" : "failed",
             commandType: commandType.rawValue,
-            timestamp: Date().timeIntervalSince1970
+            timestamp: Date().timeIntervalSince1970,
+            commandID: commandID,
+            mealID: mealID,
+            result: result,
+            syncStatus: syncStatus
         )
 
         await sendPushNotification(

--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HealthKit
 
 extension TrioRemoteControl {
     func handleMealCommand(_ payload: CommandPayload) async throws {
@@ -79,5 +80,712 @@ extension TrioRemoteControl {
             payload: payload,
             customNotificationMessage: "Meal logged"
         )
+    }
+}
+
+private struct RemoteMealMutationRequest {
+    let expected: MealMutationValues
+    let mutation: MealMutation
+}
+
+private struct RemoteMealMutationFingerprint: Encodable {
+    let user: String
+    let commandType: String
+    let mealID: String
+    let expectedCarbs: Int?
+    let expectedFat: Int?
+    let expectedProtein: Int?
+    let expectedMealTime: TimeInterval?
+    let carbs: Int?
+    let fat: Int?
+    let protein: Int?
+    let scheduledTime: TimeInterval?
+    let bolusAmount: Decimal?
+    let target: Int?
+    let duration: Int?
+    let overrideName: String?
+}
+
+private struct RemoteMealMutationReceipt: Codable, Sendable {
+    let commandID: String
+    let fingerprint: String
+    let mealID: String
+    let success: Bool
+    let message: String
+    let result: MealMutationResponseResult
+    let syncStatus: MealMutationSyncStatus
+    let disposition: MealMutationDisposition?
+    let before: MealMutationSnapshot?
+    var cobRecalculated: Bool
+    var serviceSyncAttemptFinished: Bool
+    let isFinal: Bool
+    let recordedAt: Date
+}
+
+private enum RemoteMealMutationReceiptClaim {
+    case execute
+    case resume(RemoteMealMutationReceipt)
+    case replay(RemoteMealMutationReceipt)
+    case conflict
+    case inProgress
+}
+
+private actor RemoteMealMutationReceiptStore {
+    static let shared = RemoteMealMutationReceiptStore()
+
+    private struct ActiveMutation {
+        let fingerprint: String
+    }
+
+    private let defaults = UserDefaults.standard
+    private let key = "trio.remoteMealMutationReceipts.v1"
+    private let maximumReceiptCount = 100
+    private var activeCommands: [String: ActiveMutation] = [:]
+    private var activeMeals: [String: String] = [:]
+
+    func claim(
+        commandID: String,
+        mealID: String,
+        fingerprint: String,
+        now: Date
+    ) -> RemoteMealMutationReceiptClaim {
+        if let active = activeCommands[commandID] {
+            return active.fingerprint == fingerprint ? .inProgress : .conflict
+        }
+        if activeMeals[mealID] != nil {
+            return .inProgress
+        }
+
+        let receipts = loadReceipts(now: now)
+        saveReceipts(receipts)
+        if let receipt = receipts.first(where: { $0.commandID == commandID }) {
+            guard receipt.fingerprint == fingerprint else {
+                return .conflict
+            }
+            reserve(commandID: commandID, mealID: mealID, fingerprint: fingerprint)
+            return receipt.isFinal ? .replay(receipt) : .resume(receipt)
+        }
+
+        reserve(commandID: commandID, mealID: mealID, fingerprint: fingerprint)
+        return .execute
+    }
+
+    func record(_ receipt: RemoteMealMutationReceipt) {
+        var receipts = loadReceipts(now: receipt.recordedAt)
+        receipts.removeAll { $0.commandID == receipt.commandID }
+        receipts.append(receipt)
+        receipts.sort { $0.recordedAt < $1.recordedAt }
+        if receipts.count > maximumReceiptCount {
+            receipts = Array(receipts.suffix(maximumReceiptCount))
+        }
+        saveReceipts(receipts)
+    }
+
+    func release(commandID: String, mealID: String) {
+        activeCommands.removeValue(forKey: commandID)
+        if activeMeals[mealID] == commandID {
+            activeMeals.removeValue(forKey: mealID)
+        }
+    }
+
+    func remove(commandID: String) {
+        var receipts = loadReceipts(now: Date())
+        receipts.removeAll { $0.commandID == commandID }
+        saveReceipts(receipts)
+    }
+
+    private func reserve(commandID: String, mealID: String, fingerprint: String) {
+        activeCommands[commandID] = ActiveMutation(fingerprint: fingerprint)
+        activeMeals[mealID] = commandID
+    }
+
+    private func loadReceipts(now: Date) -> [RemoteMealMutationReceipt] {
+        guard let data = defaults.data(forKey: key),
+              let receipts = try? JSONDecoder().decode([RemoteMealMutationReceipt].self, from: data)
+        else {
+            return []
+        }
+
+        return receipts.filter {
+            let age = now.timeIntervalSince($0.recordedAt)
+            return age >= 0 && age <= remoteMealMutationMaximumAge
+        }
+    }
+
+    private func saveReceipts(_ receipts: [RemoteMealMutationReceipt]) {
+        guard let data = try? JSONEncoder().encode(receipts) else { return }
+        defaults.set(data, forKey: key)
+    }
+}
+
+private enum RemoteMealMutationValidationError: LocalizedError {
+    case message(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .message(message):
+            return message
+        }
+    }
+}
+
+extension TrioRemoteControl {
+    func handleMealMutationCommand(_ payload: CommandPayload) async {
+        let now = Date()
+
+        guard let rawCommandID = payload.commandID,
+              let commandID = UUID(uuidString: rawCommandID)?.uuidString
+        else {
+            await sendMealMutationResponse(
+                payload: payload,
+                success: false,
+                message: "Command rejected: command_id must be a valid UUID.",
+                result: .rejected,
+                syncStatus: .notRequested
+            )
+            return
+        }
+        guard let rawMealID = payload.mealID,
+              let mealID = UUID(uuidString: rawMealID)?.uuidString,
+              let mealUUID = UUID(uuidString: mealID)
+        else {
+            await sendMealMutationResponse(
+                payload: payload,
+                success: false,
+                message: "Command rejected: meal_id must be a valid Trio meal UUID.",
+                result: .rejected,
+                syncStatus: .notRequested,
+                commandID: commandID
+            )
+            return
+        }
+
+        let fingerprint = Self.mealMutationFingerprint(payload: payload, mealID: mealID)
+        let claim = await RemoteMealMutationReceiptStore.shared.claim(
+            commandID: commandID,
+            mealID: mealID,
+            fingerprint: fingerprint,
+            now: now
+        )
+
+        var resumedReceipt: RemoteMealMutationReceipt?
+        switch claim {
+        case let .replay(storedReceipt):
+            var receipt = storedReceipt
+            if receipt.success, !receipt.cobRecalculated, await recalculateCOB() {
+                receipt.cobRecalculated = true
+                await RemoteMealMutationReceiptStore.shared.record(receipt)
+            }
+            if receipt.success,
+               let disposition = receipt.disposition,
+               let before = receipt.before,
+               disposition != .unchanged,
+               !receipt.serviceSyncAttemptFinished
+            {
+                if await synchronizeMealMutation(disposition: disposition, before: before) {
+                    receipt.serviceSyncAttemptFinished = true
+                    await RemoteMealMutationReceiptStore.shared.record(receipt)
+                }
+            }
+            await sendCompletedMealMutationResponse(receipt, payload: payload)
+            await RemoteMealMutationReceiptStore.shared.release(commandID: commandID, mealID: mealID)
+            return
+
+        case let .resume(receipt):
+            resumedReceipt = receipt
+
+        case .conflict:
+            await sendMealMutationResponse(
+                payload: payload,
+                success: false,
+                message: "Command rejected: command_id was already used for a different request.",
+                result: .rejected,
+                syncStatus: .notRequested,
+                commandID: commandID,
+                mealID: mealID
+            )
+            return
+
+        case .inProgress:
+            await sendMealMutationResponse(
+                payload: payload,
+                success: false,
+                message: "A command for this meal is already in progress. Retry shortly.",
+                result: .inProgress,
+                syncStatus: .notRequested,
+                commandID: commandID,
+                mealID: mealID
+            )
+            return
+
+        case .execute:
+            break
+        }
+
+        let request: RemoteMealMutationRequest
+        do {
+            request = try validatedMealMutationRequest(payload)
+        } catch let error as RemoteMealMutationValidationError {
+            await rejectClaimedMealMutation(
+                error.localizedDescription,
+                payload: payload,
+                commandID: commandID,
+                mealID: mealID,
+                fingerprint: fingerprint,
+                now: now
+            )
+            return
+        } catch {
+            await rejectClaimedMealMutation(
+                "Command rejected: meal data is invalid.",
+                payload: payload,
+                commandID: commandID,
+                mealID: mealID,
+                fingerprint: fingerprint,
+                now: now
+            )
+            return
+        }
+
+        let intendedDisposition: MealMutationDisposition = switch request.mutation {
+        case .edit: .edited
+        case .delete: .deleted
+        }
+
+        var preparedReceipt = resumedReceipt
+        if preparedReceipt == nil {
+            do {
+                let before = try await carbsStorage.mealSnapshot(id: mealUUID, now: now)
+                let pending = RemoteMealMutationReceipt(
+                    commandID: commandID,
+                    fingerprint: fingerprint,
+                    mealID: mealID,
+                    success: false,
+                    message: "Meal change is prepared",
+                    result: .inProgress,
+                    syncStatus: .notRequested,
+                    disposition: intendedDisposition,
+                    before: before,
+                    cobRecalculated: false,
+                    serviceSyncAttemptFinished: false,
+                    isFinal: false,
+                    recordedAt: now
+                )
+                await RemoteMealMutationReceiptStore.shared.record(pending)
+                preparedReceipt = pending
+            } catch let error as MealMutationError {
+                await rejectClaimedMealMutation(
+                    "Command rejected: \(error.localizedDescription)",
+                    payload: payload,
+                    commandID: commandID,
+                    mealID: mealID,
+                    fingerprint: fingerprint,
+                    now: now
+                )
+                return
+            } catch {
+                await RemoteMealMutationReceiptStore.shared.release(commandID: commandID, mealID: mealID)
+                await sendMealMutationResponse(
+                    payload: payload,
+                    success: false,
+                    message: "Meal change could not be prepared: \(error.localizedDescription)",
+                    result: .rejected,
+                    syncStatus: .notRequested,
+                    commandID: commandID,
+                    mealID: mealID
+                )
+                return
+            }
+        }
+
+        guard let prepared = preparedReceipt, let preparedBefore = prepared.before else {
+            await RemoteMealMutationReceiptStore.shared.remove(commandID: commandID)
+            await RemoteMealMutationReceiptStore.shared.release(commandID: commandID, mealID: mealID)
+            await sendMealMutationResponse(
+                payload: payload,
+                success: false,
+                message: "Meal change could not be resumed because its receipt is incomplete.",
+                result: .rejected,
+                syncStatus: .notRequested,
+                commandID: commandID,
+                mealID: mealID
+            )
+            return
+        }
+
+        var mutationResult: MealMutationResult
+        do {
+            mutationResult = try await carbsStorage.mutateMeal(
+                id: mealUUID,
+                expected: request.expected,
+                mutation: request.mutation,
+                now: resumedReceipt?.recordedAt ?? now
+            )
+            if resumedReceipt != nil,
+               intendedDisposition == .edited,
+               mutationResult.disposition == .unchanged
+            {
+                mutationResult = MealMutationResult(
+                    disposition: .edited,
+                    before: preparedBefore,
+                    after: mutationResult.after
+                )
+            }
+        } catch let error as MealMutationError {
+            if resumedReceipt != nil, intendedDisposition == .deleted, error == .notFound {
+                mutationResult = MealMutationResult(disposition: .deleted, before: preparedBefore, after: nil)
+            } else {
+                await rejectClaimedMealMutation(
+                    "Command rejected: \(error.localizedDescription)",
+                    payload: payload,
+                    commandID: commandID,
+                    mealID: mealID,
+                    fingerprint: fingerprint,
+                    now: now
+                )
+                return
+            }
+        } catch {
+            await RemoteMealMutationReceiptStore.shared.remove(commandID: commandID)
+            await RemoteMealMutationReceiptStore.shared.release(commandID: commandID, mealID: mealID)
+            await sendMealMutationResponse(
+                payload: payload,
+                success: false,
+                message: "Meal change could not be saved: \(error.localizedDescription)",
+                result: .rejected,
+                syncStatus: .notRequested,
+                commandID: commandID,
+                mealID: mealID
+            )
+            return
+        }
+
+        let response: (message: String, result: MealMutationResponseResult, syncStatus: MealMutationSyncStatus)
+        switch mutationResult.disposition {
+        case .edited:
+            response = ("Meal updated", .updated, .requested)
+        case .deleted:
+            response = ("Meal deleted", .deleted, .requested)
+        case .unchanged:
+            response = ("Meal change was already applied", .alreadyApplied, .notRequested)
+        }
+
+        var receipt = RemoteMealMutationReceipt(
+            commandID: commandID,
+            fingerprint: fingerprint,
+            mealID: mealID,
+            success: true,
+            message: response.message,
+            result: response.result,
+            syncStatus: response.syncStatus,
+            disposition: mutationResult.disposition,
+            before: mutationResult.before,
+            cobRecalculated: mutationResult.disposition == .unchanged,
+            serviceSyncAttemptFinished: mutationResult.disposition == .unchanged,
+            isFinal: true,
+            recordedAt: now
+        )
+        await RemoteMealMutationReceiptStore.shared.record(receipt)
+
+        if !receipt.cobRecalculated, await recalculateCOB() {
+            receipt.cobRecalculated = true
+            await RemoteMealMutationReceiptStore.shared.record(receipt)
+        }
+
+        if mutationResult.disposition != .unchanged {
+            if await synchronizeMealMutation(
+                disposition: mutationResult.disposition,
+                before: mutationResult.before
+            ) {
+                receipt.serviceSyncAttemptFinished = true
+                await RemoteMealMutationReceiptStore.shared.record(receipt)
+            }
+        }
+        await sendCompletedMealMutationResponse(receipt, payload: payload)
+        await RemoteMealMutationReceiptStore.shared.release(commandID: commandID, mealID: mealID)
+    }
+
+    private func validatedMealMutationRequest(_ payload: CommandPayload) throws -> RemoteMealMutationRequest {
+        guard payload.commandType == .editMeal || payload.commandType == .deleteMeal else {
+            throw RemoteMealMutationValidationError.message("Command rejected: unsupported meal operation.")
+        }
+        guard payload.bolusAmount == nil else {
+            throw RemoteMealMutationValidationError.message(
+                "Command rejected: meal edits and deletions cannot deliver a bolus."
+            )
+        }
+        guard payload.target == nil, payload.duration == nil, payload.overrideName == nil else {
+            throw RemoteMealMutationValidationError.message(
+                "Command rejected: unrelated command fields were included."
+            )
+        }
+        guard let expectedCarbs = payload.expectedCarbs,
+              let expectedFat = payload.expectedFat,
+              let expectedProtein = payload.expectedProtein,
+              let expectedMealTime = payload.expectedMealTime,
+              expectedMealTime.isFinite
+        else {
+            throw RemoteMealMutationValidationError.message(
+                "Command rejected: all expected meal values and expected_meal_time are required."
+            )
+        }
+        guard expectedCarbs >= 0, expectedFat >= 0, expectedProtein >= 0,
+              expectedCarbs > 0 || expectedFat > 0 || expectedProtein > 0
+        else {
+            throw RemoteMealMutationValidationError.message(
+                "Command rejected: expected meal amounts must be nonnegative and cannot all be zero."
+            )
+        }
+
+        let expected = MealMutationValues(
+            date: Date(timeIntervalSince1970: expectedMealTime),
+            carbs: Decimal(expectedCarbs),
+            fat: Decimal(expectedFat),
+            protein: Decimal(expectedProtein)
+        )
+
+        switch payload.commandType {
+        case .editMeal:
+            guard let carbs = payload.carbs,
+                  let fat = payload.fat,
+                  let protein = payload.protein,
+                  let scheduledTime = payload.scheduledTime,
+                  scheduledTime.isFinite
+            else {
+                throw RemoteMealMutationValidationError.message(
+                    "Command rejected: carbs, fat, protein, and scheduled_time are required for an edit."
+                )
+            }
+            guard carbs >= 0, fat >= 0, protein >= 0, carbs > 0 || fat > 0 || protein > 0 else {
+                throw RemoteMealMutationValidationError.message(
+                    "Command rejected: replacement meal amounts must be nonnegative and cannot all be zero."
+                )
+            }
+
+            let limits = settings.settings
+            guard Decimal(carbs) <= limits.maxCarbs else {
+                throw RemoteMealMutationValidationError.message(
+                    "Command rejected: carbs amount (\(carbs)g) exceeds the maximum allowed (\(limits.maxCarbs)g)."
+                )
+            }
+            guard Decimal(fat) <= limits.maxFat else {
+                throw RemoteMealMutationValidationError.message(
+                    "Command rejected: fat amount (\(fat)g) exceeds the maximum allowed (\(limits.maxFat)g)."
+                )
+            }
+            guard Decimal(protein) <= limits.maxProtein else {
+                throw RemoteMealMutationValidationError.message(
+                    "Command rejected: protein amount (\(protein)g) exceeds the maximum allowed (\(limits.maxProtein)g)."
+                )
+            }
+
+            return RemoteMealMutationRequest(
+                expected: expected,
+                mutation: .edit(MealMutationValues(
+                    date: Date(timeIntervalSince1970: scheduledTime),
+                    carbs: Decimal(carbs),
+                    fat: Decimal(fat),
+                    protein: Decimal(protein)
+                ))
+            )
+
+        case .deleteMeal:
+            guard payload.carbs == nil,
+                  payload.fat == nil,
+                  payload.protein == nil,
+                  payload.scheduledTime == nil
+            else {
+                throw RemoteMealMutationValidationError.message(
+                    "Command rejected: delete_meal cannot include replacement meal values."
+                )
+            }
+            return RemoteMealMutationRequest(expected: expected, mutation: .delete)
+
+        default:
+            throw RemoteMealMutationValidationError.message("Command rejected: unsupported meal operation.")
+        }
+    }
+
+    private func rejectClaimedMealMutation(
+        _ message: String,
+        payload: CommandPayload,
+        commandID: String,
+        mealID: String,
+        fingerprint: String,
+        now: Date
+    ) async {
+        let receipt = RemoteMealMutationReceipt(
+            commandID: commandID,
+            fingerprint: fingerprint,
+            mealID: mealID,
+            success: false,
+            message: message,
+            result: .rejected,
+            syncStatus: .notRequested,
+            disposition: nil,
+            before: nil,
+            cobRecalculated: true,
+            serviceSyncAttemptFinished: true,
+            isFinal: true,
+            recordedAt: now
+        )
+        await RemoteMealMutationReceiptStore.shared.record(receipt)
+        await RemoteMealMutationReceiptStore.shared.release(commandID: commandID, mealID: mealID)
+        await sendMealMutationResponse(
+            payload: payload,
+            success: false,
+            message: message,
+            result: .rejected,
+            syncStatus: .notRequested,
+            commandID: commandID,
+            mealID: mealID
+        )
+    }
+
+    private func sendMealMutationResponse(
+        payload: CommandPayload,
+        success: Bool,
+        message: String,
+        result: MealMutationResponseResult,
+        syncStatus: MealMutationSyncStatus,
+        commandID: String? = nil,
+        mealID: String? = nil
+    ) async {
+        let note = "\(message) Details: \(payload.humanReadableDescription())"
+        if success {
+            debug(.remoteControl, note)
+        } else {
+            debug(.remoteControl, note)
+            await nightscoutManager.uploadNoteTreatment(note: note)
+        }
+
+        await RemoteNotificationResponseManager.shared.sendResponseNotification(
+            to: payload.returnNotification,
+            commandType: payload.commandType,
+            success: success,
+            message: message,
+            commandID: commandID ?? payload.commandID,
+            mealID: mealID ?? payload.mealID,
+            result: result,
+            syncStatus: syncStatus
+        )
+    }
+
+    private func sendCompletedMealMutationResponse(
+        _ receipt: RemoteMealMutationReceipt,
+        payload: CommandPayload
+    ) async {
+        if receipt.success, !receipt.cobRecalculated || !receipt.serviceSyncAttemptFinished {
+            await sendMealMutationResponse(
+                payload: payload,
+                success: false,
+                message: "Meal change was saved locally, but follow-up processing is incomplete. Retry the same command.",
+                result: .inProgress,
+                syncStatus: receipt.serviceSyncAttemptFinished ? receipt.syncStatus : .notRequested,
+                commandID: receipt.commandID,
+                mealID: receipt.mealID
+            )
+            return
+        }
+
+        await sendMealMutationResponse(
+            payload: payload,
+            success: receipt.success,
+            message: receipt.message,
+            result: receipt.result,
+            syncStatus: receipt.syncStatus,
+            commandID: receipt.commandID,
+            mealID: receipt.mealID
+        )
+    }
+
+    private func synchronizeMealMutation(
+        disposition: MealMutationDisposition,
+        before: MealMutationSnapshot
+    ) async -> Bool {
+        guard disposition != .unchanged else { return true }
+
+        if disposition == .edited, await tidepoolManager.waitForCarbUploads() == false { return false }
+
+        await deleteMealSnapshotFromServices(before, deleteFromTidepool: disposition == .deleted)
+
+        if disposition == .edited {
+            do {
+                try await carbsStorage.markMealForUpload(id: before.id)
+            } catch {
+                debug(.remoteControl, "Could not requeue the edited meal for upload: \(error.localizedDescription)")
+                return false
+            }
+
+            async let nightscoutUpload: () = nightscoutManager.uploadCarbs()
+            async let healthKitUpload: () = healthKitManager.uploadCarbs()
+            async let tidepoolUpload: () = tidepoolManager.uploadCarbs()
+            _ = await [nightscoutUpload, healthKitUpload, tidepoolUpload]
+        }
+
+        return true
+    }
+
+    private func recalculateCOB() async -> Bool {
+        do {
+            try await apsManager.determineBasalSync()
+            return true
+        } catch {
+            debug(.remoteControl, "Meal change was saved, but COB recalculation failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    private func deleteMealSnapshotFromServices(
+        _ snapshot: MealMutationSnapshot,
+        deleteFromTidepool: Bool
+    ) async {
+        // Tidepool overwrites matching sync IDs on edit; only true deletions should enqueue a delete.
+        if deleteFromTidepool {
+            tidepoolManager.deleteCarbs(
+                withSyncId: snapshot.id,
+                carbs: snapshot.values.carbs,
+                at: snapshot.values.date,
+                enteredBy: CarbsEntry.local
+            )
+        }
+
+        await nightscoutManager.deleteCarbs(withID: snapshot.id.uuidString)
+        if let carbType = AppleHealthConfig.healthCarbObject {
+            await healthKitManager.deleteMealData(byID: snapshot.id.uuidString, sampleType: carbType)
+        }
+
+        if let fpuID = snapshot.fpuID {
+            await nightscoutManager.deleteCarbs(withID: fpuID.uuidString)
+            if let fatType = AppleHealthConfig.healthFatObject {
+                await healthKitManager.deleteMealData(byID: fpuID.uuidString, sampleType: fatType)
+            }
+            if let proteinType = AppleHealthConfig.healthProteinObject {
+                await healthKitManager.deleteMealData(byID: fpuID.uuidString, sampleType: proteinType)
+            }
+        }
+    }
+
+    private static func mealMutationFingerprint(payload: CommandPayload, mealID: String) -> String {
+        let value = RemoteMealMutationFingerprint(
+            user: payload.user,
+            commandType: payload.commandType.rawValue,
+            mealID: mealID,
+            expectedCarbs: payload.expectedCarbs,
+            expectedFat: payload.expectedFat,
+            expectedProtein: payload.expectedProtein,
+            expectedMealTime: payload.expectedMealTime,
+            carbs: payload.carbs,
+            fat: payload.fat,
+            protein: payload.protein,
+            scheduledTime: payload.scheduledTime,
+            bolusAmount: payload.bolusAmount,
+            target: payload.target,
+            duration: payload.duration,
+            overrideName: payload.overrideName
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return (try? encoder.encode(value).base64EncodedString()) ?? "invalid-fingerprint"
     }
 }

--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl.swift
@@ -11,6 +11,9 @@ class TrioRemoteControl: Injectable {
     @Injected() internal var overrideStorage: OverrideStorage!
     @Injected() internal var settings: SettingsManager!
     @Injected() internal var bolusSafetyValidator: BolusSafetyValidator!
+    @Injected() internal var healthKitManager: HealthKitManager!
+    @Injected() internal var tidepoolManager: TidepoolManager!
+    @Injected() internal var apsManager: APSManager!
 
     private let timeWindow: TimeInterval = 600
 
@@ -80,6 +83,9 @@ class TrioRemoteControl: Injectable {
             await cancelTempTarget(commandPayload)
         case .meal:
             try await handleMealCommand(commandPayload)
+        case .deleteMeal,
+             .editMeal:
+            await handleMealMutationCommand(commandPayload)
         case .startOverride:
             await handleStartOverrideCommand(commandPayload)
         case .cancelOverride:

--- a/TrioTests/CoreDataTests/CarbsStorageTests.swift
+++ b/TrioTests/CoreDataTests/CarbsStorageTests.swift
@@ -683,7 +683,7 @@ import Testing
     }
 
     @Test(
-        "Remote mutations reject stale values and enforce the closed 12-hour window"
+        "Remote mutations reject stale values and enforce the closed ±12-hour window"
     ) func testRemoteMealMutationSafetyChecks() async throws {
         let now = Date(timeIntervalSince1970: 1_800_200_000)
         let currentID = UUID()
@@ -703,17 +703,17 @@ import Testing
             #expect(error == .stale(current: current))
         }
 
-        let boundaryID = UUID()
-        let boundaryDate = now.addingTimeInterval(-remoteMealMutationMaximumAge)
-        let boundary = MealMutationValues(date: boundaryDate, carbs: 10, fat: 0, protein: 0)
-        try await insertMeal(id: boundaryID, date: boundaryDate, carbs: 10, fat: 0, protein: 0, note: nil)
-        let boundaryResult = try await mutationStorage.mutateMeal(
-            id: boundaryID,
-            expected: boundary,
+        let pastBoundaryID = UUID()
+        let pastBoundaryDate = now.addingTimeInterval(-remoteMealMutationMaximumAge)
+        let pastBoundary = MealMutationValues(date: pastBoundaryDate, carbs: 10, fat: 0, protein: 0)
+        try await insertMeal(id: pastBoundaryID, date: pastBoundaryDate, carbs: 10, fat: 0, protein: 0, note: nil)
+        let pastBoundaryResult = try await mutationStorage.mutateMeal(
+            id: pastBoundaryID,
+            expected: pastBoundary,
             mutation: .delete,
             now: now
         )
-        #expect(boundaryResult.disposition == .deleted)
+        #expect(pastBoundaryResult.disposition == .deleted)
 
         let oldID = UUID()
         let oldDate = now.addingTimeInterval(-remoteMealMutationMaximumAge - 0.001)
@@ -726,27 +726,81 @@ import Testing
             #expect(error == .outsideEditWindow)
         }
 
+        let futureBoundaryID = UUID()
+        let futureBoundaryDate = now.addingTimeInterval(remoteMealMutationMaximumAge)
+        let futureBoundary = MealMutationValues(date: futureBoundaryDate, carbs: 10, fat: 0, protein: 0)
+        try await insertMeal(
+            id: futureBoundaryID,
+            date: futureBoundaryDate,
+            carbs: 10,
+            fat: 0,
+            protein: 0,
+            note: nil
+        )
+        let futureBoundaryResult = try await mutationStorage.mutateMeal(
+            id: futureBoundaryID,
+            expected: futureBoundary,
+            mutation: .delete,
+            now: now
+        )
+        #expect(futureBoundaryResult.disposition == .deleted)
+
         let futureID = UUID()
-        let futureDate = now.addingTimeInterval(0.001)
+        let futureDate = now.addingTimeInterval(remoteMealMutationMaximumAge + 0.001)
         let future = MealMutationValues(date: futureDate, carbs: 10, fat: 0, protein: 0)
         try await insertMeal(id: futureID, date: futureDate, carbs: 10, fat: 0, protein: 0, note: nil)
         do {
             _ = try await mutationStorage.mutateMeal(id: futureID, expected: future, mutation: .delete, now: now)
-            Issue.record("A future meal should be rejected")
+            Issue.record("A meal more than 12 hours in the future should be rejected")
         } catch let error as MealMutationError {
             #expect(error == .outsideEditWindow)
         }
 
         let replacementID = UUID()
         try await insertMeal(id: replacementID, date: currentDate, carbs: 10, fat: 0, protein: 0, note: nil)
+        let initialReplacement = MealMutationValues(date: currentDate, carbs: 10, fat: 0, protein: 0)
+        let pastBoundaryReplacement = MealMutationValues(date: pastBoundaryDate, carbs: 11, fat: 0, protein: 0)
+        let pastBoundaryEdit = try await mutationStorage.mutateMeal(
+            id: replacementID,
+            expected: initialReplacement,
+            mutation: .edit(pastBoundaryReplacement),
+            now: now
+        )
+        #expect(pastBoundaryEdit.disposition == .edited)
+        #expect(pastBoundaryEdit.after?.values == pastBoundaryReplacement)
+
+        let futureBoundaryReplacement = MealMutationValues(date: futureBoundaryDate, carbs: 12, fat: 0, protein: 0)
+        let futureBoundaryEdit = try await mutationStorage.mutateMeal(
+            id: replacementID,
+            expected: pastBoundaryReplacement,
+            mutation: .edit(futureBoundaryReplacement),
+            now: now
+        )
+        #expect(futureBoundaryEdit.disposition == .edited)
+        #expect(futureBoundaryEdit.after?.values == futureBoundaryReplacement)
+
+        let pastOutsideReplacement = MealMutationValues(date: oldDate, carbs: 13, fat: 0, protein: 0)
         do {
             _ = try await mutationStorage.mutateMeal(
                 id: replacementID,
-                expected: MealMutationValues(date: currentDate, carbs: 10, fat: 0, protein: 0),
-                mutation: .edit(MealMutationValues(date: futureDate, carbs: 11, fat: 0, protein: 0)),
+                expected: futureBoundaryReplacement,
+                mutation: .edit(pastOutsideReplacement),
                 now: now
             )
-            Issue.record("A replacement time outside the window should be rejected")
+            Issue.record("A replacement more than 12 hours in the past should be rejected")
+        } catch let error as MealMutationError {
+            #expect(error == .replacementOutsideEditWindow)
+        }
+
+        let futureOutsideReplacement = MealMutationValues(date: futureDate, carbs: 13, fat: 0, protein: 0)
+        do {
+            _ = try await mutationStorage.mutateMeal(
+                id: replacementID,
+                expected: futureBoundaryReplacement,
+                mutation: .edit(futureOutsideReplacement),
+                now: now
+            )
+            Issue.record("A replacement more than 12 hours in the future should be rejected")
         } catch let error as MealMutationError {
             #expect(error == .replacementOutsideEditWindow)
         }

--- a/TrioTests/CoreDataTests/CarbsStorageTests.swift
+++ b/TrioTests/CoreDataTests/CarbsStorageTests.swift
@@ -377,11 +377,22 @@ import Testing
 
         // When
         try await storage.storeCarbs([testEntry], areFetchedFromRemote: false)
+        let storedRoots = try await coreDataStack.fetchEntitiesAsync(
+            ofType: CarbEntryStored.self,
+            onContext: testContext,
+            predicate: NSPredicate(format: "note == %@ AND isFPU == NO", "NS test"),
+            key: "date",
+            ascending: false
+        ) as? [CarbEntryStored]
+        let storedRootID = try #require(storedRoots?.first?.id?.uuidString)
         let notUploadedEntries = try await storage.getCarbsNotYetUploadedToNightscout()
 
         // Then
         #expect(!notUploadedEntries.isEmpty, "Should have entries not uploaded to NS")
-        #expect(notUploadedEntries[0].carbs == 40, "Carbs value should match")
+        let root = try #require(notUploadedEntries.first(where: { $0.id == storedRootID }))
+        #expect(root.id == storedRootID, "Root ID should match its Core Data UUID")
+        #expect(root.fpuID == nil, "Carb-only roots should not publish an FPU family ID")
+        #expect(root.carbs == 40, "Carbs value should match")
     }
 
     @Test("Get FPUs not yet uploaded to Nightscout") func testGetFPUsNotYetUploadedToNightscout() async throws {
@@ -422,20 +433,36 @@ import Testing
         #expect(carbNonFpuEntry?.carbs == 30, "Original carbs should match")
         #expect(carbNonFpuEntry?.protein == 10, "Original carbs should match")
         #expect(carbNonFpuEntry?.fat == 20, "Original carbs should match")
+        let storedRootID = try #require(carbNonFpuEntry?.id?.uuidString)
 
         // Additional carb-fpu entries should be created for fat/protein with isFPU set to true and the carbs set to the amount of each carbEquivalent
         let carbFpuEntry = allStoredEntries?.filter { $0.isFPU == true }
         #expect(carbFpuEntry?.isEmpty == false, "Should have additional carb-fpu entries")
 
         // Now test the Nightscout upload function
+        let notUploadedRoots = try await storage.getCarbsNotYetUploadedToNightscout()
         let notUploadedFPUs = try await storage.getFPUsNotYetUploadedToNightscout()
 
         // Then verify Nightscout entries
+        let root = try #require(notUploadedRoots.first(where: { $0.id == storedRootID }))
+        #expect(root.id == storedRootID, "Root ID should match its Core Data UUID")
+        #expect(root.fpuID == fpuID, "Root should publish its FPU family ID")
+        #expect(root.id != root.fpuID, "A family root should have distinct root and FPU IDs")
         #expect(!notUploadedFPUs.isEmpty, "Should have FPUs not uploaded to NS")
         let fpu = notUploadedFPUs[0]
         #expect(fpu.carbs ?? 0 < 30, "Original carbs value should match")
         #expect(fpu.protein == 0, "Protein value should match")
         #expect(fpu.fat == 0, "Fat value should match")
+        for treatment in notUploadedFPUs {
+            #expect(treatment.id == fpuID, "Generated FPU treatment ID should remain the family ID")
+            #expect(treatment.fpuID == fpuID, "Generated FPU treatment should publish the family ID")
+            #expect(treatment.id == treatment.fpuID, "Generated FPU treatment IDs should identify children")
+        }
+
+        let encodedFPU = try JSONCoding.encoder.encode([fpu])
+        let encodedTreatments = try #require(JSONSerialization.jsonObject(with: encodedFPU) as? [[String: Any]])
+        let encodedJSON = try #require(encodedTreatments.first)
+        #expect(encodedJSON["fpuID"] as? String == fpuID, "Nightscout JSON should encode the exact fpuID key")
 
         // Verify all entries share the same fpuID
         #expect(
@@ -553,19 +580,20 @@ import Testing
         #expect(result.before.id == rootID)
         #expect(result.before.fpuID == oldFPUID)
         #expect(Set(result.before.fpuEntries.map(\.id)) == Set(oldChildren.map(\.id)))
-        #expect(result.after?.id == rootID)
-        #expect(result.after?.values == replacement)
-        #expect(result.after?.note == "Keep this note")
-        #expect(result.after?.fpuID != nil)
-        #expect(result.after?.fpuID != oldFPUID)
-        #expect(result.after?.fpuEntries.isEmpty == false)
+        let editedSnapshot = try #require(result.after)
+        #expect(editedSnapshot.id == rootID)
+        #expect(editedSnapshot.values == replacement)
+        #expect(editedSnapshot.note == "Keep this note")
+        let replacementFPUID = try #require(editedSnapshot.fpuID)
+        #expect(replacementFPUID != oldFPUID)
+        #expect(!editedSnapshot.fpuEntries.isEmpty)
 
         let stored = try await loadMeal(id: rootID)
         #expect(stored.snapshot.id == rootID)
         #expect(stored.snapshot.values == replacement)
         #expect(stored.snapshot.note == "Keep this note")
-        #expect(stored.snapshot.fpuID == result.after?.fpuID)
-        #expect(stored.snapshot.fpuEntries == result.after?.fpuEntries)
+        #expect(stored.snapshot.fpuID == replacementFPUID)
+        #expect(stored.snapshot.fpuEntries == editedSnapshot.fpuEntries)
         let oldChildrenStillExist = try await entriesExist(ids: oldChildren.map(\.id))
         #expect(!oldChildrenStillExist)
 
@@ -595,8 +623,16 @@ import Testing
         let pendingHealth = try await mutationStorage.getCarbsNotYetUploadedToHealth()
         let pendingTidepool = try await mutationStorage.getCarbsNotYetUploadedToTidepool()
         #expect(pendingNightscoutRoots.map(\.id) == [rootID.uuidString])
-        #expect(pendingNightscoutFPUs.count == result.after?.fpuEntries.count)
-        #expect(pendingNightscoutFPUs.allSatisfy { $0.id == result.after?.fpuID?.uuidString })
+        let pendingNightscoutRoot = try #require(pendingNightscoutRoots.first)
+        #expect(pendingNightscoutRoot.id == rootID.uuidString)
+        #expect(pendingNightscoutRoot.fpuID == replacementFPUID.uuidString)
+        #expect(pendingNightscoutRoot.id != pendingNightscoutRoot.fpuID)
+        #expect(pendingNightscoutFPUs.count == editedSnapshot.fpuEntries.count)
+        #expect(pendingNightscoutFPUs.allSatisfy {
+            $0.id == replacementFPUID.uuidString &&
+                $0.fpuID == replacementFPUID.uuidString &&
+                $0.id == $0.fpuID
+        })
         #expect(pendingHealth.map(\.id) == [rootID.uuidString])
         #expect(pendingTidepool.map(\.id) == [rootID.uuidString])
     }

--- a/TrioTests/CoreDataTests/CarbsStorageTests.swift
+++ b/TrioTests/CoreDataTests/CarbsStorageTests.swift
@@ -10,6 +10,7 @@ import Testing
     let resolver: Resolver
     var coreDataStack: CoreDataStack!
     var testContext: NSManagedObjectContext!
+    var mutationStorage: CarbsStorage!
 
     init() async throws {
         // Create test context
@@ -29,6 +30,8 @@ import Testing
 
         resolver = assembler.resolver
         injectServices(resolver)
+        let testStack = coreDataStack!
+        mutationStorage = BaseCarbsStorage(resolver: resolver, contextProvider: { testStack.newTaskContext() })
     }
 
     @Test("Storage is correctly initialized") func testStorageInitialization() {
@@ -439,5 +442,460 @@ import Testing
             allStoredEntries?.allSatisfy { $0.fpuID?.uuidString == fpuID } == true,
             "All entries should share the same fpuID"
         )
+    }
+
+    @Test(
+        "Remote meal command payload and response metadata use the correlated contract"
+    ) func testRemoteMealMutationContract() throws {
+        let commandID = UUID()
+        let mealID = UUID()
+        let editJSON = """
+        {
+          "user": "LoopFollow",
+          "command_type": "edit_meal",
+          "timestamp": 1800000000,
+          "command_id": "\(commandID.uuidString)",
+          "meal_id": "\(mealID.uuidString)",
+          "expected_carbs": 30,
+          "expected_fat": 10,
+          "expected_protein": 5,
+          "expected_meal_time": 1799996400,
+          "carbs": 25,
+          "fat": 12,
+          "protein": 6,
+          "scheduled_time": 1799996700
+        }
+        """
+
+        let edit = try JSONDecoder().decode(CommandPayload.self, from: Data(editJSON.utf8))
+        #expect(edit.commandType == .editMeal)
+        #expect(edit.commandID == commandID.uuidString)
+        #expect(edit.mealID == mealID.uuidString)
+        #expect(edit.expectedCarbs == 30)
+        #expect(edit.expectedFat == 10)
+        #expect(edit.expectedProtein == 5)
+        #expect(edit.expectedMealTime == 1_799_996_400)
+        #expect(edit.carbs == 25)
+        #expect(edit.scheduledTime == 1_799_996_700)
+
+        let deleteJSON = """
+        {
+          "user": "LoopFollow",
+          "command_type": "delete_meal",
+          "timestamp": 1800000000,
+          "command_id": "\(UUID().uuidString)",
+          "meal_id": "\(mealID.uuidString)",
+          "expected_carbs": 30,
+          "expected_fat": 10,
+          "expected_protein": 5,
+          "expected_meal_time": 1799996400
+        }
+        """
+
+        let delete = try JSONDecoder().decode(CommandPayload.self, from: Data(deleteJSON.utf8))
+        #expect(delete.commandType == .deleteMeal)
+        #expect(delete.carbs == nil)
+        #expect(delete.scheduledTime == nil)
+
+        let response = RemoteNotificationResponseManager.NotificationPayload(
+            aps: .init(alert: .init(title: "Command Successful", body: "Meal updated")),
+            commandStatus: "success",
+            commandType: TrioRemoteControl.CommandType.editMeal.rawValue,
+            timestamp: 1_800_000_000,
+            commandID: commandID.uuidString,
+            mealID: mealID.uuidString,
+            result: .updated,
+            syncStatus: .requested
+        )
+        let responseData = try JSONEncoder().encode(response)
+        let responseJSON = try #require(JSONSerialization.jsonObject(with: responseData) as? [String: Any])
+        let aps = try #require(responseJSON["aps"] as? [String: Any])
+        #expect(responseJSON["command_id"] as? String == commandID.uuidString)
+        #expect(responseJSON["meal_id"] as? String == mealID.uuidString)
+        #expect(responseJSON["result"] as? String == "updated")
+        #expect(responseJSON["sync_status"] as? String == "requested")
+        #expect(aps["content-available"] as? Int == 1)
+    }
+
+    @Test(
+        "Remote edit preserves the root identity and replaces its FPU family atomically"
+    ) func testRemoteMealEditPreservesRootAndRebuildsFPUFamily() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let originalDate = now.addingTimeInterval(-60 * 60)
+        let replacementDate = now.addingTimeInterval(-30 * 60)
+        let rootID = UUID()
+        let oldFPUID = UUID()
+        let oldChildren = [
+            MealFPUEntrySnapshot(id: UUID(), date: originalDate.addingTimeInterval(60 * 60), carbs: 12),
+            MealFPUEntrySnapshot(id: UUID(), date: originalDate.addingTimeInterval(90 * 60), carbs: 12)
+        ]
+        try await insertMeal(
+            id: rootID,
+            date: originalDate,
+            carbs: 30,
+            fat: 20,
+            protein: 10,
+            note: "Keep this note",
+            fpuID: oldFPUID,
+            children: oldChildren
+        )
+
+        let expected = MealMutationValues(date: originalDate, carbs: 30, fat: 20, protein: 10)
+        let replacement = MealMutationValues(date: replacementDate, carbs: 25, fat: 200, protein: 200)
+        let result = try await mutationStorage.mutateMeal(
+            id: rootID,
+            expected: expected,
+            mutation: .edit(replacement),
+            now: now
+        )
+
+        #expect(result.disposition == .edited)
+        #expect(result.before.id == rootID)
+        #expect(result.before.fpuID == oldFPUID)
+        #expect(Set(result.before.fpuEntries.map(\.id)) == Set(oldChildren.map(\.id)))
+        #expect(result.after?.id == rootID)
+        #expect(result.after?.values == replacement)
+        #expect(result.after?.note == "Keep this note")
+        #expect(result.after?.fpuID != nil)
+        #expect(result.after?.fpuID != oldFPUID)
+        #expect(result.after?.fpuEntries.isEmpty == false)
+
+        let stored = try await loadMeal(id: rootID)
+        #expect(stored.snapshot.id == rootID)
+        #expect(stored.snapshot.values == replacement)
+        #expect(stored.snapshot.note == "Keep this note")
+        #expect(stored.snapshot.fpuID == result.after?.fpuID)
+        #expect(stored.snapshot.fpuEntries == result.after?.fpuEntries)
+        let oldChildrenStillExist = try await entriesExist(ids: oldChildren.map(\.id))
+        #expect(!oldChildrenStillExist)
+
+        let staleRemoteEntry = CarbsEntry(
+            id: rootID.uuidString,
+            createdAt: originalDate,
+            actualDate: originalDate,
+            carbs: 30,
+            fat: 20,
+            protein: 10,
+            note: "Stale Nightscout copy",
+            enteredBy: CarbsEntry.local,
+            isFPU: false,
+            fpuID: oldFPUID.uuidString
+        )
+        try await mutationStorage.storeCarbs([staleRemoteEntry], areFetchedFromRemote: true)
+        #expect(!(try await entriesExist(at: originalDate)))
+
+        #expect(try await mutationStorage.getCarbsNotYetUploadedToNightscout().isEmpty)
+        #expect(try await mutationStorage.getFPUsNotYetUploadedToNightscout().isEmpty)
+        #expect(try await mutationStorage.getCarbsNotYetUploadedToHealth().isEmpty)
+        #expect(try await mutationStorage.getCarbsNotYetUploadedToTidepool().isEmpty)
+
+        try await mutationStorage.markMealForUpload(id: rootID)
+        let pendingNightscoutRoots = try await mutationStorage.getCarbsNotYetUploadedToNightscout()
+        let pendingNightscoutFPUs = try await mutationStorage.getFPUsNotYetUploadedToNightscout()
+        let pendingHealth = try await mutationStorage.getCarbsNotYetUploadedToHealth()
+        let pendingTidepool = try await mutationStorage.getCarbsNotYetUploadedToTidepool()
+        #expect(pendingNightscoutRoots.map(\.id) == [rootID.uuidString])
+        #expect(pendingNightscoutFPUs.count == result.after?.fpuEntries.count)
+        #expect(pendingNightscoutFPUs.allSatisfy { $0.id == result.after?.fpuID?.uuidString })
+        #expect(pendingHealth.map(\.id) == [rootID.uuidString])
+        #expect(pendingTidepool.map(\.id) == [rootID.uuidString])
+    }
+
+    @Test(
+        "An already-applied edit succeeds before stale expected-value checking"
+    ) func testRemoteMealEditIsIdempotent() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_100_000)
+        let mealDate = now.addingTimeInterval(-60 * 60)
+        let rootID = UUID()
+        try await insertMeal(id: rootID, date: mealDate, carbs: 20, fat: 0, protein: 0, note: "Original")
+
+        let staleExpected = MealMutationValues(date: mealDate, carbs: 99, fat: 0, protein: 0)
+        let current = MealMutationValues(date: mealDate, carbs: 20, fat: 0, protein: 0)
+        let result = try await mutationStorage.mutateMeal(
+            id: rootID,
+            expected: staleExpected,
+            mutation: .edit(current),
+            now: now
+        )
+
+        #expect(result.disposition == .unchanged)
+        #expect(result.before == result.after)
+        let stored = try await loadMeal(id: rootID)
+        #expect(stored.snapshot.note == "Original")
+    }
+
+    @Test(
+        "Fat/protein-only roots expose their stable meal ID to Nightscout"
+    ) func testRemoteMealMutationFatProteinOnlyRootIsDiscoverable() async throws {
+        let now = Date()
+        let rootID = UUID()
+        try await insertMeal(
+            id: rootID,
+            date: now.addingTimeInterval(-60),
+            carbs: 0,
+            fat: 20,
+            protein: 10,
+            note: "FPU only"
+        )
+
+        try await mutationStorage.markMealForUpload(id: rootID)
+        let treatments = try await mutationStorage.getCarbsNotYetUploadedToNightscout()
+        let treatment = try #require(treatments.first { $0.id == rootID.uuidString })
+        #expect(treatment.carbs == 0)
+        #expect(treatment.fat == 20)
+        #expect(treatment.protein == 10)
+    }
+
+    @Test(
+        "Remote mutations reject stale values and enforce the closed 12-hour window"
+    ) func testRemoteMealMutationSafetyChecks() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_200_000)
+        let currentID = UUID()
+        let currentDate = now.addingTimeInterval(-60 * 60)
+        let current = MealMutationValues(date: currentDate, carbs: 15, fat: 0, protein: 0)
+        try await insertMeal(id: currentID, date: currentDate, carbs: 15, fat: 0, protein: 0, note: nil)
+
+        do {
+            _ = try await mutationStorage.mutateMeal(
+                id: currentID,
+                expected: MealMutationValues(date: currentDate, carbs: 14, fat: 0, protein: 0),
+                mutation: .edit(MealMutationValues(date: currentDate, carbs: 16, fat: 0, protein: 0)),
+                now: now
+            )
+            Issue.record("A stale expected value should not mutate the meal")
+        } catch let error as MealMutationError {
+            #expect(error == .stale(current: current))
+        }
+
+        let boundaryID = UUID()
+        let boundaryDate = now.addingTimeInterval(-remoteMealMutationMaximumAge)
+        let boundary = MealMutationValues(date: boundaryDate, carbs: 10, fat: 0, protein: 0)
+        try await insertMeal(id: boundaryID, date: boundaryDate, carbs: 10, fat: 0, protein: 0, note: nil)
+        let boundaryResult = try await mutationStorage.mutateMeal(
+            id: boundaryID,
+            expected: boundary,
+            mutation: .delete,
+            now: now
+        )
+        #expect(boundaryResult.disposition == .deleted)
+
+        let oldID = UUID()
+        let oldDate = now.addingTimeInterval(-remoteMealMutationMaximumAge - 0.001)
+        let old = MealMutationValues(date: oldDate, carbs: 10, fat: 0, protein: 0)
+        try await insertMeal(id: oldID, date: oldDate, carbs: 10, fat: 0, protein: 0, note: nil)
+        do {
+            _ = try await mutationStorage.mutateMeal(id: oldID, expected: old, mutation: .delete, now: now)
+            Issue.record("A meal older than 12 hours should be rejected")
+        } catch let error as MealMutationError {
+            #expect(error == .outsideEditWindow)
+        }
+
+        let futureID = UUID()
+        let futureDate = now.addingTimeInterval(0.001)
+        let future = MealMutationValues(date: futureDate, carbs: 10, fat: 0, protein: 0)
+        try await insertMeal(id: futureID, date: futureDate, carbs: 10, fat: 0, protein: 0, note: nil)
+        do {
+            _ = try await mutationStorage.mutateMeal(id: futureID, expected: future, mutation: .delete, now: now)
+            Issue.record("A future meal should be rejected")
+        } catch let error as MealMutationError {
+            #expect(error == .outsideEditWindow)
+        }
+
+        let replacementID = UUID()
+        try await insertMeal(id: replacementID, date: currentDate, carbs: 10, fat: 0, protein: 0, note: nil)
+        do {
+            _ = try await mutationStorage.mutateMeal(
+                id: replacementID,
+                expected: MealMutationValues(date: currentDate, carbs: 10, fat: 0, protein: 0),
+                mutation: .edit(MealMutationValues(date: futureDate, carbs: 11, fat: 0, protein: 0)),
+                now: now
+            )
+            Issue.record("A replacement time outside the window should be rejected")
+        } catch let error as MealMutationError {
+            #expect(error == .replacementOutsideEditWindow)
+        }
+    }
+
+    @Test(
+        "Concurrent edits serialize so only one stale expectation can commit"
+    ) func testRemoteMealMutationSerializesConcurrentEdits() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_250_000)
+        let mealDate = now.addingTimeInterval(-60 * 60)
+        let rootID = UUID()
+        let original = MealMutationValues(date: mealDate, carbs: 20, fat: 0, protein: 0)
+        let firstReplacement = MealMutationValues(date: mealDate, carbs: 21, fat: 0, protein: 0)
+        let secondReplacement = MealMutationValues(date: mealDate, carbs: 22, fat: 0, protein: 0)
+        try await insertMeal(id: rootID, date: mealDate, carbs: 20, fat: 0, protein: 0, note: nil)
+
+        async let first: MealMutationResult? = try? mutationStorage.mutateMeal(
+            id: rootID,
+            expected: original,
+            mutation: .edit(firstReplacement),
+            now: now
+        )
+        async let second: MealMutationResult? = try? mutationStorage.mutateMeal(
+            id: rootID,
+            expected: original,
+            mutation: .edit(secondReplacement),
+            now: now
+        )
+        let (firstResult, secondResult) = await (first, second)
+        let results = [firstResult, secondResult].compactMap { $0 }
+
+        #expect(results.count == 1)
+        #expect(results.first?.disposition == .edited)
+        let stored = try await loadMeal(id: rootID)
+        #expect(stored.snapshot.values == firstReplacement || stored.snapshot.values == secondReplacement)
+    }
+
+    @Test(
+        "Remote delete removes the root and every generated FPU child"
+    ) func testRemoteMealDeleteRemovesFamily() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_300_000)
+        let mealDate = now.addingTimeInterval(-60 * 60)
+        let rootID = UUID()
+        let fpuID = UUID()
+        let children = [
+            MealFPUEntrySnapshot(id: UUID(), date: mealDate.addingTimeInterval(60 * 60), carbs: 15),
+            MealFPUEntrySnapshot(id: UUID(), date: mealDate.addingTimeInterval(90 * 60), carbs: 15)
+        ]
+        try await insertMeal(
+            id: rootID,
+            date: mealDate,
+            carbs: 35,
+            fat: 30,
+            protein: 20,
+            note: "Delete family",
+            fpuID: fpuID,
+            children: children
+        )
+
+        let result = try await mutationStorage.mutateMeal(
+            id: rootID,
+            expected: MealMutationValues(date: mealDate, carbs: 35, fat: 30, protein: 20),
+            mutation: .delete,
+            now: now
+        )
+
+        #expect(result.disposition == .deleted)
+        #expect(result.after == nil)
+        #expect(Set(result.before.fpuEntries.map(\.id)) == Set(children.map(\.id)))
+        let familyStillExists = try await entriesExist(ids: [rootID] + children.map(\.id))
+        #expect(!familyStillExists)
+    }
+
+    private struct StoredMeal: Sendable {
+        let snapshot: MealMutationSnapshot
+    }
+
+    private func insertMeal(
+        id: UUID,
+        date: Date,
+        carbs: Double,
+        fat: Double,
+        protein: Double,
+        note: String?,
+        fpuID: UUID? = nil,
+        children: [MealFPUEntrySnapshot] = []
+    ) async throws {
+        try await testContext.perform {
+            let root = CarbEntryStored(context: self.testContext)
+            root.id = id
+            root.date = date
+            root.carbs = carbs
+            root.fat = fat
+            root.protein = protein
+            root.note = note
+            root.fpuID = fpuID
+            root.isFPU = false
+            root.isUploadedToNS = true
+            root.isUploadedToHealth = true
+            root.isUploadedToTidepool = true
+
+            for snapshot in children {
+                let child = CarbEntryStored(context: self.testContext)
+                child.id = snapshot.id
+                child.date = snapshot.date
+                child.carbs = Double(truncating: NSDecimalNumber(decimal: snapshot.carbs))
+                child.fat = 0
+                child.protein = 0
+                child.fpuID = fpuID
+                child.isFPU = true
+                child.isUploadedToNS = true
+                child.isUploadedToHealth = true
+                child.isUploadedToTidepool = true
+            }
+            try self.testContext.save()
+        }
+    }
+
+    private func loadMeal(id: UUID) async throws -> StoredMeal {
+        try await testContext.perform {
+            self.testContext.reset()
+            let rootRequest: NSFetchRequest<CarbEntryStored> = CarbEntryStored.fetchRequest()
+            rootRequest.predicate = NSPredicate(format: "id == %@ AND isFPU == NO", id as CVarArg)
+            guard let root = try self.testContext.fetch(rootRequest).first,
+                  let rootID = root.id,
+                  let rootDate = root.date
+            else {
+                throw TestError("Failed to load stored meal")
+            }
+
+            var children: [CarbEntryStored] = []
+            if let fpuID = root.fpuID {
+                let childRequest: NSFetchRequest<CarbEntryStored> = CarbEntryStored.fetchRequest()
+                childRequest.predicate = NSPredicate(format: "fpuID == %@ AND isFPU == YES", fpuID as CVarArg)
+                childRequest.sortDescriptors = [NSSortDescriptor(key: "date", ascending: true)]
+                children = try self.testContext.fetch(childRequest)
+            }
+
+            let childSnapshots = try children.map { child in
+                guard let childID = child.id, let childDate = child.date else {
+                    throw TestError("Failed to load stored FPU entry")
+                }
+                return MealFPUEntrySnapshot(
+                    id: childID,
+                    date: childDate,
+                    carbs: Decimal(algorithmValue: child.carbs)
+                )
+            }
+            let snapshot = MealMutationSnapshot(
+                id: rootID,
+                fpuID: root.fpuID,
+                values: MealMutationValues(
+                    date: rootDate,
+                    carbs: Decimal(algorithmValue: root.carbs),
+                    fat: Decimal(algorithmValue: root.fat),
+                    protein: Decimal(algorithmValue: root.protein)
+                ),
+                note: root.note,
+                fpuEntries: childSnapshots
+            )
+            return StoredMeal(snapshot: snapshot)
+        }
+    }
+
+    private func entriesExist(ids: [UUID]) async throws -> Bool {
+        try await testContext.perform {
+            self.testContext.reset()
+            let request: NSFetchRequest<CarbEntryStored> = CarbEntryStored.fetchRequest()
+            request.predicate = NSPredicate(format: "id IN %@", ids)
+            request.fetchLimit = 1
+            return try self.testContext.count(for: request) > 0
+        }
+    }
+
+    private func entriesExist(at date: Date) async throws -> Bool {
+        try await testContext.perform {
+            self.testContext.reset()
+            let request: NSFetchRequest<CarbEntryStored> = CarbEntryStored.fetchRequest()
+            request.predicate = NSPredicate(
+                format: "date >= %@ AND date <= %@",
+                date.addingTimeInterval(-1) as NSDate,
+                date.addingTimeInterval(1) as NSDate
+            )
+            request.fetchLimit = 1
+            return try self.testContext.count(for: request) > 0
+        }
     }
 }


### PR DESCRIPTION
- Allow remote editing & deleting of meals in Trio, from LoopFollow
- Paired with a PR for LoopFollow, which will submit the new remote event type with the needed data