### PR TITLE
Add Smart advertisement protocol parser

### DIFF
--- a/DeveloperDocs/SmartCGM/advertisement-protocol.md
+++ b/DeveloperDocs/SmartCGM/advertisement-protocol.md
@@ -1,0 +1,59 @@
+# Smart / LinX advertisement protocol
+
+This document describes the manufacturer payload used by the tested MicroTech
+Medical Smart / LinX sensor family. This first contribution is intentionally
+limited to parsing and deduplication. It does not register a CGM, scan for a
+sensor, connect to Bluetooth services, or deliver glucose to Trio.
+
+## Evidence and privacy
+
+The layout and checksum were verified against controlled physical-device
+observations from a Smart GX-01S. Raw captures are not included because they can
+contain health data and session timing. The test suite instead uses fixed,
+synthetic protocol vectors.
+
+The evidence currently applies only to the tested Smart GX-01S behavior. Other
+MicroTech or white-label models and firmware revisions require separate
+validation.
+
+## Manufacturer payload
+
+The parser accepts manufacturer data whose first 22 bytes have this layout:
+
+| Offset | Length | Field |
+| --- | ---: | --- |
+| 0 | 2 | Little-endian company identifier `0x0059` |
+| 2 | 2 | Little-endian session minute |
+| 4 | 1 | Sensor status |
+| 5 | 1 | Calibration/temperature status |
+| 6 | 1 | Signed trend value |
+| 7 | 2 | Current glucose word |
+| 9 | 1 | Current quality |
+| 10 | 2 | Previous-minute glucose word |
+| 12 | 1 | Previous-minute quality |
+| 13 | 2 | Two-minutes-ago glucose word |
+| 15 | 1 | Two-minutes-ago quality |
+| 16 | 2 | Reserved bytes |
+| 18 | 4 | Little-endian checksum |
+
+Each glucose word uses the lower 10 bits for the value and bit 15 as the
+validity flag. Bytes after the first 22 are transport-specific and are ignored.
+
+## Checksum
+
+The checksum covers bytes 2 through 17:
+
+1. Read the 16 bytes as four little-endian 32-bit words.
+2. Add the words with wrapping 32-bit arithmetic.
+3. Reduce the result modulo `0x7FA777`.
+4. For each payload byte, XOR it into the high byte of the accumulator and run
+   eight MSB-first CRC steps using polynomial `0x04C11DB7`.
+5. Compare the resulting 32-bit value with the little-endian checksum at bytes
+   18 through 21.
+
+## Delivery boundary
+
+Parsing a valid packet does not make it suitable for therapy. A future direct
+CGM contribution must separately validate lifecycle state, data quality,
+freshness, restoration, sensor ownership, and failure behavior before admitting
+readings to Trio's glucose pipeline.

--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A5A100000000000000000002 /* SmartAdvertisement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A100000000000000000001 /* SmartAdvertisement.swift */; };
+		A5A100000000000000000004 /* SmartAdvertisementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A100000000000000000003 /* SmartAdvertisementTests.swift */; };
 		041D1E995A6AE92E9289DC49 /* TreatmentsDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D1A7CA8C10C4403D4BBFA7 /* TreatmentsDataFlow.swift */; };
 		0D9A5E34A899219C5C4CDFAF /* HistoryStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9455FA2D92E77A6C4AFED8A3 /* HistoryStateModel.swift */; };
 		110AEDE32C5193D200615CC9 /* BolusIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110AEDE02C5193D100615CC9 /* BolusIntent.swift */; };
