### PR TITLE
Enter remote meals without a note

### DIFF
--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
@@ -63,7 +63,7 @@ extension TrioRemoteControl {
         let mealEntry = CarbsEntry(
             id: UUID().uuidString, createdAt: Date(), actualDate: actualDate,
             carbs: carbsDecimal ?? 0, fat: fatDecimal, protein: proteinDecimal,
-            note: nil, enteredBy: CarbsEntry.local, isFPU: false,
+            note: "📡", enteredBy: CarbsEntry.local, isFPU: false,
             fpuID: fatDecimal ?? 0 > 0 || proteinDecimal ?? 0 > 0 ? UUID().uuidString : nil
         )
 

--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Meal.swift
@@ -63,7 +63,7 @@ extension TrioRemoteControl {
         let mealEntry = CarbsEntry(
             id: UUID().uuidString, createdAt: Date(), actualDate: actualDate,
             carbs: carbsDecimal ?? 0, fat: fatDecimal, protein: proteinDecimal,
-            note: "Remote meal command", enteredBy: CarbsEntry.local, isFPU: false,
+            note: nil, enteredBy: CarbsEntry.local, isFPU: false,
             fpuID: fatDecimal ?? 0 > 0 || proteinDecimal ?? 0 > 0 ? UUID().uuidString : nil
         )
 


### PR DESCRIPTION
Carbs entered from a remote meal command get the note "Remote meal command". Trio uploads the carb note in both notes and foodType, and Nightscout prints foodType as text next to the carb entry on the chart, so every remotely entered meal ends up labeled on the graph.

This drops the note, so remote meals render like any other carb entry.