### PR TITLE
Fix non-atomic append in the log file writer

### DIFF
--- a/Trio/Sources/Logger/IssueReporter/SimpleLogReporter.swift
+++ b/Trio/Sources/Logger/IssueReporter/SimpleLogReporter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftDate
+import System
 
 final class SimpleLogReporter: IssueReporter {
     private let fileManager = FileManager.default
@@ -111,16 +112,16 @@ extension SimpleLogReporter {
 }
 
 private extension Data {
+    /// `O_APPEND` + a single `write(2)`: seek-then-write loses lines when another writer in the
+    /// process appends to the same file.
     func append(fileURL: URL) throws {
-        if let fileHandle = FileHandle(forWritingAtPath: fileURL.path) {
-            defer {
-                fileHandle.closeFile()
-            }
-            fileHandle.seekToEndOfFile()
-            fileHandle.write(self)
-        } else {
-            try write(to: fileURL, options: .atomic)
-        }
+        let descriptor = try FileDescriptor.open(
+            FilePath(fileURL.path),
+            .writeOnly,
+            options: [.append, .create],
+            permissions: [.ownerReadWrite, .groupRead, .otherRead]
+        )
+        try descriptor.closeAfter { _ = try descriptor.writeAll(self) }
     }
 }
 

--- a/Trio/Sources/Logger/IssueReporter/SimpleLogReporter.swift
+++ b/Trio/Sources/Logger/IssueReporter/SimpleLogReporter.swift
@@ -112,8 +112,6 @@ extension SimpleLogReporter {
 }
 
 private extension Data {
-    /// `O_APPEND` + a single `write(2)`: seek-then-write loses lines when another writer in the
-    /// process appends to the same file.
     func append(fileURL: URL) throws {
         let descriptor = try FileDescriptor.open(
             FilePath(fileURL.path),


### PR DESCRIPTION
SimpleLogReporter seeks to end-of-file and then writes, so anything appended between the two is overwritten. Harmless while it is the only writer of logs/log.txt, but pump manager plugins run in-process and loggerLock does not cover them. O_APPEND plus a single write(2) makes it atomic. appendToWatchLog uses the same extension.