@@ -1091,6 +1093,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A5A100000000000000000001 /* SmartAdvertisement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartAdvertisement.swift; sourceTree = "<group>"; };
+		A5A100000000000000000003 /* SmartAdvertisementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartAdvertisementTests.swift; sourceTree = "<group>"; };
 		10E61A0885164081B57C357C /* NightscoutUploadSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightscoutUploadSerializer.swift; sourceTree = "<group>"; };
 		110AEDE02C5193D100615CC9 /* BolusIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BolusIntent.swift; sourceTree = "<group>"; };
 		110AEDE12C5193D100615CC9 /* BolusIntentRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BolusIntentRequest.swift; sourceTree = "<group>"; };
@@ -2806,6 +2810,7 @@
 		3856933F270B57A00002C50D /* CGM */ = {
 			isa = PBXGroup;
 			children = (
+				A5A100000000000000000001 /* SmartAdvertisement.swift */,
 				CEE9A65A2BBB41AD00EB5194 /* Calibrations */,
 				F816825F28DB441800054060 /* BluetoothTransmitter.swift */,
 				F816825D28DB441200054060 /* HeartBeatManager.swift */,
@@ -3156,6 +3161,7 @@
 		38FCF3EE25E9028E0078B0D1 /* TrioTests */ = {
 			isa = PBXGroup;
 			children = (
+				A5A100000000000000000003 /* SmartAdvertisementTests.swift */,
 				DDDD0FFD2F4E231600F9C645 /* Mocks */,
 				DDDD0FFA2F4E22C000F9C645 /* GlucoseSmoothingTests.swift */,
 				DDDD0FFC2F4E22C000F9C645 /* GlucoseNativeConversionTests.swift */,
@@ -5165,6 +5171,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5A100000000000000000002 /* SmartAdvertisement.swift in Sources */,
 				DD5DC9F12CF3D97C00AB8703 /* AdjustmentsStateModel+Overrides.swift in Sources */,
 				3811DE2325C9D48300A708ED /* MainDataFlow.swift in Sources */,
 				C2A0A42F2CE03131003B98E8 /* ConstantValues.swift in Sources */,
@@ -5909,6 +5916,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5A100000000000000000004 /* SmartAdvertisementTests.swift in Sources */,
 				3B5CD2C92D4AECD500CE213C /* ProfileCarbsTests.swift in Sources */,
 				3BEDC9932EEB27B600AC6492 /* IobConsecutiveEventsTests.swift in Sources */,
 				3B1DB90F2E63C14C00BD814B /* DetermineBasalLowEventualGlucoseTests.swift in Sources */,

--- a/Trio/Sources/APS/CGM/SmartAdvertisement.swift
+++ b/Trio/Sources/APS/CGM/SmartAdvertisement.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// A glucose record carried in the manufacturer data advertised by Smart/LinX sensors.
+struct SmartAdvertisement: Equatable {
+    struct GlucoseRecord: Equatable {
+        let glucose: UInt16
+        let quality: UInt8
+        let isValid: Bool
+    }
+
+    static let companyIdentifier: UInt16 = 0x0059
+    static let payloadLength = 22
+
+    let minutesSinceStart: UInt16
+    let status: UInt8
+    let calibrationTemperatureStatus: UInt8
+    let trend: Int8
+    let current: GlucoseRecord
+    let previous: [GlucoseRecord]
+    let checksum: UInt32
+
+    /// Returns the records carried by one advertisement in chronological order.
+    var chronologicalRecords: [(minutesSinceStart: UInt16, record: GlucoseRecord)] {
+        var records: [(minutesSinceStart: UInt16, record: GlucoseRecord)] = []
+        if minutesSinceStart >= 2, previous.indices.contains(1) {
+            records.append((minutesSinceStart - 2, previous[1]))
+        }
+        if minutesSinceStart >= 1, previous.indices.contains(0) {
+            records.append((minutesSinceStart - 1, previous[0]))
+        }
+        records.append((minutesSinceStart, current))
+        return records
+    }
+
+    init?(manufacturerData: Data) {
+        guard manufacturerData.count >= Self.payloadLength else { return nil }
+
+        // Some Smart/LinX firmware appends transport-specific bytes after the
+        // 22-byte payload. They are not covered by the protocol checksum.
+        let bytes = [UInt8](manufacturerData.prefix(Self.payloadLength))
+        guard Self.uint16(bytes, at: 0) == Self.companyIdentifier else { return nil }
+
+        let checksum = Self.uint32(bytes, at: 18)
+        guard checksum == Self.calculateChecksum(bytes) else { return nil }
+
+        minutesSinceStart = Self.uint16(bytes, at: 2)
+        status = bytes[4]
+        calibrationTemperatureStatus = bytes[5]
+        trend = Int8(bitPattern: bytes[6])
+        current = Self.glucoseRecord(bytes, wordOffset: 7, qualityOffset: 9)
+        previous = [
+            Self.glucoseRecord(bytes, wordOffset: 10, qualityOffset: 12),
+            Self.glucoseRecord(bytes, wordOffset: 13, qualityOffset: 15)
+        ]
+        self.checksum = checksum
+    }
+
+    private static func glucoseRecord(
+        _ bytes: [UInt8],
+        wordOffset: Int,
+        qualityOffset: Int
+    ) -> GlucoseRecord {
+        let word = uint16(bytes, at: wordOffset)
+        return GlucoseRecord(
+            glucose: word & 0x03FF,
+            quality: bytes[qualityOffset],
+            isValid: word & 0x8000 != 0
+        )
+    }
+
+    private static func calculateChecksum(_ bytes: [UInt8]) -> UInt32 {
+        let payload = Array(bytes[2 ..< 18])
+        // The sensor performs this sum in a 32-bit register and discards carry
+        // before applying the modulus.
+        let sum = stride(from: 0, to: payload.count, by: 4).reduce(UInt32(0)) { partial, offset in
+            partial &+ uint32(payload, at: offset)
+        }
+        var crc = sum % 0x7FA777
+
+        for byte in payload {
+            crc ^= UInt32(byte) << 24
+            for _ in 0 ..< 8 {
+                crc = crc & 0x8000_0000 != 0
+                    ? (crc << 1) ^ 0x04C1_1DB7
+                    : crc << 1
+            }
+        }
+
+        return crc
+    }
+
+    private static func uint16(_ bytes: [UInt8], at offset: Int) -> UInt16 {
+        UInt16(bytes[offset]) | UInt16(bytes[offset + 1]) << 8
+    }
+
+    private static func uint32(_ bytes: [UInt8], at offset: Int) -> UInt32 {
+        UInt32(bytes[offset]) |
+            UInt32(bytes[offset + 1]) << 8 |
+            UInt32(bytes[offset + 2]) << 16 |
+            UInt32(bytes[offset + 3]) << 24
+    }
+}
+
+/// Suppresses repeated callbacks carrying the same sensor minute and checksum.
+struct SmartAdvertisementDeduplicator {
+    private var lastForwarded: [UUID: (minute: UInt16, checksum: UInt32)] = [:]
+
+    mutating func shouldForward(
+        peripheralIdentifier: UUID,
+        advertisement: SmartAdvertisement
+    ) -> Bool {
+        let fingerprint = (
+            minute: advertisement.minutesSinceStart,
+            checksum: advertisement.checksum
+        )
+        if let previous = lastForwarded[peripheralIdentifier],
+           previous.minute == fingerprint.minute,
+           previous.checksum == fingerprint.checksum
+        {
+            return false
+        }
+        lastForwarded[peripheralIdentifier] = fingerprint
+        return true
+    }
+}

--- a/TrioTests/SmartAdvertisementTests.swift
+++ b/TrioTests/SmartAdvertisementTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import Trio
+
+@Suite("Smart Advertisement Tests") struct SmartAdvertisementTests {
+    // These fixtures are synthetic protocol vectors. They do not contain
+    // production sensor identifiers, timestamps, or health data.
+    private let validPayload = "5900D2040000FE7B805F7A805E79805D0000858BCA5B"
+    private let overflowPayload = "5900FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF938CC73A"
+
+    @Test("Parses a valid synthetic Smart advertisement") func parsesAdvertisement() throws {
+        let advertisement = try #require(
+            SmartAdvertisement(manufacturerData: try data(from: validPayload))
+        )
+
+        #expect(advertisement.minutesSinceStart == 1234)
+        #expect(advertisement.status == 0)
+        #expect(advertisement.calibrationTemperatureStatus == 0)
+        #expect(advertisement.trend == -2)
+        #expect(advertisement.current == .init(glucose: 123, quality: 95, isValid: true))
+        #expect(advertisement.previous == [
+            .init(glucose: 122, quality: 94, isValid: true),
+            .init(glucose: 121, quality: 93, isValid: true)
+        ])
+    }
+
+    @Test("Rejects an invalid checksum") func rejectsInvalidChecksum() throws {
+        var bytes = [UInt8](try data(from: validPayload))
+        bytes[7] ^= 0x01
+        #expect(SmartAdvertisement(manufacturerData: Data(bytes)) == nil)
+    }
+
+    @Test("Rejects another manufacturer") func rejectsAnotherManufacturer() throws {
+        var bytes = [UInt8](try data(from: validPayload))
+        bytes[0] = 0x58
+        #expect(SmartAdvertisement(manufacturerData: Data(bytes)) == nil)
+    }
+
+    @Test("Rejects incomplete advertisements") func rejectsIncompleteAdvertisement() throws {
+        let bytes = try data(from: validPayload)
+        #expect(SmartAdvertisement(manufacturerData: bytes.dropLast()) == nil)
+    }
+
+    @Test("Ignores trailing transport data") func acceptsTrailingTransportData() throws {
+        var bytes = try data(from: validPayload)
+        bytes.append(contentsOf: [0x01, 0x02, 0x03, 0x04, 0x05])
+        #expect(SmartAdvertisement(manufacturerData: bytes)?.minutesSinceStart == 1234)
+    }
+
+    @Test("Handles checksum sum overflow") func handlesChecksumOverflow() throws {
+        let advertisement = try #require(
+            SmartAdvertisement(manufacturerData: try data(from: overflowPayload))
+        )
+        #expect(advertisement.checksum == 0x3AC7_8C93)
+    }
+
+    @Test("Orders current and previous records chronologically") func ordersRecords() throws {
+        let advertisement = try #require(
+            SmartAdvertisement(manufacturerData: try data(from: validPayload))
+        )
+
+        #expect(advertisement.chronologicalRecords.map(\.minutesSinceStart) == [1232, 1233, 1234])
+        #expect(advertisement.chronologicalRecords.map(\.record.glucose) == [121, 122, 123])
+    }
+
+    @Test("Suppresses only repeated advertisements from the same peripheral") func suppressesDuplicates() throws {
+        let advertisement = try #require(
+            SmartAdvertisement(manufacturerData: try data(from: validPayload))
+        )
+        let firstPeripheral = UUID()
+        let secondPeripheral = UUID()
+        var deduplicator = SmartAdvertisementDeduplicator()
+
+        let firstResult = deduplicator.shouldForward(
+            peripheralIdentifier: firstPeripheral,
+            advertisement: advertisement
+        )
+        let repeatedResult = deduplicator.shouldForward(
+            peripheralIdentifier: firstPeripheral,
+            advertisement: advertisement
+        )
+        let secondPeripheralResult = deduplicator.shouldForward(
+            peripheralIdentifier: secondPeripheral,
+            advertisement: advertisement
+        )
+
+        #expect(firstResult)
+        #expect(!repeatedResult)
+        #expect(secondPeripheralResult)
+    }
+
+    private func data(from hex: String) throws -> Data {
+        let characters = Array(hex)
+        guard characters.count.isMultiple(of: 2) else {
+            throw TestError("Hex input must contain an even number of characters")
+        }
+
+        return try Data(stride(from: 0, to: characters.count, by: 2).map { offset in
+            let byte = String(characters[offset ... offset + 1])
+            guard let value = UInt8(byte, radix: 16) else {
+                throw TestError("Invalid hexadecimal byte: \(byte)")
+            }
+            return value
+        })
+    }
+}


