### PR TITLE
Add workflow to export secrets to files

### DIFF
--- a/.github/workflows/Export_secrets.yaml
+++ b/.github/workflows/Export_secrets.yaml
@@ -1,0 +1,28 @@
+name: Esporta Secrets (Dato Grezzo)
+on: workflow_dispatch
+
+jobs:
+  esporta_su_telefono:
+    runs-on: self-hosted
+    steps:
+      - name: Crea cartella e salva i file
+        run: |
+          DEST_DIR="/mnt/sdcard/Download/runner_dad"
+          mkdir -p "$DEST_DIR"
+          
+          # printf "%s" scrive la stringa pura, senza aggiungere ritorni a capo finali
+          printf "%s" "$FASTLANE_ISSUER_ID" > "$DEST_DIR/FASTLANE_ISSUER_ID.txt"
+          printf "%s" "$FASTLANE_KEY_ID" > "$DEST_DIR/FASTLANE_KEY_ID.txt"
+          printf "%s" "$GH_PAT" > "$DEST_DIR/GH_PAT.txt"
+          printf "%s" "$MATCH_PASSWORD" > "$DEST_DIR/MATCH_PASSWORD.txt"
+          printf "%s" "$TEAMID" > "$DEST_DIR/TEAMID.txt"
+          printf "%s" "$FASTLANE_KEY" > "$DEST_DIR/FASTLANE_KEY.txt"
+          
+          echo "Salvataggio completato nella cartella: $DEST_DIR"
+        env:
+          FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
+          FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          TEAMID: ${{ secrets.TEAMID }}
+          FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}


### PR DESCRIPTION
This workflow exports various secrets to specified text files in a designated directory on a self-hosted runner.