### PR TITLE
Use fixed consensus TIR bound in home stats banner

### DIFF
--- a/Trio/Sources/Modules/Home/HomeStateModel+Setup/GlucoseSetup.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel+Setup/GlucoseSetup.swift
@@ -49,7 +49,9 @@ extension Home.StateModel {
         return GlucoseDailyDistributionStats.compute(
             date: startOfDay,
             readings: readings,
-            highLimit: highGlucose,
+            // fixed consensus TIR bound (StatStateModel.highLimit), not the user's
+            // chart threshold, so the banner always matches the Stats screen
+            highLimit: 180,
             timeInRangeType: timeInRangeType
         )
     }


### PR DESCRIPTION
The banner passed the user's High Glucose chart threshold as the upper bound while Stats always uses 180 mg/dL; any threshold below 10 mmol/L made the two disagree. Fixes the banner, not Stats.