### PR TITLE
Update TreatmentsRootView.swift to fix wrong field order

### DIFF
--- a/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
+++ b/Trio/Sources/Modules/Treatments/View/TreatmentsRootView.swift
@@ -170,11 +170,11 @@ extension Treatments {
 
             switch current {
             case .fat:
-                return .bolus
+                return .protein
             case .protein:
-                return .fat
+                return .bolus
             case .carbs:
-                return showFPU ? .protein : .bolus
+                return showFPU ? .fat : .bolus
             case .bolus:
                 return .carbs
             }
@@ -192,13 +192,13 @@ extension Treatments {
 
             switch current {
             case .fat:
-                return .protein
-            case .protein:
                 return .carbs
+            case .protein:
+                return .fat
             case .carbs:
                 return .bolus
             case .bolus:
-                return showFPU ? .fat : .carbs
+                return showFPU ? .protein : .carbs
             }
         }
 


### PR DESCRIPTION
It looks like some point in the past, the fat and protein field got exchanged. However, their order appears to be wrong. As a result, when using the UP ^ and DOWN arrow buttons that now appear with Liquid Glass (next to the trashcan) when you have the keyboard open: they return to the wrong fields. When you tap "up" on fat, it goes to protein to the right, and "up" on protein returns to Carbs instead of to the Fat field to the left. 

In other words the order defined in previousField and nextField appears to be incorrect. This commit re-orders them so the up and down arrows (and any other scenario wherein the order matters) should be fixed. (Works for me on iOS 26 and fixes the observed wrong order. Not tested on iOS 27.)