### PR DESCRIPTION
## Summary

- add a parser for the 22-byte Smart / LinX manufacturer advertisement
- validate the MicroTech company identifier, payload checksum, glucose validity bits, quality fields, trend, and session minute
- expose the current and two previous records in chronological order
- deduplicate repeated callbacks per Bluetooth peripheral using session minute and checksum
- document the observed protocol boundary and privacy constraints

## Why

Smart / LinX sensors broadcast current and recent glucose records in manufacturer data. This focused change contributes only the tested protocol core so that its byte layout and checksum can be reviewed independently before any scanner, CGM manager, user interface, lifecycle handling, or glucose delivery is proposed.

This is related to #1264, but it is an independent, small implementation based on controlled physical-device validation. It does not import the linked community plugin.

## Safety and scope

- parsing alone never admits readings to Trio's glucose or therapy pipelines
- no Bluetooth scanning or connections
- no CGM registration or glucose delivery
- no activation, warmup, replacement, or user-interface behavior
- no changes to insulin delivery, the algorithm, signing, identifiers, assets, or CI
- test fixtures are synthetic and contain no production sensor identifiers, timestamps, or health data

Future contributions must separately validate lifecycle state, data quality, freshness, restoration, ownership, failure handling, and physical-device behavior before glucose can reach Trio.

## Validation

- 8 focused `SmartAdvertisementTests` passed
- full serialized `Trio Tests` suite: 638 total, 634 passed, 4 skipped, 0 failed
- clean Release simulator build passed with code signing disabled
- project file property-list validation passed
- whitespace and patch validation passed

All Xcode tests and builds were run through `Trio.xcworkspace` from the current `dev` branch.

## Review notes

Please pay particular attention to the checksum arithmetic, the interpretation of the validity bit, chronological ordering of the three records, and whether this protocol core should remain in Trio or eventually live in a dedicated manager package.
