### PR TITLE
Use unique ids to draw forecast lines

### DIFF
--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/ForecastView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/ForecastView.swift
@@ -73,7 +73,7 @@ struct ForecastView: ChartContent {
     }
 
     private func drawForecastsLines() -> some ChartContent {
-        ForEach(preprocessedData, id: \.id) { tuple in
+        ForEach(preprocessedData, id: \.forecastValue.objectID) { tuple in
             let forecastValue = tuple.forecastValue
             let forecast = tuple.forecast
             let valueAsDecimal = Decimal(forecastValue.value)


### PR DESCRIPTION
### Problem

`ForecastView.drawForecastsLines()` keyed its `ForEach` on `\.id`:

```swift
ForEach(preprocessedData, id: \.id) { tuple in
```

That id isn't unique per row. `fetchForecastHierarchy` mints one `UUID()` per
*forecast*, and `ForecastSetup` stamps it onto every value in that forecast — so
~240 rows share ~5 identities. Duplicate ids in a `ForEach` are undefined
behaviour; SwiftUI may collapse them, leaving each series a single point and a
`LineMark` nothing to connect.

The cone is unaffected (`ForEach(0 ..< n, id: \.self)`), as is the Live Activity,
which uses the same unique-index pattern.

### Fix

```swift
ForEach(preprocessedData, id: \.forecastValue.objectID) { tuple in
```

Every row is a distinct `ForecastValue` managed object, so its `objectID` is
unique by construction and stable across fetches — no allocation, no positional
identity. Series grouping comes from `foregroundStyle(by:)`, not `ForEach`
identity, so lines neither merge nor split.

### Why it needs a fix

It seems we've just been lucky until now, but building with Xcode 27 causes the forecast lines to not display at all in the main chart because of this.