### PR TITLE
fix for contact backgrounds having unstable background colours

### DIFF
--- a/Model/Classes+Properties/ContactTrickEntryStored+CoreDataProperties.swift
+++ b/Model/Classes+Properties/ContactTrickEntryStored+CoreDataProperties.swift
@@ -18,6 +18,7 @@ public extension ContactImageEntryStored {
     @NSManaged var ringGap: Int16
     @NSManaged var id: UUID?
     @NSManaged var colorMode: String?
+    @NSManaged var backgroundMode: String?
     @NSManaged var fontSize: Int16
     @NSManaged var fontSizeSecondary: Int16
     @NSManaged var fontWidth: String?

--- a/Model/TrioCoreDataPersistentContainer.xcdatamodeld/TrioCoreDataPersistentContainer.xcdatamodel/contents
+++ b/Model/TrioCoreDataPersistentContainer.xcdatamodeld/TrioCoreDataPersistentContainer.xcdatamodel/contents
@@ -28,6 +28,7 @@
     <entity name="ContactImageEntryStored" representedClassName="ContactImageEntryStored" syncable="YES" codeGenerationType="class">
         <attribute name="bottom" optional="YES" attributeType="String"/>
         <attribute name="colorMode" optional="YES" attributeType="String"/>
+        <attribute name="backgroundMode" optional="YES" attributeType="String"/>
         <attribute name="contactId" optional="YES" attributeType="String"/>
         <attribute name="fontSize" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="fontSizeSecondary" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Trio/Sources/APS/Storage/ContactImageStorage.swift
+++ b/Trio/Sources/APS/Storage/ContactImageStorage.swift
@@ -56,6 +56,8 @@ final class BaseContactImageStorage: ContactImageStorage, Injectable {
                         ringWidth: ContactImageEntry.RingWidth(rawValue: Int(entry.ringWidth)) ?? .regular,
                         ringGap: ContactImageEntry.RingGap(rawValue: Int(entry.ringGap)) ?? .small,
                         colorMode: ContactImageEntry.ColorMode(rawValue: entry.colorMode ?? "Color") ?? .color,
+                        backgroundMode: ContactImageEntry
+                            .BackgroundMode(rawValue: entry.backgroundMode ?? "transparent") ?? .transparent,
                         fontSize: ContactImageEntry.FontSize(rawValue: Int(entry.fontSize)) ?? .regular,
                         secondaryFontSize: ContactImageEntry.FontSize(rawValue: Int(entry.fontSizeSecondary)) ?? .small,
                         fontWeight: Font.Weight.fromString(entry.fontWeight ?? "regular"),
@@ -95,6 +97,7 @@ final class BaseContactImageStorage: ContactImageStorage, Injectable {
             newContactImageEntry.ringWidth = Int16(contactImageEntry.ringWidth.rawValue)
             newContactImageEntry.ringGap = Int16(contactImageEntry.ringGap.rawValue)
             newContactImageEntry.colorMode = contactImageEntry.colorMode.rawValue
+            newContactImageEntry.backgroundMode = contactImageEntry.backgroundMode.rawValue
             newContactImageEntry.fontSize = Int16(contactImageEntry.fontSize.rawValue)
             newContactImageEntry.fontSizeSecondary = Int16(contactImageEntry.secondaryFontSize.rawValue)
             newContactImageEntry.fontWidth = contactImageEntry.fontWidth.asString
@@ -138,6 +141,7 @@ final class BaseContactImageStorage: ContactImageStorage, Injectable {
                     existingEntry.ringWidth = Int16(contactImageEntry.ringWidth.rawValue)
                     existingEntry.ringGap = Int16(contactImageEntry.ringGap.rawValue)
                     existingEntry.colorMode = contactImageEntry.colorMode.rawValue
+                    existingEntry.backgroundMode = contactImageEntry.backgroundMode.rawValue
                     existingEntry.fontSize = Int16(contactImageEntry.fontSize.rawValue)
                     existingEntry.fontSizeSecondary = Int16(contactImageEntry.secondaryFontSize.rawValue)
                     existingEntry.fontWeight = contactImageEntry.fontWeight.asString

--- a/Trio/Sources/Models/ContactTrickEntry.swift
+++ b/Trio/Sources/Models/ContactTrickEntry.swift
@@ -14,6 +14,7 @@ struct ContactImageEntry: Hashable, Equatable, Sendable {
     var ringWidth: RingWidth = .regular
     var ringGap: RingGap = .small
     var colorMode: ColorMode = .color
+    var backgroundMode: BackgroundMode = .transparent
     var fontSize: FontSize = .regular
     var secondaryFontSize: FontSize = .small
     var fontWeight: Font.Weight = .medium
@@ -33,6 +34,7 @@ struct ContactImageEntry: Hashable, Equatable, Sendable {
             lhs.ringWidth == rhs.ringWidth &&
             lhs.ringGap == rhs.ringGap &&
             lhs.colorMode == rhs.colorMode &&
+            lhs.backgroundMode == rhs.backgroundMode &&
             lhs.fontSize == rhs.fontSize &&
             lhs.secondaryFontSize == rhs.secondaryFontSize &&
             lhs.fontWeight == rhs.fontWeight &&
@@ -70,6 +72,21 @@ struct ContactImageEntry: Hashable, Equatable, Sendable {
                 return String(localized: "Color", comment: "")
             case .monochrome:
                 return String(localized: "Monochrome", comment: "")
+            }
+        }
+    }
+
+    enum BackgroundMode: String, JSON, CaseIterable, Identifiable, Codable {
+        var id: String { rawValue }
+        case transparent
+        case black
+
+        var displayName: String {
+            switch self {
+            case .transparent:
+                return String(localized: "Transparent", comment: "")
+            case .black:
+                return String(localized: "Black", comment: "")
             }
         }
     }

--- a/Trio/Sources/Modules/ContactImage/View/AddContactImageSheet.swift
+++ b/Trio/Sources/Modules/ContactImage/View/AddContactImageSheet.swift
@@ -17,6 +17,7 @@ struct AddContactImageSheet: View {
     @State private var bottom: ContactImageValue = .trend
     @State private var ring: ContactImageLargeRing = .none
     @State private var colorMode: ContactImageEntry.ColorMode = .color
+    @State private var backgroundMode: ContactImageEntry.BackgroundMode = .transparent
     @State private var fontSize: ContactImageEntry.FontSize = .regular
     @State private var secondaryFontSize: ContactImageEntry.FontSize = .small
     @State private var fontWeight: Font.Weight = .medium
@@ -36,6 +37,7 @@ struct AddContactImageSheet: View {
             ringWidth: ringWidth,
             ringGap: ringGap,
             colorMode: colorMode,
+            backgroundMode: backgroundMode,
             fontSize: fontSize,
             secondaryFontSize: secondaryFontSize,
             fontWeight: fontWeight,
@@ -138,6 +140,7 @@ struct AddContactImageSheet: View {
 
                     // Font Settings Section
                     Section(header: Text("Font Settings")) {
+                        backgroundModePicker
                         colorModePicker
                         fontSizePicker
                         if layout == .split {
@@ -201,6 +204,14 @@ struct AddContactImageSheet: View {
                 .tint(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .padding(5)
+        }
+    }
+
+    private var backgroundModePicker: some View {
+        Picker("Background", selection: $backgroundMode) {
+            ForEach(ContactImageEntry.BackgroundMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+            }
         }
     }
 

--- a/Trio/Sources/Modules/ContactImage/View/ContactImageDetailView.swift
+++ b/Trio/Sources/Modules/ContactImage/View/ContactImageDetailView.swift
@@ -109,6 +109,7 @@ struct ContactImageDetailView: View {
 
                 // Font Settings Section
                 Section(header: Text("Font Settings")) {
+                    backgroundModePicker
                     colorModePicker
                     fontSizePicker
                     if contactImageEntry.layout == .split {
@@ -175,6 +176,14 @@ struct ContactImageDetailView: View {
                 .tint(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
                 .padding(5)
+        }
+    }
+
+    private var backgroundModePicker: some View {
+        Picker("Background", selection: $contactImageEntry.backgroundMode) {
+            ForEach(ContactImageEntry.BackgroundMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+            }
         }
     }
 

--- a/Trio/Sources/Services/ContactImage/ContactPicture.swift
+++ b/Trio/Sources/Services/ContactImage/ContactPicture.swift
@@ -30,6 +30,8 @@ struct ContactPicture: View {
         if let context = UIGraphicsGetCurrentContext() {
             context.setShouldAntialias(true)
             context.setAllowsAntialiasing(true)
+            UIColor.black.setFill()
+            UIRectFill(rect)
         }
 
         let ringWidth = Double(contact.ringWidth.rawValue) / 100.0

--- a/Trio/Sources/Services/ContactImage/ContactPicture.swift
+++ b/Trio/Sources/Services/ContactImage/ContactPicture.swift
@@ -26,202 +26,207 @@ struct ContactPicture: View {
         let secondaryTextColor: Color = .loopGray.opacity(contact.hasHighContrast ? 1 : 0.8)
         let fontWeight = contact.fontWeight
 
-        UIGraphicsBeginImageContext(rect.size)
-        if let context = UIGraphicsGetCurrentContext() {
-            context.setShouldAntialias(true)
-            context.setAllowsAntialiasing(true)
-            UIColor.black.setFill()
-            UIRectFill(rect)
-        }
-
-        let ringWidth = Double(contact.ringWidth.rawValue) / 100.0
-        let ringGap = Double(contact.ringGap.rawValue) / 100.0
-        let outerGap = 0.03
-
-        if contact.ring != .none {
-            rect = CGRect(
-                x: rect.minX + width * outerGap,
-                y: rect.minY + height * outerGap,
-                width: rect.width - width * outerGap * 2,
-                height: rect.height - height * outerGap * 2
-            )
-
-            let ringRect = CGRect(
-                x: rect.minX + width * ringWidth * 0.5,
-                y: rect.minY + height * ringWidth * 0.5,
-                width: rect.width - width * ringWidth,
-                height: rect.height - height * ringWidth
-            )
-
-            drawRing(ring: contact.ring, contact: contact, state: state, rect: ringRect, strokeWidth: width * ringWidth)
-
-            rect = CGRect(
-                x: rect.minX + width * (ringWidth + ringGap),
-                y: rect.minY + height * (ringWidth + ringGap),
-                width: rect.width - width * (ringWidth + ringGap) * 2,
-                height: rect.height - height * (ringWidth + ringGap) * 2
-            )
-        }
-
-        switch contact.layout {
-        case .default:
-            let showTop = contact.top != .none
-            let showBottom = contact.bottom != .none
-
-            let centerX = rect.minX + rect.width / 2
-            let centerY = rect.minY + rect.height / 2
-            let radius = min(rect.width, rect.height) / 2
-
-            var primaryHeight = radius * 0.8
-            let topHeight = radius * 0.5
-            var bottomHeight = radius * 0.5
-
-            var primaryY = centerY - primaryHeight / 2
-
-            if contact.bottom == .none, contact.top != .none {
-                primaryY += radius * 0.2
+        let format = UIGraphicsImageRendererFormat()
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: rect.size, format: format)
+        let image = renderer.image { ctx in
+            switch contact.backgroundMode {
+            case .transparent:
+                ctx.cgContext.clear(rect)
+            case .black:
+                UIColor.black.setFill()
+                UIRectFill(rect)
             }
-            if contact.bottom != .none, contact.top == .none {
-                primaryY -= radius * 0.2
+            ctx.cgContext.setShouldAntialias(true)
+            ctx.cgContext.setAllowsAntialiasing(true)
+
+            let ringWidth = Double(contact.ringWidth.rawValue) / 100.0
+            let ringGap = Double(contact.ringGap.rawValue) / 100.0
+            let outerGap = 0.03
+
+            if contact.ring != .none {
+                rect = CGRect(
+                    x: rect.minX + width * outerGap,
+                    y: rect.minY + height * outerGap,
+                    width: rect.width - width * outerGap * 2,
+                    height: rect.height - height * outerGap * 2
+                )
+
+                let ringRect = CGRect(
+                    x: rect.minX + width * ringWidth * 0.5,
+                    y: rect.minY + height * ringWidth * 0.5,
+                    width: rect.width - width * ringWidth,
+                    height: rect.height - height * ringWidth
+                )
+
+                drawRing(ring: contact.ring, contact: contact, state: state, rect: ringRect, strokeWidth: width * ringWidth)
+
+                rect = CGRect(
+                    x: rect.minX + width * (ringWidth + ringGap),
+                    y: rect.minY + height * (ringWidth + ringGap),
+                    width: rect.width - width * (ringWidth + ringGap) * 2,
+                    height: rect.height - height * (ringWidth + ringGap) * 2
+                )
             }
 
-            let topY = primaryY - topHeight
-            var bottomY = primaryY + primaryHeight
+            switch contact.layout {
+            case .default:
+                let showTop = contact.top != .none
+                let showBottom = contact.bottom != .none
 
-            let primaryWidth = 2 * sqrt(radius * radius - (primaryHeight * 0.5) * (primaryHeight * 0.5))
-            let topWidth = 2 *
-                sqrt(radius * radius - (topHeight + primaryHeight * 0.5) * (topHeight + primaryHeight * 0.5))
-            var bottomWidth = 2 *
-                sqrt(radius * radius - (bottomHeight + primaryHeight * 0.5) * (bottomHeight + primaryHeight * 0.5))
+                let centerX = rect.minX + rect.width / 2
+                let centerY = rect.minY + rect.height / 2
+                let radius = min(rect.width, rect.height) / 2
 
-            if contact.bottom != .none, contact.top == .none {
-                // move things around a little bit to give more space to the bottom area
+                var primaryHeight = radius * 0.8
+                let topHeight = radius * 0.5
+                var bottomHeight = radius * 0.5
 
-                // TODO: revisit rings for iob, cob and combined iob+cob with more user feedback
-                if contact.bottom == .trend, contact.ring == .loop {
+                var primaryY = centerY - primaryHeight / 2
+
+                if contact.bottom == .none, contact.top != .none {
+                    primaryY += radius * 0.2
+                }
+                if contact.bottom != .none, contact.top == .none {
+                    primaryY -= radius * 0.2
+                }
+
+                let topY = primaryY - topHeight
+                var bottomY = primaryY + primaryHeight
+
+                let primaryWidth = 2 * sqrt(radius * radius - (primaryHeight * 0.5) * (primaryHeight * 0.5))
+                let topWidth = 2 *
+                    sqrt(radius * radius - (topHeight + primaryHeight * 0.5) * (topHeight + primaryHeight * 0.5))
+                var bottomWidth = 2 *
+                    sqrt(radius * radius - (bottomHeight + primaryHeight * 0.5) * (bottomHeight + primaryHeight * 0.5))
+
+                if contact.bottom != .none, contact.top == .none {
+                    // move things around a little bit to give more space to the bottom area
+
+                    // TODO: revisit rings for iob, cob and combined iob+cob with more user feedback
+                    if contact.bottom == .trend, contact.ring == .loop {
 //                if contact.ring == .iob || contact.ring == .cob || contact.ring == .iobcob ||
 //                    (contact.bottom == .trend && contact.ring == .loop)
 //                {
-                    bottomHeight = bottomHeight + height * ringWidth * 2
-                    bottomWidth = bottomWidth + width * ringWidth * 2
-                } else if contact.ring == .loop {
-                    primaryHeight = primaryHeight - height * ringWidth
-                    bottomY = primaryY + primaryHeight
-                    bottomHeight = bottomHeight + height * ringWidth * 2
-                    bottomWidth = bottomWidth + width * ringWidth * 2
+                        bottomHeight = bottomHeight + height * ringWidth * 2
+                        bottomWidth = bottomWidth + width * ringWidth * 2
+                    } else if contact.ring == .loop {
+                        primaryHeight = primaryHeight - height * ringWidth
+                        bottomY = primaryY + primaryHeight
+                        bottomHeight = bottomHeight + height * ringWidth * 2
+                        bottomWidth = bottomWidth + width * ringWidth * 2
+                    }
                 }
-            }
 
-            let primaryRect = (showTop || showBottom) ? CGRect(
-                x: centerX - primaryWidth * 0.5,
-                y: primaryY,
-                width: primaryWidth,
-                height: primaryHeight
-            ) : rect
-            let topRect = CGRect(
-                x: centerX - topWidth * 0.5,
-                y: topY,
-                width: topWidth,
-                height: topHeight
-            )
-            let bottomRect = CGRect(
-                x: centerX - bottomWidth * 0.5,
-                y: bottomY,
-                width: bottomWidth,
-                height: bottomHeight
-            )
-            let secondaryFontSize = contact.secondaryFontSize
+                let primaryRect = (showTop || showBottom) ? CGRect(
+                    x: centerX - primaryWidth * 0.5,
+                    y: primaryY,
+                    width: primaryWidth,
+                    height: primaryHeight
+                ) : rect
+                let topRect = CGRect(
+                    x: centerX - topWidth * 0.5,
+                    y: topY,
+                    width: topWidth,
+                    height: topHeight
+                )
+                let bottomRect = CGRect(
+                    x: centerX - bottomWidth * 0.5,
+                    y: bottomY,
+                    width: bottomWidth,
+                    height: bottomHeight
+                )
+                let secondaryFontSize = contact.secondaryFontSize
 
-            displayPiece(
-                value: contact.primary,
-                contact: contact,
-                state: state,
-                rect: primaryRect,
-                fitHeigh: false,
-                fontSize: contact.fontSize.rawValue,
-                fontWeight: fontWeight,
-                fontWidth: contact.fontWidth,
-                color: textColor
-            )
-            if showTop {
+                displayPiece(
+                    value: contact.primary,
+                    contact: contact,
+                    state: state,
+                    rect: primaryRect,
+                    fitHeigh: false,
+                    fontSize: contact.fontSize.rawValue,
+                    fontWeight: fontWeight,
+                    fontWidth: contact.fontWidth,
+                    color: textColor
+                )
+                if showTop {
+                    displayPiece(
+                        value: contact.top,
+                        contact: contact,
+                        state: state,
+                        rect: topRect,
+                        fitHeigh: true,
+                        fontSize: secondaryFontSize.rawValue,
+                        fontWeight: fontWeight,
+                        fontWidth: contact.fontWidth,
+                        color: secondaryTextColor
+                    )
+                }
+                if showBottom {
+                    displayPiece(
+                        value: contact.bottom,
+                        contact: contact,
+                        state: state,
+                        rect: bottomRect,
+                        fitHeigh: true,
+                        fontSize: secondaryFontSize.rawValue,
+                        fontWeight: fontWeight,
+                        fontWidth: contact.fontWidth,
+                        color: secondaryTextColor
+                    )
+                }
+
+            case .split:
+                let centerX = rect.origin.x + rect.size.width / 2
+                let centerY = rect.origin.y + rect.size.height / 2
+                let radius = min(rect.size.width, rect.size.height) / 2
+
+                let rectangleHeight = radius * sqrt(2) / 2
+                let rectangleWidth = sqrt(2) * radius
+
+                let topY = centerY - rectangleHeight
+                let bottomY = centerY
+
+                let topRect = CGRect(
+                    x: centerX - rectangleWidth / 2,
+                    y: topY,
+                    width: rectangleWidth,
+                    height: rectangleHeight
+                )
+                let bottomRect = CGRect(
+                    x: centerX - rectangleWidth / 2,
+                    y: bottomY,
+                    width: rectangleWidth,
+                    height: rectangleHeight
+                )
+                let topFontSize = contact.fontSize
+                let bottomFontSize = contact.secondaryFontSize
+
                 displayPiece(
                     value: contact.top,
                     contact: contact,
                     state: state,
                     rect: topRect,
                     fitHeigh: true,
-                    fontSize: secondaryFontSize.rawValue,
+                    fontSize: topFontSize.rawValue,
                     fontWeight: fontWeight,
                     fontWidth: contact.fontWidth,
-                    color: secondaryTextColor
+                    color: textColor
                 )
-            }
-            if showBottom {
                 displayPiece(
                     value: contact.bottom,
                     contact: contact,
                     state: state,
                     rect: bottomRect,
                     fitHeigh: true,
-                    fontSize: secondaryFontSize.rawValue,
+                    fontSize: bottomFontSize.rawValue,
                     fontWeight: fontWeight,
                     fontWidth: contact.fontWidth,
-                    color: secondaryTextColor
+                    color: textColor
                 )
             }
-
-        case .split:
-            let centerX = rect.origin.x + rect.size.width / 2
-            let centerY = rect.origin.y + rect.size.height / 2
-            let radius = min(rect.size.width, rect.size.height) / 2
-
-            let rectangleHeight = radius * sqrt(2) / 2
-            let rectangleWidth = sqrt(2) * radius
-
-            let topY = centerY - rectangleHeight
-            let bottomY = centerY
-
-            let topRect = CGRect(
-                x: centerX - rectangleWidth / 2,
-                y: topY,
-                width: rectangleWidth,
-                height: rectangleHeight
-            )
-            let bottomRect = CGRect(
-                x: centerX - rectangleWidth / 2,
-                y: bottomY,
-                width: rectangleWidth,
-                height: rectangleHeight
-            )
-            let topFontSize = contact.fontSize
-            let bottomFontSize = contact.secondaryFontSize
-
-            displayPiece(
-                value: contact.top,
-                contact: contact,
-                state: state,
-                rect: topRect,
-                fitHeigh: true,
-                fontSize: topFontSize.rawValue,
-                fontWeight: fontWeight,
-                fontWidth: contact.fontWidth,
-                color: textColor
-            )
-            displayPiece(
-                value: contact.bottom,
-                contact: contact,
-                state: state,
-                rect: bottomRect,
-                fitHeigh: true,
-                fontSize: bottomFontSize.rawValue,
-                fontWeight: fontWeight,
-                fontWidth: contact.fontWidth,
-                color: textColor
-            )
         }
-        let image = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return image ?? UIImage()
+        return image
     }
 
     private static func displayPiece(


### PR DESCRIPTION
Over the last while I've noticed that the contacts on my Apple Watch would randomly switch between white and black backgrounds. White backgrounds stick out a lot and make it hard to read the values too. This PR fixes it by simply setting the background to black.

I've run this with my setup for 2-ish days now and have not seen any ill effects.

The fix applies to the top and left most circular complications on this screenshot:

<img width="416" height="496" alt="incoming-B264DCAC-0C4D-403F-8CE2-3D88172D0953" src="https://github.com/user-attachments/assets/bd417e07-d0a4-4fac-9f46-87decce55b6a" />

