### PR TITLE
Centralize override and temp target activation

### DIFF
--- a/Model/Helper/CustomNotification.swift
+++ b/Model/Helper/CustomNotification.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 
 extension Notification.Name {
@@ -8,21 +7,4 @@ extension Notification.Name {
     static let didUpdateTempTargetConfiguration = Notification.Name("didUpdateTempTargetConfiguration")
     static let liveActivityOrderDidChange = Notification.Name("liveActivityOrderDidChange")
     static let openFromGarminConnect = Notification.Name("Notification.Name.openFromGarminConnect")
-}
-
-func awaitNotification(_ name: Notification.Name) async {
-    await withCheckedContinuation { continuation in
-        var cancellable: AnyCancellable?
-
-        // Create a Combine publisher that listens for notifications
-        cancellable = Foundation.NotificationCenter.default
-            .publisher(for: name)
-            .sink { _ in
-                // When the notification is received, resume the awaiting task
-                continuation.resume()
-
-                // Cancel the subscription after the continuation has resumed
-                cancellable?.cancel()
-            }
-    }
 }

--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -425,6 +425,8 @@
 		AABB00022C54389F00211FAC /* TreatmentsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00012C54389F00211FAC /* TreatmentsSettingsView.swift */; };
 		AC19EF2C94084B5BA0175D1D /* SettingsSearchHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B83503461B4F8D97B30115 /* SettingsSearchHighlight.swift */; };
 		AD3D2CD42CD01B9EB8F26522 /* PumpConfigDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF65DA88F972B56090AD6AC3 /* PumpConfigDataFlow.swift */; };
+		B015AFF32E600000000D7351 /* AdjustmentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015AFF12E600000000D7351 /* AdjustmentManager.swift */; };
+		B015AFF52E600000000D7351 /* AdjustmentManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015AFF42E600000000D7351 /* AdjustmentManagerTests.swift */; };
 		B015AFE32E500000000D7351 /* BolusSafetyValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015AFE12E500000000D7351 /* BolusSafetyValidator.swift */; };
 		B015AFE52E500000000D7351 /* BolusSafetyValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B015AFE42E500000000D7351 /* BolusSafetyValidatorTests.swift */; };
 		B63C9D934FC54853BC4EF29A /* NightscoutUploadSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10E61A0885164081B57C357C /* NightscoutUploadSerializer.swift */; };
@@ -1483,6 +1485,8 @@
 		AABB00012C54389F00211FAC /* TreatmentsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreatmentsSettingsView.swift; sourceTree = "<group>"; };
 		AAFF91130F2FCCC7EBBA11AD /* BasalProfileEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorStateModel.swift; sourceTree = "<group>"; };
 		AF65DA88F972B56090AD6AC3 /* PumpConfigDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PumpConfigDataFlow.swift; sourceTree = "<group>"; };
+		B015AFF12E600000000D7351 /* AdjustmentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustmentManager.swift; sourceTree = "<group>"; };
+		B015AFF42E600000000D7351 /* AdjustmentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustmentManagerTests.swift; sourceTree = "<group>"; };
 		B015AFE12E500000000D7351 /* BolusSafetyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusSafetyValidator.swift; sourceTree = "<group>"; };
 		B015AFE42E500000000D7351 /* BolusSafetyValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusSafetyValidatorTests.swift; sourceTree = "<group>"; };
 		B3919BBB515547118D684CA2 /* SettingsSearchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsSearchTests.swift; sourceTree = "<group>"; };
@@ -2512,6 +2516,7 @@
 		3811DE9125C9D88200A708ED /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				B015AFF22E600000000D7351 /* Adjustments */,
 				BD1179262F4E22C100F90001 /* Alerts */,
 				3811DE9225C9D88200A708ED /* Appearance */,
 				DDA9AC072D67291600E6F1A9 /* AppVersionChecker */,
@@ -3111,6 +3116,7 @@
 				DDC6CA6C2DD90A2A0060EE25 /* LocalizationTests.swift */,
 				3B997DD22DC02AEF006B6BB2 /* JSONImporterData */,
 				BD8FC05C2D6618BE00B95AED /* BolusCalculatorTests */,
+				B015AFF62E600000000D7351 /* AdjustmentsTests */,
 				B015AFE62E500000000D7351 /* BolusSafetyTests */,
 				BD8FC0552D66187700B95AED /* CoreDataTests */,
 				38FCF3F125E9028E0078B0D1 /* Info.plist */,
@@ -3516,6 +3522,22 @@
 				18B49BC9587A59E3A347C1CD /* View */,
 			);
 			path = BasalProfileEditor;
+			sourceTree = "<group>";
+		};
+		B015AFF22E600000000D7351 /* Adjustments */ = {
+			isa = PBXGroup;
+			children = (
+				B015AFF12E600000000D7351 /* AdjustmentManager.swift */,
+			);
+			path = Adjustments;
+			sourceTree = "<group>";
+		};
+		B015AFF62E600000000D7351 /* AdjustmentsTests */ = {
+			isa = PBXGroup;
+			children = (
+				B015AFF42E600000000D7351 /* AdjustmentManagerTests.swift */,
+			);
+			path = AdjustmentsTests;
 			sourceTree = "<group>";
 		};
 		B015AFE22E500000000D7351 /* BolusSafety */ = {
@@ -5448,6 +5470,7 @@
 				38BF021B25E7D06400579895 /* PumpSettingsView.swift in Sources */,
 				3811DEEA25CA063400A708ED /* SyncAccess.swift in Sources */,
 				190EBCC829FF13AA00BA767D /* UserInterfaceSettingsStateModel.swift in Sources */,
+				B015AFF32E600000000D7351 /* AdjustmentManager.swift in Sources */,
 				B015AFE32E500000000D7351 /* BolusSafetyValidator.swift in Sources */,
 				DDF847EA2C5DABAC0049BB3B /* WatchConfigGarminView.swift in Sources */,
 				38BF021F25E7F0DE00579895 /* DeviceDataManager.swift in Sources */,
@@ -5920,6 +5943,7 @@
 				DD30BA002E0745C400DA677C /* DetermineBasalDeltaCalculationTests.swift in Sources */,
 				BD8FC05E2D6618CE00B95AED /* BolusCalculatorTests.swift in Sources */,
 				41740E936552456AAC0EDAC3 /* SettingsSearchTests.swift in Sources */,
+				B015AFF52E600000000D7351 /* AdjustmentManagerTests.swift in Sources */,
 				B015AFE52E500000000D7351 /* BolusSafetyValidatorTests.swift in Sources */,
 				BD8FC0712D661B0000B95AED /* TidepoolTherapySettingsTests.swift in Sources */,
 				CA03000000000000000010C2 /* AlertCatalogRegistryOmniFaultTests.swift in Sources */,

--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -30,6 +30,10 @@ protocol APSManager {
     func enactTempBasal(rate: Double, duration: TimeInterval) async
     func determineBasal() async throws
     func determineBasalSync() async throws
+    /// Recomputes the determination after something the algorithm reads has changed — an override,
+    /// a temp target. Skips itself while a loop is running, because that loop determines from the
+    /// same state, and never delays a loop start.
+    func recomputeDetermination() async
     func simulateDetermineBasal(
         simulatedCarbsAmount: Decimal,
         simulatedBolusAmount: Decimal,
@@ -76,6 +80,7 @@ enum APSError: LocalizedError {
 /// Ensures only one loop runs at a time via actor isolation
 private actor LoopGuard {
     private var isRunning = false
+    private var isRecomputing = false
 
     /// Atomically checks whether a new loop can start and marks it as running if so.
     func tryStart(minInterval: TimeInterval, lastLoopDate: Date, lastLoopStartDate: Date) -> Bool {
@@ -90,6 +95,19 @@ private actor LoopGuard {
 
     func finish() {
         isRunning = false
+    }
+
+    /// Claims the guard for a determination-only recompute. Refuses while a loop runs, and while
+    /// another recompute runs — a second one would compute the same state. `tryStart` ignores this
+    /// claim: a skipped loop has a therapy cost, an overlapping recompute only wastes work.
+    func tryStartRecompute() -> Bool {
+        guard !isRunning, !isRecomputing else { return false }
+        isRecomputing = true
+        return true
+    }
+
+    func finishRecompute() {
+        isRecomputing = false
     }
 }
 
@@ -556,6 +574,19 @@ final class BaseAPSManager: APSManager, Injectable {
 
     func determineBasalSync() async throws {
         _ = try await determineBasal()
+    }
+
+    func recomputeDetermination() async {
+        guard await loopGuard.tryStartRecompute() else {
+            debug(.apsManager, "Determination recompute skipped: loop or recompute in flight")
+            return
+        }
+        do {
+            try await determineBasal()
+        } catch {
+            debug(.apsManager, "Determination recompute failed: \(error)")
+        }
+        await loopGuard.finishRecompute()
     }
 
     func simulateDetermineBasal(

--- a/Trio/Sources/APS/APSManager.swift
+++ b/Trio/Sources/APS/APSManager.swift
@@ -29,11 +29,11 @@ protocol APSManager {
     var isSuspended: Bool { get }
     func enactTempBasal(rate: Double, duration: TimeInterval) async
     func determineBasal() async throws
+    /// Runs a determination outside the loop, after a treatment or adjustment changed what the
+    /// algorithm reads. Waits for a loop in flight to finish first, since that loop determined
+    /// before the change landed. Concurrent calls collapse into the one already running. Algorithm
+    /// errors propagate to the caller.
     func determineBasalSync() async throws
-    /// Recomputes the determination after something the algorithm reads has changed — an override,
-    /// a temp target. Skips itself while a loop is running, because that loop determines from the
-    /// same state, and never delays a loop start.
-    func recomputeDetermination() async
     func simulateDetermineBasal(
         simulatedCarbsAmount: Decimal,
         simulatedBolusAmount: Decimal,
@@ -80,7 +80,8 @@ enum APSError: LocalizedError {
 /// Ensures only one loop runs at a time via actor isolation
 private actor LoopGuard {
     private var isRunning = false
-    private var isRecomputing = false
+    private var isDeterminingStandalone = false
+    private var loopWaiters: [CheckedContinuation<Void, Never>] = []
 
     /// Atomically checks whether a new loop can start and marks it as running if so.
     func tryStart(minInterval: TimeInterval, lastLoopDate: Date, lastLoopStartDate: Date) -> Bool {
@@ -95,19 +96,28 @@ private actor LoopGuard {
 
     func finish() {
         isRunning = false
+        let waiters = loopWaiters
+        loopWaiters.removeAll()
+        waiters.forEach { $0.resume() }
     }
 
-    /// Claims the guard for a determination-only recompute. Refuses while a loop runs, and while
-    /// another recompute runs — a second one would compute the same state. `tryStart` ignores this
-    /// claim: a skipped loop has a therapy cost, an overlapping recompute only wastes work.
-    func tryStartRecompute() -> Bool {
-        guard !isRunning, !isRecomputing else { return false }
-        isRecomputing = true
+    /// Returns once no loop is running.
+    func waitForLoop() async {
+        guard isRunning else { return }
+        await withCheckedContinuation { loopWaiters.append($0) }
+    }
+
+    /// Claims the guard for a determination that runs outside the loop. Refuses while another one
+    /// runs, since it computes the same state. `tryStart` ignores this claim: a skipped loop has a
+    /// therapy cost, an overlapping determination only wastes work.
+    func tryStartStandaloneDetermination() -> Bool {
+        guard !isDeterminingStandalone else { return false }
+        isDeterminingStandalone = true
         return true
     }
 
-    func finishRecompute() {
-        isRecomputing = false
+    func finishStandaloneDetermination() {
+        isDeterminingStandalone = false
     }
 }
 
@@ -573,20 +583,18 @@ final class BaseAPSManager: APSManager, Injectable {
     }
 
     func determineBasalSync() async throws {
-        _ = try await determineBasal()
-    }
-
-    func recomputeDetermination() async {
-        guard await loopGuard.tryStartRecompute() else {
-            debug(.apsManager, "Determination recompute skipped: loop or recompute in flight")
+        await loopGuard.waitForLoop()
+        guard await loopGuard.tryStartStandaloneDetermination() else {
+            debug(.apsManager, "Standalone determination skipped: one is already running")
             return
         }
         do {
             try await determineBasal()
         } catch {
-            debug(.apsManager, "Determination recompute failed: \(error)")
+            await loopGuard.finishStandaloneDetermination()
+            throw error
         }
-        await loopGuard.finishRecompute()
+        await loopGuard.finishStandaloneDetermination()
     }
 
     func simulateDetermineBasal(

--- a/Trio/Sources/APS/Storage/OverrideStorage.swift
+++ b/Trio/Sources/APS/Storage/OverrideStorage.swift
@@ -289,7 +289,7 @@ final class BaseOverrideStorage: @preconcurrency OverrideStorage, Injectable {
             ofType: OverrideRunStored.self,
             onContext: context,
             predicate: NSPredicate(
-                format: "startDate >= %@ AND isUploadedToNS == %@",
+                format: "endDate >= %@ AND isUploadedToNS == %@",
                 Date.oneDayAgo as NSDate,
                 false as NSNumber
             ),

--- a/Trio/Sources/APS/Storage/TempTargetsStorage.swift
+++ b/Trio/Sources/APS/Storage/TempTargetsStorage.swift
@@ -8,7 +8,7 @@ protocol TempTargetsObserver {
 }
 
 protocol TempTargetsStorage {
-    func storeTempTarget(tempTarget: TempTarget) async throws
+    @discardableResult func storeTempTarget(tempTarget: TempTarget) async throws -> NSManagedObjectID
     func saveTempTargetsToStorage(_ targets: [TempTarget])
     func fetchForTempTargetPresets() async throws -> [NSManagedObjectID]
     func fetchScheduledTempTargets() async throws -> [NSManagedObjectID]
@@ -131,7 +131,7 @@ final class BaseTempTargetsStorage: TempTargetsStorage, Injectable {
         }
     }
 
-    func storeTempTarget(tempTarget: TempTarget) async throws {
+    @discardableResult func storeTempTarget(tempTarget: TempTarget) async throws -> NSManagedObjectID {
         let context = makeContext()
         context.name = "storeTempTarget"
 
@@ -141,7 +141,7 @@ final class BaseTempTargetsStorage: TempTargetsStorage, Injectable {
             presetCount = presets.count
         }
 
-        try await context.perform {
+        return try await context.perform {
             let newTempTarget = TempTargetStored(context: context)
             newTempTarget.date = tempTarget.createdAt
             newTempTarget.id = UUID()
@@ -167,12 +167,15 @@ final class BaseTempTargetsStorage: TempTargetsStorage, Injectable {
             }
 
             do {
-                guard context.hasChanges else { return }
-                try context.save()
+                if context.hasChanges {
+                    try context.save()
+                }
             } catch let error as NSError {
                 debug(.default, "\(DebuggingIdentifiers.failed) Failed to save new temp target with error: \(error.userInfo)")
                 throw error
             }
+
+            return newTempTarget.objectID
         }
     }
 
@@ -336,7 +339,7 @@ final class BaseTempTargetsStorage: TempTargetsStorage, Injectable {
             ofType: TempTargetRunStored.self,
             onContext: context,
             predicate: NSPredicate(
-                format: "startDate >= %@ AND isUploadedToNS == %@",
+                format: "endDate >= %@ AND isUploadedToNS == %@",
                 Date.oneDayAgo as NSDate,
                 false as NSNumber
             ),

--- a/Trio/Sources/Assemblies/ServiceAssembly.swift
+++ b/Trio/Sources/Assemblies/ServiceAssembly.swift
@@ -36,5 +36,9 @@ final class ServiceAssembly: Assembly {
         }
         container.register(IOBService.self) { r in BaseIOBService(resolver: r) }
         container.register(BolusSafetyValidator.self) { r in BaseBolusSafetyValidator(resolver: r) }
+        // Container scope: the manager serializes adjustment mutations across every entry point,
+        // so all callers share one instance.
+        container.register(AdjustmentManager.self) { r in BaseAdjustmentManager(resolver: r) }
+            .inObjectScope(.container)
     }
 }

--- a/Trio/Sources/Assemblies/ServiceAssembly.swift
+++ b/Trio/Sources/Assemblies/ServiceAssembly.swift
@@ -36,8 +36,6 @@ final class ServiceAssembly: Assembly {
         }
         container.register(IOBService.self) { r in BaseIOBService(resolver: r) }
         container.register(BolusSafetyValidator.self) { r in BaseBolusSafetyValidator(resolver: r) }
-        // Container scope: the manager serializes adjustment mutations across every entry point,
-        // so all callers share one instance.
         container.register(AdjustmentManager.self) { r in BaseAdjustmentManager(resolver: r) }
             .inObjectScope(.container)
     }

--- a/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+Overrides.swift
+++ b/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+Overrides.swift
@@ -233,8 +233,7 @@ extension Adjustments.StateModel {
                 await self.updateLatestOverrideConfigurationOfState(from: id)
                 await self.setCurrentOverride(from: id)
 
-                // perform determine basal sync to immediately apply override changes
-                try await apsManager.determineBasalSync()
+                await apsManager.recomputeDetermination()
             } catch {
                 debug(
                     .default,

--- a/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+Overrides.swift
+++ b/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+Overrides.swift
@@ -233,7 +233,7 @@ extension Adjustments.StateModel {
                 await self.updateLatestOverrideConfigurationOfState(from: id)
                 await self.setCurrentOverride(from: id)
 
-                await apsManager.recomputeDetermination()
+                try await apsManager.determineBasalSync()
             } catch {
                 debug(
                     .default,

--- a/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+TempTargets.swift
+++ b/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+TempTargets.swift
@@ -17,8 +17,7 @@ extension Adjustments.StateModel {
                 async let setTempTarget: () = setCurrentTempTarget(from: id)
                 _ = await (updateState, setTempTarget)
 
-                // perform determine basal sync to immediately apply temp target changes
-                try await apsManager.determineBasalSync()
+                await apsManager.recomputeDetermination()
             } catch {
                 debug(
                     .default,

--- a/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+TempTargets.swift
+++ b/Trio/Sources/Modules/Adjustments/AdjustmentsStateModel+Extensions/AdjustmentsStateModel+TempTargets.swift
@@ -17,7 +17,7 @@ extension Adjustments.StateModel {
                 async let setTempTarget: () = setCurrentTempTarget(from: id)
                 _ = await (updateState, setTempTarget)
 
-                await apsManager.recomputeDetermination()
+                try await apsManager.determineBasalSync()
             } catch {
                 debug(
                     .default,

--- a/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
+++ b/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
@@ -1,0 +1,487 @@
+import CoreData
+import Foundation
+import Swinject
+
+// MARK: - Public surface
+
+/// How a caller names the adjustment to activate.
+enum AdjustmentRef: Equatable {
+    /// A row the caller already holds. Saved rows only: a row that has never been saved carries a
+    /// temporary object ID, which resolves in no other context.
+    case objectID(NSManagedObjectID)
+    /// The preset's own identifier — `OverrideStored.id` / `TempTargetStored.id`.
+    case presetID(String)
+    /// The preset's display name, compared with surrounding whitespace trimmed on both sides.
+    /// Names are free text and may repeat, so the lowest order position wins.
+    case presetName(String)
+}
+
+/// The entry point a command came from. Travels into the log line and the Nightscout upload
+/// request, and is the only thing the manager knows about its caller.
+enum AdjustmentSource: String {
+    case app
+    case remote
+    case watch
+}
+
+/// What one command started or ended. Callers build their own acknowledgment, log line or toast
+/// from this.
+struct AdjustmentSummary: Equatable {
+    let name: String?
+    let startDate: Date
+    let endDate: Date?
+    /// Minutes, as stored on the adjustment.
+    let duration: Decimal?
+    let indefinite: Bool
+}
+
+struct AdjustmentOutcome: Equatable {
+    let started: AdjustmentSummary?
+    /// One entry per row that was enabled when the command arrived; each has a run entry.
+    let ended: [AdjustmentSummary]
+}
+
+enum AdjustmentError: LocalizedError, Equatable {
+    case presetNotFound(String)
+    case nothingActive
+    case persistenceFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .presetNotFound(name):
+            return String(localized: "Preset \"\(name)\" not found.", comment: "Adjustment preset not found")
+        case .nothingActive:
+            return String(localized: "Nothing is currently running.", comment: "No active adjustment to cancel")
+        case .persistenceFailed:
+            // The associated value carries the Core Data detail for the log, not for the reader.
+            return String(localized: "Could not save the change.", comment: "Adjustment could not be saved")
+        }
+    }
+}
+
+/// Single writer for override and temp target activation.
+///
+/// Every entry point — app UI, Shortcuts, remote control, watch, Nightscout import — routes
+/// activation and cancellation through this service, which performs the full sequence for each
+/// command: end every enabled adjustment and record each one as a run entry, enable the requested
+/// one, then apply the dependent side effects in a fixed order.
+///
+/// The run entry carries two jobs. It is the row the home chart renders as a finished adjustment
+/// (`OverrideView`), and it is the row that carries the real duration to Nightscout, which
+/// replaces the placeholder duration uploaded when the adjustment started
+/// (`OverrideStorage.getOverrideRunsNotYetUploadedToNightscout`). Both `isUploadedToNS` flags are
+/// cleared in the same transaction, which is what the Nightscout upload controllers key on
+/// (`BaseNightscoutManager.wireUploadControllers`).
+protocol AdjustmentManager {
+    @discardableResult func activateOverride(
+        _ preset: AdjustmentRef,
+        source: AdjustmentSource,
+        waitForUpload: Bool
+    ) async throws -> AdjustmentOutcome
+
+    @discardableResult func cancelOverride(source: AdjustmentSource, waitForUpload: Bool) async throws -> AdjustmentOutcome
+
+    @discardableResult func activateTempTarget(
+        _ preset: AdjustmentRef,
+        source: AdjustmentSource,
+        waitForUpload: Bool
+    ) async throws -> AdjustmentOutcome
+
+    @discardableResult func cancelTempTarget(source: AdjustmentSource, waitForUpload: Bool) async throws -> AdjustmentOutcome
+}
+
+extension AdjustmentManager {
+    @discardableResult func activateOverride(
+        _ preset: AdjustmentRef,
+        source: AdjustmentSource
+    ) async throws -> AdjustmentOutcome {
+        try await activateOverride(preset, source: source, waitForUpload: false)
+    }
+
+    @discardableResult func cancelOverride(source: AdjustmentSource) async throws -> AdjustmentOutcome {
+        try await cancelOverride(source: source, waitForUpload: false)
+    }
+
+    @discardableResult func activateTempTarget(
+        _ preset: AdjustmentRef,
+        source: AdjustmentSource
+    ) async throws -> AdjustmentOutcome {
+        try await activateTempTarget(preset, source: source, waitForUpload: false)
+    }
+
+    @discardableResult func cancelTempTarget(source: AdjustmentSource) async throws -> AdjustmentOutcome {
+        try await cancelTempTarget(source: source, waitForUpload: false)
+    }
+}
+
+// MARK: - Implementation
+
+final class BaseAdjustmentManager: AdjustmentManager, Injectable, @unchecked Sendable {
+    @Injected() private var tempTargetStorage: TempTargetsStorage!
+    @Injected() private var nightscoutManager: NightscoutManager!
+    @Injected() private var apsManager: APSManager!
+    @Injected() private var settingsManager: SettingsManager!
+
+    private let makeContext: () -> NSManagedObjectContext
+    private let serializer = AdjustmentSerializer()
+    /// Stands in for the determination step, so a caller can exercise the transaction on its own.
+    private let recompute: (@Sendable() async -> Void)?
+
+    init(
+        resolver: Resolver,
+        contextProvider: (() -> NSManagedObjectContext)? = nil,
+        recompute: (@Sendable() async -> Void)? = nil
+    ) {
+        makeContext = contextProvider ?? { CoreDataStack.shared.newTaskContext() }
+        self.recompute = recompute
+        injectServices(resolver)
+    }
+
+    // MARK: Overrides
+
+    @discardableResult func activateOverride(
+        _ preset: AdjustmentRef,
+        source: AdjustmentSource,
+        waitForUpload: Bool
+    ) async throws -> AdjustmentOutcome {
+        let outcome = try await serializer.run { try await self.commitOverride(activating: preset) }
+        debug(.service, "Override activated from \(source.rawValue): \(outcome.logDescription)")
+        await applyOverrideSideEffects(source: source, waitForUpload: waitForUpload)
+        return outcome
+    }
+
+    @discardableResult func cancelOverride(source: AdjustmentSource, waitForUpload: Bool) async throws -> AdjustmentOutcome {
+        let outcome = try await serializer.run { try await self.commitOverride(activating: nil) }
+        debug(.service, "Override cancelled from \(source.rawValue): \(outcome.logDescription)")
+        await applyOverrideSideEffects(source: source, waitForUpload: waitForUpload)
+        return outcome
+    }
+
+    /// `activating == nil` cancels whatever runs. Ending the active rows and enabling the
+    /// requested one share one transaction, so no command can leave the app with nothing enabled
+    /// or with two adjustments enabled at once.
+    private func commitOverride(activating preset: AdjustmentRef?) async throws -> AdjustmentOutcome {
+        let context = makeContext()
+        context.name = "commitOverride"
+
+        return try await context.perform {
+            let now = Date()
+            let target = try preset.map { try self.fetchOverride($0, in: context) }
+            let active = try self.fetchActiveOverrides(in: context)
+
+            if preset == nil, active.isEmpty {
+                throw AdjustmentError.nothingActive
+            }
+
+            var ended: [AdjustmentSummary] = []
+            // Every enabled row gets its own run entry. When the requested preset is the row that
+            // is already running, the enable below restarts it and this entry holds the segment
+            // that has elapsed.
+            for row in active {
+                let endDate = self.effectiveEndDate(start: row.date, duration: row.duration, indefinite: row.indefinite, now: now)
+                let run = OverrideRunStored(context: context)
+                run.id = UUID()
+                run.name = row.name
+                run.startDate = row.date ?? endDate
+                run.endDate = endDate
+                run.target = row.target ?? 0
+                run.override = row
+                run.isUploadedToNS = false
+
+                row.enabled = false
+                ended.append(AdjustmentSummary(row: row, startDate: run.startDate ?? endDate, endDate: endDate))
+            }
+
+            var started: AdjustmentSummary?
+            if let target {
+                target.enabled = true
+                target.date = now
+                target.isUploadedToNS = false
+                started = AdjustmentSummary(row: target, startDate: now, endDate: nil)
+            }
+
+            try self.save(context)
+            return AdjustmentOutcome(started: started, ended: ended)
+        }
+    }
+
+    private func applyOverrideSideEffects(source: AdjustmentSource, waitForUpload: Bool) async {
+        if waitForUpload {
+            await nightscoutManager.uploadOverrides()
+        } else {
+            requestNightscoutUpload([.overrides], source: source.rawValue)
+        }
+        Foundation.NotificationCenter.default.post(name: .didUpdateOverrideConfiguration, object: nil)
+        recomputeDetermination()
+    }
+
+    // MARK: Temp targets
+
+    @discardableResult func activateTempTarget(
+        _ preset: AdjustmentRef,
+        source: AdjustmentSource,
+        waitForUpload: Bool
+    ) async throws -> AdjustmentOutcome {
+        let (outcome, orefTarget) = try await serializer.run { try await self.commitTempTarget(activating: preset) }
+        debug(.service, "Temp target activated from \(source.rawValue): \(outcome.logDescription)")
+        await applyTempTargetSideEffects(orefTarget: orefTarget, source: source, waitForUpload: waitForUpload)
+        return outcome
+    }
+
+    @discardableResult func cancelTempTarget(source: AdjustmentSource, waitForUpload: Bool) async throws -> AdjustmentOutcome {
+        let (outcome, orefTarget) = try await serializer.run { try await self.commitTempTarget(activating: nil) }
+        debug(.service, "Temp target cancelled from \(source.rawValue): \(outcome.logDescription)")
+        await applyTempTargetSideEffects(orefTarget: orefTarget, source: source, waitForUpload: waitForUpload)
+        return outcome
+    }
+
+    /// Returns the outcome plus the entry to hand oref, which has to be built inside the
+    /// transaction while the row is still safe to read on this context.
+    private func commitTempTarget(activating preset: AdjustmentRef?) async throws -> (AdjustmentOutcome, TempTarget?) {
+        let context = makeContext()
+        context.name = "commitTempTarget"
+
+        return try await context.perform {
+            let now = Date()
+            let target = try preset.map { try self.fetchTempTarget($0, in: context) }
+            let active = try self.fetchActiveTempTargets(in: context)
+
+            if preset == nil, active.isEmpty {
+                throw AdjustmentError.nothingActive
+            }
+
+            var ended: [AdjustmentSummary] = []
+            for row in active {
+                let endDate = self.effectiveEndDate(start: row.date, duration: row.duration, indefinite: false, now: now)
+                let run = TempTargetRunStored(context: context)
+                run.id = UUID()
+                run.name = row.name
+                run.startDate = row.date ?? endDate
+                run.endDate = endDate
+                run.target = row.target ?? 0
+                run.tempTarget = row
+                run.isUploadedToNS = false
+
+                row.enabled = false
+                ended.append(AdjustmentSummary(row: row, startDate: run.startDate ?? endDate, endDate: endDate))
+            }
+
+            var started: AdjustmentSummary?
+            var orefTarget: TempTarget?
+            if let target {
+                target.enabled = true
+                target.date = now
+                target.isUploadedToNS = false
+                started = AdjustmentSummary(row: target, startDate: now, endDate: nil)
+                orefTarget = self.orefTempTarget(for: target, at: now)
+            } else {
+                // oref reads the newest entry in the temp targets file, so the entry that ends a
+                // temp target carries the commit's own timestamp: file order then follows commit
+                // order even when two commands land back to back.
+                orefTarget = TempTarget.cancel(at: now)
+            }
+
+            try self.save(context)
+            return (AdjustmentOutcome(started: started, ended: ended), orefTarget)
+        }
+    }
+
+    private func applyTempTargetSideEffects(orefTarget: TempTarget?, source: AdjustmentSource, waitForUpload: Bool) async {
+        if let orefTarget {
+            // The write lands on the storage's own queue after this returns, so a determination
+            // that starts immediately can still read the previous file contents.
+            tempTargetStorage.saveTempTargetsToStorage([orefTarget])
+        }
+        if waitForUpload {
+            await nightscoutManager.uploadTempTargets()
+        } else {
+            requestNightscoutUpload([.tempTargets], source: source.rawValue)
+        }
+        Foundation.NotificationCenter.default.post(name: .didUpdateTempTargetConfiguration, object: nil)
+        recomputeDetermination()
+    }
+
+    /// The entry oref reads from the temp targets file. `halfBasalTarget` falls back to the
+    /// preference, which is what the algorithm assumes when a preset carries none.
+    private func orefTempTarget(for row: TempTargetStored, at date: Date) -> TempTarget {
+        TempTarget(
+            name: row.name,
+            createdAt: date,
+            targetTop: row.target?.decimalValue,
+            targetBottom: row.target?.decimalValue,
+            duration: row.duration?.decimalValue ?? 0,
+            enteredBy: TempTarget.local,
+            reason: TempTarget.custom,
+            isPreset: row.isPreset,
+            enabled: true,
+            halfBasalTarget: row.halfBasalTarget?.decimalValue ?? settingsManager.preferences.halfBasalExerciseTarget
+        )
+    }
+
+    // MARK: Shared
+
+    /// A determination is only recomputed while the loop is idle; a loop in flight produces one of
+    /// its own. Delivery follows the loop either way, so this refreshes the forecast and the
+    /// pills, not the pump.
+    /// Refreshes the determination and the forecast in the background: a command's outcome does not
+    /// depend on it, so callers acknowledge as soon as the transaction has committed.
+    ///
+    /// `APSManager` owns the decision to run: it holds the loop guard, skips a recompute while a
+    /// loop is in flight, and enacts nothing — delivery follows the loop either way.
+    private func recomputeDetermination() {
+        Task { [weak self] in
+            guard let self else { return }
+            if let recompute {
+                await recompute()
+                return
+            }
+            await apsManager.recomputeDetermination()
+        }
+    }
+
+    /// Runs end when they are cancelled, or when their duration ran out while they were still
+    /// enabled, whichever came first.
+    private func effectiveEndDate(start: Date?, duration: NSDecimalNumber?, indefinite: Bool, now: Date) -> Date {
+        guard !indefinite,
+              let start,
+              let minutes = duration?.doubleValue,
+              minutes > 0
+        else { return now }
+        let expiry = start.addingTimeInterval(minutes * 60)
+        return min(now, expiry)
+    }
+
+    private func save(_ context: NSManagedObjectContext) throws {
+        guard context.hasChanges else { return }
+        do {
+            try context.save()
+        } catch {
+            throw AdjustmentError.persistenceFailed(String(describing: error))
+        }
+    }
+
+    private func fetchActiveOverrides(in context: NSManagedObjectContext) throws -> [OverrideStored] {
+        let request: NSFetchRequest<OverrideStored> = OverrideStored.fetchRequest()
+        request.predicate = NSPredicate.lastActiveOverride
+        request.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+        return try context.fetch(request)
+    }
+
+    private func fetchActiveTempTargets(in context: NSManagedObjectContext) throws -> [TempTargetStored] {
+        let request: NSFetchRequest<TempTargetStored> = TempTargetStored.fetchRequest()
+        request.predicate = NSPredicate.lastActiveTempTarget
+        request.sortDescriptors = [NSSortDescriptor(key: "orderPosition", ascending: true)]
+        return try context.fetch(request)
+    }
+
+    private func fetchOverride(_ ref: AdjustmentRef, in context: NSManagedObjectContext) throws -> OverrideStored {
+        switch ref {
+        case let .objectID(objectID):
+            guard let row = try? context.existingObject(with: objectID) as? OverrideStored else {
+                throw AdjustmentError.presetNotFound(objectID.uriRepresentation().lastPathComponent)
+            }
+            return row
+        case let .presetID(id):
+            let request: NSFetchRequest<OverrideStored> = OverrideStored.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", id)
+            request.fetchLimit = 1
+            guard let row = try context.fetch(request).first else { throw AdjustmentError.presetNotFound(id) }
+            return row
+        case let .presetName(name):
+            let request: NSFetchRequest<OverrideStored> = OverrideStored.fetchRequest()
+            request.predicate = NSPredicate(format: "isPreset == %@", true as NSNumber)
+            request.sortDescriptors = [NSSortDescriptor(key: "orderPosition", ascending: true)]
+            guard let row = try context.fetch(request).first(where: { $0.name?.matchesPresetName(name) == true }) else {
+                throw AdjustmentError.presetNotFound(name)
+            }
+            return row
+        }
+    }
+
+    private func fetchTempTarget(_ ref: AdjustmentRef, in context: NSManagedObjectContext) throws -> TempTargetStored {
+        switch ref {
+        case let .objectID(objectID):
+            guard let row = try? context.existingObject(with: objectID) as? TempTargetStored else {
+                throw AdjustmentError.presetNotFound(objectID.uriRepresentation().lastPathComponent)
+            }
+            return row
+        case let .presetID(id):
+            guard let uuid = UUID(uuidString: id) else { throw AdjustmentError.presetNotFound(id) }
+            let request: NSFetchRequest<TempTargetStored> = TempTargetStored.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", uuid as CVarArg)
+            request.fetchLimit = 1
+            guard let row = try context.fetch(request).first else { throw AdjustmentError.presetNotFound(id) }
+            return row
+        case let .presetName(name):
+            let request: NSFetchRequest<TempTargetStored> = TempTargetStored.fetchRequest()
+            request.predicate = NSPredicate(format: "isPreset == %@", true as NSNumber)
+            request.sortDescriptors = [NSSortDescriptor(key: "orderPosition", ascending: true)]
+            guard let row = try context.fetch(request).first(where: { $0.name?.matchesPresetName(name) == true }) else {
+                throw AdjustmentError.presetNotFound(name)
+            }
+            return row
+        }
+    }
+}
+
+// MARK: - Serialization
+
+/// Runs adjustment mutations one at a time, in order: each starts after the previous one has
+/// committed. Commands arrive from independent sources — a watch tap and a remote command can land
+/// milliseconds apart — and each mutation reads the active rows, writes run entries and enables a
+/// row, so it needs the previous one's committed state to be visible.
+private actor AdjustmentSerializer {
+    private var tail: Task<Void, Never>?
+
+    /// Calling `run` from inside an operation deadlocks: the inner call waits for the outer one's
+    /// place in the chain. An operation performs its own work and nothing else.
+    func run<T: Sendable>(_ operation: @escaping @Sendable() async throws -> T) async throws -> T {
+        let previous = tail
+        let task = Task<T, Error> {
+            await previous?.value
+            return try await operation()
+        }
+        tail = Task { _ = try? await task.value }
+        return try await task.value
+    }
+}
+
+// MARK: - Helpers
+
+private extension String {
+    func matchesPresetName(_ name: String) -> Bool {
+        trimmingCharacters(in: .whitespacesAndNewlines) == name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private extension AdjustmentSummary {
+    init(row: OverrideStored, startDate: Date, endDate: Date?) {
+        self.init(
+            name: row.name,
+            startDate: startDate,
+            endDate: endDate,
+            duration: row.duration?.decimalValue,
+            indefinite: row.indefinite
+        )
+    }
+
+    init(row: TempTargetStored, startDate: Date, endDate: Date?) {
+        self.init(
+            name: row.name,
+            startDate: startDate,
+            endDate: endDate,
+            duration: row.duration?.decimalValue,
+            indefinite: false
+        )
+    }
+}
+
+private extension AdjustmentOutcome {
+    var logDescription: String {
+        let startedText = started.map { "started \"\($0.name ?? "Custom")\"" } ?? "started nothing"
+        let endedText = ended.isEmpty
+            ? "ended nothing"
+            : "ended \(ended.map { "\"\($0.name ?? "Custom")\"" }.joined(separator: ", "))"
+        return "\(startedText), \(endedText)"
+    }
+}

--- a/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
+++ b/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
@@ -53,8 +53,8 @@ enum AdjustmentError: LocalizedError, Equatable {
 
 /// Single writer for override and temp target activation.
 ///
-/// Every entry point — app UI, Shortcuts, remote control, watch, Nightscout import — routes
-/// activation and cancellation through this service, which performs the full sequence for each
+/// Shortcuts, remote control and the watch route activation and cancellation through this
+/// service, which performs the full sequence for each
 /// command: end every enabled adjustment and record each one as a run entry, enable the requested
 /// one, then apply the dependent side effects in a fixed order.
 ///

--- a/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
+++ b/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
@@ -11,8 +11,6 @@ enum AdjustmentRef: Equatable {
     case presetName(String)
 }
 
-/// The entry point a command came from. Travels into the log line and the Nightscout upload
-/// request, and is the only thing the manager knows about its caller.
 enum AdjustmentSource: String {
     case app
     case remote

--- a/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
+++ b/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
@@ -7,7 +7,6 @@ import Swinject
 /// How a caller names the adjustment to activate.
 enum AdjustmentRef: Equatable {
     case objectID(NSManagedObjectID)
-    /// The preset's own identifier — `OverrideStored.id` / `TempTargetStored.id`.
     case presetID(String)
     /// The preset's display name, compared with surrounding whitespace trimmed on both sides.
     /// Names are free text and may repeat, so the lowest order position wins.

--- a/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
+++ b/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
@@ -14,6 +14,7 @@ enum AdjustmentRef: Equatable {
 enum AdjustmentSource: String {
     case app
     case remote
+    case shortcut
     case watch
 }
 

--- a/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
+++ b/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
@@ -17,8 +17,6 @@ enum AdjustmentSource: String {
     case watch
 }
 
-/// What one command started or ended. Callers build their own acknowledgment, log line or toast
-/// from this.
 struct AdjustmentSummary: Equatable {
     let name: String?
     let startDate: Date

--- a/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
+++ b/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
@@ -6,8 +6,6 @@ import Swinject
 
 /// How a caller names the adjustment to activate.
 enum AdjustmentRef: Equatable {
-    /// A row the caller already holds. Saved rows only: a row that has never been saved carries a
-    /// temporary object ID, which resolves in no other context.
     case objectID(NSManagedObjectID)
     /// The preset's own identifier — `OverrideStored.id` / `TempTargetStored.id`.
     case presetID(String)

--- a/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
+++ b/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
@@ -311,14 +311,9 @@ final class BaseAdjustmentManager: AdjustmentManager, Injectable, @unchecked Sen
 
     // MARK: Shared
 
-    /// A determination is only recomputed while the loop is idle; a loop in flight produces one of
-    /// its own. Delivery follows the loop either way, so this refreshes the forecast and the
-    /// pills, not the pump.
     /// Refreshes the determination and the forecast in the background: a command's outcome does not
-    /// depend on it, so callers acknowledge as soon as the transaction has committed.
-    ///
-    /// `APSManager` owns the decision to run: it holds the loop guard, skips a recompute while a
-    /// loop is in flight, and enacts nothing — delivery follows the loop either way.
+    /// depend on it, so callers acknowledge as soon as the transaction has committed. The
+    /// determination enacts nothing; delivery follows the loop.
     private func recomputeDetermination() {
         Task { [weak self] in
             guard let self else { return }
@@ -326,7 +321,11 @@ final class BaseAdjustmentManager: AdjustmentManager, Injectable, @unchecked Sen
                 await recompute()
                 return
             }
-            await apsManager.recomputeDetermination()
+            do {
+                try await apsManager.determineBasalSync()
+            } catch {
+                debug(.service, "Determination after adjustment change failed: \(error)")
+            }
         }
     }
 

--- a/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
+++ b/Trio/Sources/Services/Adjustments/AdjustmentManager.swift
@@ -8,8 +8,6 @@ import Swinject
 enum AdjustmentRef: Equatable {
     case objectID(NSManagedObjectID)
     case presetID(String)
-    /// The preset's display name, compared with surrounding whitespace trimmed on both sides.
-    /// Names are free text and may repeat, so the lowest order position wins.
     case presetName(String)
 }
 

--- a/Trio/Sources/Services/Network/Nightscout/NightscoutAPI.swift
+++ b/Trio/Sources/Services/Network/Nightscout/NightscoutAPI.swift
@@ -449,7 +449,8 @@ extension NightscoutAPI {
         components.port = url.port
         components.path = Config.treatmentsPath
         components.queryItems = [
-            URLQueryItem(name: "find[created_at][$eq]", value: createdAt)
+            URLQueryItem(name: "find[created_at][$eq]", value: createdAt),
+            URLQueryItem(name: "find[eventType][$eq]", value: OverrideStored.EventType.nsExercise.rawValue)
         ]
 
         guard let url = components.url else {

--- a/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
+++ b/Trio/Sources/Services/Network/Nightscout/NightscoutManager.swift
@@ -1180,13 +1180,11 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
                     continue
                 }
 
-                /// Check for an existing stored override and delete if needed
-                /// This is neccessary when a running override is cancelled, or replaced with a new override, before its duration is over.
-                try await overridesStorage.checkIfShouldDeleteNightscoutOverrideEntry(
-                    forCreatedAt: createdAtString,
-                    newDuration: overrideRun.duration,
-                    using: nightscout
-                )
+                /// The entry Nightscout holds for this activation carries the placeholder duration
+                /// uploaded when the override started, under the same `created_at` the run derives
+                /// from its `startDate`. Nightscout re-renders a duration change only when the entry
+                /// is replaced, so the entry is deleted and the run re-posted in its place.
+                try await nightscout.deleteNightscoutOverride(withCreatedAt: createdAtString)
 
                 processedOverrideRuns.append(overrideRun)
             }

--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Override.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl+Override.swift
@@ -1,89 +1,52 @@
-import CoreData
 import Foundation
-import UIKit
 
 extension TrioRemoteControl {
-    @MainActor internal func handleCancelOverrideCommand(_ payload: CommandPayload) async {
-        await disableAllActiveOverrides()
-        await logSuccess(
-            "Remote command processed successfully. \(payload.humanReadableDescription())",
-            payload: payload,
-            customNotificationMessage: "Override canceled"
-        )
-    }
-
-    @MainActor internal func handleStartOverrideCommand(_ payload: CommandPayload) async {
+    @MainActor func handleCancelOverrideCommand(_ payload: CommandPayload) async {
         do {
-            guard let overrideName = payload.overrideName, !overrideName.isEmpty else {
-                await logError("Command rejected: override name is missing.", payload: payload)
-                return
-            }
-            let presetIDs = try await overrideStorage.fetchForOverridePresets()
-            let presets = try presetIDs.compactMap { try viewContext.existingObject(with: $0) as? OverrideStored }
-            if let preset = presets.first(where: { $0.name == overrideName }) {
-                await enactOverridePreset(preset: preset, payload: payload)
-            } else {
-                await logError("Command rejected: override preset '\(overrideName)' not found.", payload: payload)
-            }
+            let outcome = try await adjustmentManager.cancelOverride(source: .remote, waitForUpload: true)
+            debug(.remoteControl, "Cancelled override \"\(outcome.ended.first?.name ?? "Custom Override")\"")
+            await logSuccess(
+                "Remote command processed successfully. \(payload.humanReadableDescription())",
+                payload: payload,
+                customNotificationMessage: "Override canceled"
+            )
+        } catch AdjustmentError.nothingActive {
+            // Nothing was running, which is the state the command asked for.
+            await logSuccess(
+                "Remote command processed successfully. \(payload.humanReadableDescription())",
+                payload: payload,
+                customNotificationMessage: "Override canceled"
+            )
         } catch {
-            debug(.remoteControl, "\(DebuggingIdentifiers.failed) Failed to handle start override command: \(error)")
+            debug(.remoteControl, "Failed to cancel override: \(error)")
             await logError("Command failed: \(error.localizedDescription)", payload: payload)
         }
     }
 
-    @MainActor private func enactOverridePreset(preset: OverrideStored, payload: CommandPayload) async {
-        preset.enabled = true
-        preset.date = Date()
-        preset.isUploadedToNS = false
-        await disableAllActiveOverrides(except: preset.objectID)
-        do {
-            if viewContext.hasChanges {
-                try viewContext.save()
-                Foundation.NotificationCenter.default.post(name: .willUpdateOverrideConfiguration, object: nil)
-                await awaitNotification(.didUpdateOverrideConfiguration)
-                await logSuccess(
-                    "Remote command processed successfully. \(payload.humanReadableDescription())",
-                    payload: payload,
-                    customNotificationMessage: "Override started"
-                )
-            }
-        } catch {
-            debug(.remoteControl, "Failed to enact override preset: \(error)")
-            await logError("Failed to enact override preset: \(error.localizedDescription)", payload: payload)
+    @MainActor func handleStartOverrideCommand(_ payload: CommandPayload) async {
+        guard let overrideName = payload.overrideName, !overrideName.isEmpty else {
+            await logError("Command rejected: override name is missing.", payload: payload)
+            return
         }
-    }
 
-    @MainActor private func disableAllActiveOverrides(except overrideID: NSManagedObjectID? = nil) async {
         do {
-            let ids = try await overrideStorage.loadLatestOverrideConfigurations(fetchLimit: 0)
-            let didPostNotification = try await viewContext.perform { () -> Bool in
-                let results = try ids.compactMap { try self.viewContext.existingObject(with: $0) as? OverrideStored }
-                guard !results.isEmpty else { return false }
-                for canceledOverride in results where canceledOverride.enabled {
-                    if let overrideID = overrideID, canceledOverride.objectID == overrideID { continue }
-                    let newOverrideRunStored = OverrideRunStored(context: self.viewContext)
-                    newOverrideRunStored.id = UUID()
-                    newOverrideRunStored.name = canceledOverride.name
-                    newOverrideRunStored.startDate = canceledOverride.date ?? .distantPast
-                    newOverrideRunStored.endDate = Date()
-                    newOverrideRunStored
-                        .target = NSDecimalNumber(decimal: self.overrideStorage.calculateTarget(override: canceledOverride))
-                    newOverrideRunStored.override = canceledOverride
-                    newOverrideRunStored.isUploadedToNS = false
-                    canceledOverride.enabled = false
-                    canceledOverride.isUploadedToNS = false
-                }
-                if self.viewContext.hasChanges {
-                    try self.viewContext.save()
-                    Foundation.NotificationCenter.default.post(name: .willUpdateOverrideConfiguration, object: nil)
-                    return true
-                } else {
-                    return false
-                }
+            let outcome = try await adjustmentManager.activateOverride(
+                .presetName(overrideName),
+                source: .remote,
+                waitForUpload: true
+            )
+            if let ended = outcome.ended.first {
+                debug(.remoteControl, "Recorded run for replaced override \"\(ended.name ?? "Custom Override")\"")
             }
-            if didPostNotification { await awaitNotification(.didUpdateOverrideConfiguration) }
+            await logSuccess(
+                "Remote command processed successfully. \(payload.humanReadableDescription())",
+                payload: payload,
+                customNotificationMessage: "Override started"
+            )
+        } catch let error as AdjustmentError {
+            await logError("Command rejected: \(error.errorDescription ?? "unknown reason")", payload: payload)
         } catch {
-            debug(.remoteControl, "\(DebuggingIdentifiers.failed) Failed to disable active overrides: \(error)")
+            await logError("Command failed: \(error.localizedDescription)", payload: payload)
         }
     }
 }

--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl+TempTarget.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl+TempTarget.swift
@@ -1,6 +1,5 @@
 import CoreData
 import Foundation
-import UIKit
 
 extension TrioRemoteControl {
     @MainActor func handleTempTargetCommand(_ payload: CommandPayload) async throws {
@@ -9,71 +8,57 @@ extension TrioRemoteControl {
             return
         }
 
-        let durationInMinutes = Int(durationValue)
-        let payloadDate = Date(timeIntervalSince1970: payload.timestamp)
-
+        // Stored disabled and then activated through the manager, which ends and records whatever
+        // was running, stamps the start, and hands oref the new entry.
         let tempTarget = TempTarget(
-            name: TempTarget.custom, createdAt: payloadDate,
+            name: TempTarget.custom, createdAt: Date(),
             targetTop: Decimal(targetValue), targetBottom: Decimal(targetValue),
-            duration: Decimal(durationInMinutes), enteredBy: TempTarget.local,
-            reason: TempTarget.custom, isPreset: false, enabled: true,
+            duration: Decimal(Int(durationValue)), enteredBy: TempTarget.local,
+            reason: TempTarget.custom, isPreset: false, enabled: false,
             halfBasalTarget: settings.preferences.halfBasalExerciseTarget
         )
 
-        try await tempTargetsStorage.storeTempTarget(tempTarget: tempTarget)
-        tempTargetsStorage.saveTempTargetsToStorage([tempTarget])
-
-        await logSuccess(
-            "Remote command processed successfully. \(payload.humanReadableDescription())",
-            payload: payload,
-            customNotificationMessage: "Temp target set"
-        )
+        do {
+            let objectID = try await tempTargetsStorage.storeTempTarget(tempTarget: tempTarget)
+            let outcome = try await adjustmentManager.activateTempTarget(
+                .objectID(objectID),
+                source: .remote,
+                waitForUpload: true
+            )
+            if let ended = outcome.ended.first {
+                debug(.remoteControl, "Recorded run for replaced temp target \"\(ended.name ?? "Temp Target")\"")
+            }
+            await logSuccess(
+                "Remote command processed successfully. \(payload.humanReadableDescription())",
+                payload: payload,
+                customNotificationMessage: "Temp target set"
+            )
+        } catch let error as AdjustmentError {
+            await logError("Command rejected: \(error.errorDescription ?? "unknown reason")", payload: payload)
+        } catch {
+            await logError("Command failed: \(error.localizedDescription)", payload: payload)
+        }
     }
 
     @MainActor func cancelTempTarget(_ payload: CommandPayload) async {
-        debug(.remoteControl, "Cancelling temp target.")
-        await disableAllActiveTempTargets()
-        await logSuccess(
-            "Remote command processed successfully. \(payload.humanReadableDescription())",
-            payload: payload,
-            customNotificationMessage: "Temp target canceled"
-        )
-    }
-
-    @MainActor func disableAllActiveTempTargets() async {
         do {
-            let ids = try await tempTargetsStorage.loadLatestTempTargetConfigurations(fetchLimit: 0)
-            let didPostNotification = try await viewContext.perform { () -> Bool in
-                let results = try ids.compactMap { try self.viewContext.existingObject(with: $0) as? TempTargetStored }
-                guard !results.isEmpty else {
-                    Task { await self.logError("Command rejected: no active temp target to cancel.") }
-                    return false
-                }
-                for canceledTempTarget in results where canceledTempTarget.enabled {
-                    let newTempTargetRunStored = TempTargetRunStored(context: self.viewContext)
-                    newTempTargetRunStored.id = UUID()
-                    newTempTargetRunStored.name = canceledTempTarget.name
-                    newTempTargetRunStored.startDate = canceledTempTarget.date ?? .distantPast
-                    newTempTargetRunStored.endDate = Date()
-                    newTempTargetRunStored.target = canceledTempTarget.target ?? 0
-                    newTempTargetRunStored.tempTarget = canceledTempTarget
-                    newTempTargetRunStored.isUploadedToNS = false
-                    canceledTempTarget.enabled = false
-                    canceledTempTarget.isUploadedToNS = false
-                }
-                if self.viewContext.hasChanges {
-                    try self.viewContext.save()
-                    Foundation.NotificationCenter.default.post(name: .willUpdateTempTargetConfiguration, object: nil)
-                    self.tempTargetsStorage.saveTempTargetsToStorage([TempTarget.cancel(at: Date().addingTimeInterval(-1))])
-                    return true
-                } else {
-                    return false
-                }
-            }
-            if didPostNotification { await awaitNotification(.didUpdateTempTargetConfiguration) }
+            let outcome = try await adjustmentManager.cancelTempTarget(source: .remote, waitForUpload: true)
+            debug(.remoteControl, "Cancelled temp target \"\(outcome.ended.first?.name ?? "Temp Target")\"")
+            await logSuccess(
+                "Remote command processed successfully. \(payload.humanReadableDescription())",
+                payload: payload,
+                customNotificationMessage: "Temp target canceled"
+            )
+        } catch AdjustmentError.nothingActive {
+            // Nothing was running, which is the state the command asked for.
+            await logSuccess(
+                "Remote command processed successfully. \(payload.humanReadableDescription())",
+                payload: payload,
+                customNotificationMessage: "Temp target canceled"
+            )
         } catch {
-            debug(.remoteControl, "\(DebuggingIdentifiers.failed) Failed to disable active temp targets: \(error)")
-            await logError("Failed to disable temp targets: \(error.localizedDescription)")
+            debug(.remoteControl, "Failed to cancel temp target: \(error)")
+            await logError("Command failed: \(error.localizedDescription)", payload: payload)
         }
     }
 }

--- a/Trio/Sources/Services/RemoteControl/TrioRemoteControl.swift
+++ b/Trio/Sources/Services/RemoteControl/TrioRemoteControl.swift
@@ -8,16 +8,13 @@ class TrioRemoteControl: Injectable {
     @Injected() internal var tempTargetsStorage: TempTargetsStorage!
     @Injected() internal var carbsStorage: CarbsStorage!
     @Injected() internal var nightscoutManager: NightscoutManager!
-    @Injected() internal var overrideStorage: OverrideStorage!
+    @Injected() internal var adjustmentManager: AdjustmentManager!
     @Injected() internal var settings: SettingsManager!
     @Injected() internal var bolusSafetyValidator: BolusSafetyValidator!
 
     private let timeWindow: TimeInterval = 600
 
-    internal let viewContext: NSManagedObjectContext
-
     private init() {
-        viewContext = CoreDataStack.shared.persistentContainer.viewContext
         injectServices(TrioApp.resolver)
     }
 

--- a/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
+++ b/Trio/Sources/Services/WatchManager/AppleWatchManager.swift
@@ -23,6 +23,7 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
     @Injected() private var determinationStorage: DeterminationStorage!
     @Injected() private var overrideStorage: OverrideStorage!
     @Injected() private var tempTargetStorage: TempTargetsStorage!
+    @Injected() private var adjustmentManager: AdjustmentManager!
     @Injected() private var bolusCalculationManager: BolusCalculationManager!
     @Injected() private var iobService: IOBService!
     @Injected() private var notificationsManager: UserNotificationsManager!
@@ -691,7 +692,12 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
                     "📱 Received meal bolus combo request from watch: \(bolusAmount)U, \(carbsAmount)g at \(date)"
                 )
                 self.handleCombinedRequest(bolusAmount: Decimal(bolusAmount), carbsAmount: Decimal(carbsAmount), date: date)
-            } else {
+            } else if message[WatchMessageKeys.cancelOverride] == nil,
+                      message[WatchMessageKeys.activateOverride] == nil,
+                      message[WatchMessageKeys.cancelTempTarget] == nil,
+                      message[WatchMessageKeys.activateTempTarget] == nil,
+                      message[WatchMessageKeys.requestBolusRecommendation] == nil
+            {
                 debug(.watchManager, "📱 Invalid or incomplete data received from watch. Received:  \(message)")
                 // Acknowledge failure
                 self.sendAcknowledgment(
@@ -967,314 +973,106 @@ final class BaseWatchManager: NSObject, WCSessionDelegate, Injectable, WatchMana
 
     private func handleCancelOverride() {
         Task {
-            let context = CoreDataStack.shared.newTaskContext()
+            do {
+                let outcome = try await adjustmentManager.cancelOverride(source: .watch)
+                debug(.watchManager, "📱 Successfully stopped override \"\(outcome.ended.first?.name ?? "Custom Override")\"")
 
-            if let overrideId = try await overrideStorage.fetchLatestActiveOverride() {
-                let override = await context.perform {
-                    context.object(with: overrideId) as? OverrideStored
-                }
-
-                await context.perform {
-                    if let activeOverride = override {
-                        activeOverride.enabled = false
-
-                        do {
-                            guard context.hasChanges else {
-                                // Acknowledge failure
-                                self.sendAcknowledgment(
-                                    toWatch: false,
-                                    message: "Error! Something went wrong when processing your request.",
-                                    ackCode: .genericFailure
-                                )
-                                return
-                            }
-                            try context.save()
-                            debug(.watchManager, "📱 Successfully stopped override")
-
-                            // Send notification to update Adjustments UI
-                            Foundation.NotificationCenter.default.post(
-                                name: .didUpdateOverrideConfiguration,
-                                object: nil
-                            )
-
-                            // Acknowledge cancellation success
-                            self.sendAcknowledgment(
-                                toWatch: true,
-                                message: String(
-                                    localized: "Stopped Override successfully.",
-                                    comment: "Stopped Override successfully"
-                                ),
-                                ackCode: .overrideStopped
-                            )
-                        } catch {
-                            debug(.watchManager, "❌ Error cancelling override: \(error)")
-                            // Acknowledge cancellation error
-                            self.sendAcknowledgment(toWatch: false, message: "Error stopping Override.", ackCode: .genericFailure)
-                        }
-                    }
-                }
-            } else {
-                debug(.watchManager, "❌ No active override found.")
+                self.sendAcknowledgment(
+                    toWatch: true,
+                    message: String(
+                        localized: "Stopped Override successfully.",
+                        comment: "Stopped Override successfully"
+                    ),
+                    ackCode: .overrideStopped
+                )
+            } catch {
+                debug(.watchManager, "❌ Error cancelling override: \(error)")
                 self.sendAcknowledgment(
                     toWatch: false,
-                    message: "No active override found.",
+                    message: (error as? AdjustmentError)?.errorDescription ?? "Error stopping Override.",
                     ackCode: .genericFailure
                 )
-                return
             }
         }
     }
 
     private func handleActivateOverride(_ presetName: String) {
         Task {
-            let context = CoreDataStack.shared.newTaskContext()
-
-            debug(.watchManager, "📱 Fetching all override presets...")
-
-            // Fetch all presets to find the one to activate
-            let presetIds = try await overrideStorage.fetchForOverridePresets()
-            let presets: [OverrideStored] = try await CoreDataStack.shared
-                .getNSManagedObject(with: presetIds, context: context)
-
-            debug(.watchManager, "📱 Checking for active override...")
-
             do {
-                // Check for active override
-                if let activeOverrideId = try await overrideStorage.fetchLatestActiveOverride() {
-                    let activeOverride = await context.perform {
-                        context.object(with: activeOverrideId) as? OverrideStored
-                    }
-
-                    // Deactivate, if necessary
-                    if let override = activeOverride {
-                        await context.perform {
-                            override.enabled = false
-                        }
-                    }
-                } else {
-                    debug(.watchManager, "📱 Currently no override is active... proceeding to activate override: \(presetName)")
+                let outcome = try await adjustmentManager.activateOverride(.presetName(presetName), source: .watch)
+                debug(.watchManager, "📱 Successfully activated override: \(presetName)")
+                if let ended = outcome.ended.first {
+                    debug(.watchManager, "📱 Recorded run for replaced override \"\(ended.name ?? "Custom Override")\"")
                 }
+
+                self.sendAcknowledgment(
+                    toWatch: true,
+                    message: String(
+                        localized: "Started Override \"\(presetName)\" successfully.",
+                        comment: "Start override with override name"
+                    ),
+                    ackCode: .overrideStarted
+                )
             } catch {
-                debug(.watchManager, "❌ Error while checking for active override: \(error)")
+                debug(.watchManager, "❌ Error activating override: \(error)")
                 self.sendAcknowledgment(
                     toWatch: false,
-                    message: "Failed to load active override.",
+                    message: (error as? AdjustmentError)?.errorDescription ?? "Error activating Override \"\(presetName)\".",
                     ackCode: .genericFailure
                 )
-                return
-            }
-
-            // Activate the selected preset
-            await context.perform {
-                guard let presetToActivate = presets
-                    .first(where: { $0.name?.trimmingCharacters(in: .whitespacesAndNewlines) == presetName })
-                else {
-                    debug(.watchManager, "❌ No matching preset found for name: \"\(presetName)\" in \(presets.map(\.name))")
-                    self.sendAcknowledgment(
-                        toWatch: false,
-                        message: String(
-                            localized: "Preset \"\(presetName)\" not found.",
-                            comment: "Preset not found"
-                        ),
-                        ackCode: .genericFailure
-                    )
-                    return
-                }
-
-                presetToActivate.enabled = true
-                presetToActivate.date = Date()
-
-                do {
-                    guard context.hasChanges else {
-                        // Acknowledge failure
-                        self.sendAcknowledgment(
-                            toWatch: false,
-                            message: String(
-                                localized: "Error! Something went wrong when processing your request.",
-                                comment: "Error message when activating override"
-                            ),
-                            ackCode: .genericFailure
-                        )
-                        return
-                    }
-                    try context.save()
-                    debug(.watchManager, "📱 Successfully activated override: \(presetName)")
-
-                    // Send notification to update Adjustments UI
-                    Foundation.NotificationCenter.default.post(
-                        name: .didUpdateOverrideConfiguration,
-                        object: nil
-                    )
-
-                    // Acknowledge activation success
-                    self.sendAcknowledgment(
-                        toWatch: true,
-                        message: String(
-                            localized: "Started Override \"\(presetName)\" successfully.",
-                            comment: "Start override with override name"
-                        ),
-                        ackCode: .overrideStarted
-                    )
-                } catch {
-                    debug(.watchManager, "❌ Error activating override: \(error)")
-                    // Acknowledge activation error
-                    self.sendAcknowledgment(
-                        toWatch: false,
-                        message: "Error activating Override \"\(presetName)\".",
-                        ackCode: .genericFailure
-                    )
-                }
             }
         }
     }
 
     private func handleActivateTempTarget(_ presetName: String) {
         Task {
-            let context = CoreDataStack.shared.newTaskContext()
-
-            // Fetch all presets to find the one to activate
-            let presetIds = try await tempTargetStorage.fetchForTempTargetPresets()
-            let presets: [TempTargetStored] = try await CoreDataStack.shared
-                .getNSManagedObject(with: presetIds, context: context)
-
-            // Check for active temp target
-            if let activeTempTargetId = try await tempTargetStorage.loadLatestTempTargetConfigurations(fetchLimit: 1).first {
-                let activeTempTarget = await context.perform {
-                    context.object(with: activeTempTargetId) as? TempTargetStored
+            do {
+                let outcome = try await adjustmentManager.activateTempTarget(.presetName(presetName), source: .watch)
+                debug(.watchManager, "📱 Successfully activated temp target: \(presetName)")
+                if let ended = outcome.ended.first {
+                    debug(.watchManager, "📱 Recorded run for replaced temp target \"\(ended.name ?? "Temp Target")\"")
                 }
 
-                // Deactivate if exists
-                if let tempTarget = activeTempTarget {
-                    await context.perform {
-                        tempTarget.enabled = false
-                    }
-                }
-            }
-
-            // Activate the selected preset
-            await context.perform {
-                if let presetToActivate = presets.first(where: { $0.name == presetName }) {
-                    presetToActivate.enabled = true
-                    presetToActivate.date = Date()
-
-                    do {
-                        guard context.hasChanges else {
-                            // Acknowledge failure
-                            self.sendAcknowledgment(
-                                toWatch: false,
-                                message: "Error! Something went wrong when processing your request.",
-                                ackCode: .genericFailure
-                            )
-                            return
-                        }
-                        try context.save()
-                        debug(.watchManager, "📱 Successfully activated temp target: \(presetName)")
-
-                        let settingsHalfBasalTarget = self.settingsManager.preferences
-                            .halfBasalExerciseTarget
-
-                        let halfBasalTarget = presetToActivate.halfBasalTarget?.decimalValue
-
-                        // To activate the temp target also in oref
-                        let tempTarget = TempTarget(
-                            name: presetToActivate.name,
-                            createdAt: Date(),
-                            targetTop: presetToActivate.target?.decimalValue,
-                            targetBottom: presetToActivate.target?.decimalValue,
-                            duration: presetToActivate.duration?.decimalValue ?? 0,
-                            enteredBy: TempTarget.local,
-                            reason: TempTarget.custom,
-                            isPreset: true,
-                            enabled: true,
-                            halfBasalTarget: halfBasalTarget ?? settingsHalfBasalTarget
-                        )
-
-                        self.tempTargetStorage.saveTempTargetsToStorage([tempTarget])
-
-                        // Send notification to update Adjustments UI
-                        Foundation.NotificationCenter.default.post(
-                            name: .didUpdateTempTargetConfiguration,
-                            object: nil
-                        )
-
-                        // Acknowledge activation success
-                        self.sendAcknowledgment(
-                            toWatch: true,
-                            message: String(
-                                localized: "Started Temp Target \"\(presetName)\" successfully.",
-                                comment: "Started Temp Target successfully."
-                            ),
-                            ackCode: .tempTargetStarted
-                        )
-                    } catch {
-                        debug(.watchManager, "❌ Error activating temp target: \(error)")
-                        // Acknowledge activation error
-                        self.sendAcknowledgment(
-                            toWatch: false,
-                            message: "Error activating Temp Target \"\(presetName)\".",
-                            ackCode: .genericFailure
-                        )
-                    }
-                }
+                self.sendAcknowledgment(
+                    toWatch: true,
+                    message: String(
+                        localized: "Started Temp Target \"\(presetName)\" successfully.",
+                        comment: "Started Temp Target successfully."
+                    ),
+                    ackCode: .tempTargetStarted
+                )
+            } catch {
+                debug(.watchManager, "❌ Error activating temp target: \(error)")
+                self.sendAcknowledgment(
+                    toWatch: false,
+                    message: (error as? AdjustmentError)?.errorDescription ?? "Error activating Temp Target \"\(presetName)\".",
+                    ackCode: .genericFailure
+                )
             }
         }
     }
 
     private func handleCancelTempTarget() {
         Task {
-            let context = CoreDataStack.shared.newTaskContext()
+            do {
+                let outcome = try await adjustmentManager.cancelTempTarget(source: .watch)
+                debug(.watchManager, "📱 Successfully cancelled temp target \"\(outcome.ended.first?.name ?? "Temp Target")\"")
 
-            if let tempTargetId = try await tempTargetStorage.loadLatestTempTargetConfigurations(fetchLimit: 1).first {
-                let tempTarget = await context.perform {
-                    context.object(with: tempTargetId) as? TempTargetStored
-                }
-
-                await context.perform {
-                    if let activeTempTarget = tempTarget {
-                        activeTempTarget.enabled = false
-
-                        do {
-                            guard context.hasChanges else {
-                                // Acknowledge failure
-                                self.sendAcknowledgment(
-                                    toWatch: false,
-                                    message: "Error! Something went wrong when processing your request.",
-                                    ackCode: .genericFailure
-                                )
-                                return
-                            }
-                            try context.save()
-                            debug(.watchManager, "📱 Successfully cancelled temp target")
-
-                            // To cancel the temp target also for oref
-                            self.tempTargetStorage.saveTempTargetsToStorage([TempTarget.cancel(at: Date())])
-
-                            // Send notification to update Adjustments UI
-                            Foundation.NotificationCenter.default.post(
-                                name: .didUpdateTempTargetConfiguration,
-                                object: nil
-                            )
-
-                            // Acknowledge cancellation success
-                            self.sendAcknowledgment(
-                                toWatch: true,
-                                message: String(
-                                    localized: "Stopped Temp Target successfully.",
-                                    comment: "Stopped Temp Target successfully."
-                                ),
-                                ackCode: .tempTargetStopped
-                            )
-                        } catch {
-                            debug(.watchManager, "❌ Error stopping temp target: \(error)")
-                            // Acknowledge cancellation error
-                            self.sendAcknowledgment(
-                                toWatch: false,
-                                message: "Error stopping Temp Target.",
-                                ackCode: .genericFailure
-                            )
-                        }
-                    }
-                }
+                self.sendAcknowledgment(
+                    toWatch: true,
+                    message: String(
+                        localized: "Stopped Temp Target successfully.",
+                        comment: "Stopped Temp Target successfully."
+                    ),
+                    ackCode: .tempTargetStopped
+                )
+            } catch {
+                debug(.watchManager, "❌ Error stopping temp target: \(error)")
+                self.sendAcknowledgment(
+                    toWatch: false,
+                    message: (error as? AdjustmentError)?.errorDescription ?? "Error stopping Temp Target.",
+                    ackCode: .genericFailure
+                )
             }
         }
     }

--- a/Trio/Sources/Shortcuts/BaseIntentsRequest.swift
+++ b/Trio/Sources/Shortcuts/BaseIntentsRequest.swift
@@ -14,6 +14,7 @@ import Swinject
     @Injected() var glucoseStorage: GlucoseStorage!
     @Injected() var apsManager: APSManager!
     @Injected() var overrideStorage: OverrideStorage!
+    @Injected() var adjustmentManager: AdjustmentManager!
     @Injected() var liveActivityManager: LiveActivityManager!
     @Injected() var pumpHistoryStorage: PumpHistoryStorage!
     @Injected() var iobService: IOBService!

--- a/Trio/Sources/Shortcuts/Override/OverridePresetsIntentRequest.swift
+++ b/Trio/Sources/Shortcuts/Override/OverridePresetsIntentRequest.swift
@@ -9,8 +9,6 @@ import UIKit
         case noActiveOverride
     }
 
-    private var intentSuccess: Bool = false
-
     /**
      Fetches and processes override presets from Core Data.
 
@@ -86,166 +84,41 @@ import UIKit
     }
 
     /**
-     Fetches the Core Data `NSManagedObjectID` for a given `OverridePreset`.
-
-     - Parameter preset: The `OverridePreset` for which to fetch the object ID.
-     - Returns: The corresponding `NSManagedObjectID`.
-     - Throws: `overridePresetsError.noTempOverrideFound` if the preset is not found.
-     */
-    private func fetchOverrideID(_ preset: OverridePreset) async throws -> NSManagedObjectID {
-        let context = CoreDataStack.shared.newTaskContext()
-        context.name = "fetchOverrideID"
-
-        let fetchRequest: NSFetchRequest<OverrideStored> = OverrideStored.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "id == %@", preset.id)
-        fetchRequest.fetchLimit = 1
-
-        return try await context.perform {
-            guard let objectID = try context.fetch(fetchRequest).first?.objectID else {
-                debug(
-                    .default,
-                    "\(DebuggingIdentifiers.failed) No override found for preset: \(preset.name)"
-                )
-                throw overridePresetsError.noTempOverrideFound
-            }
-            return objectID
-        }
-    }
-
-    /**
-     Enacts an override preset by enabling it in Core Data and notifying the system.
+     Enacts an override preset. The adjustment manager ends whatever runs, records its run entry,
+     enables the preset and uploads the change to Nightscout before returning.
 
      - Parameter preset: The `OverridePreset` to enact.
      - Returns: A boolean indicating whether the override was successfully enacted.
      */
     @MainActor func enactOverride(_ preset: OverridePreset) async -> Bool {
         debug(.default, "Enacting override: \(preset.name)")
-        intentSuccess = false
-
-        var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
-        backgroundTaskID = startBackgroundTask(withName: "Override Enact")
-
-        await disableAllActiveOverrides(shouldStartBackgroundTask: false)
+        var backgroundTaskID = startBackgroundTask(withName: "Override Enact")
+        defer { endBackgroundTaskSafely(&backgroundTaskID, taskName: "Override Enact") }
 
         do {
-            let overrideID = try await fetchOverrideID(preset)
-            guard let overrideObject = try viewContext.existingObject(with: overrideID) as? OverrideStored else {
-                endBackgroundTaskSafely(&backgroundTaskID, taskName: "Override Enact")
-                throw overridePresetsError.noTempOverrideFound
-            }
-
-            overrideObject.enabled = true
-            overrideObject.date = Date()
-            overrideObject.isUploadedToNS = false
-
-            if viewContext.hasChanges {
-                debug(.default, "Saving changes...")
-                try viewContext.save()
-                debug(.default, "Waiting for notification...")
-                Foundation.NotificationCenter.default.post(name: .willUpdateOverrideConfiguration, object: nil)
-                await awaitNotification(.didUpdateOverrideConfiguration)
-                debug(.default, "Notification received, continuing...")
-                intentSuccess = true
-            }
-
-            endBackgroundTaskSafely(&backgroundTaskID, taskName: "Override Enact")
+            try await adjustmentManager.activateOverride(.presetID(preset.id), source: .shortcut, waitForUpload: true)
             debug(.default, "Finished. Override enacted via Shortcut.")
-            return intentSuccess
+            return true
         } catch {
-            debug(
-                .default,
-                "\(DebuggingIdentifiers.failed) Failed to enact override: \(error)"
-            )
-            endBackgroundTaskSafely(&backgroundTaskID, taskName: "Override Enact")
+            debug(.default, "\(DebuggingIdentifiers.failed) Failed to enact override: \(error)")
             return false
         }
     }
 
     /**
-     Cancels all active overrides asynchronously.
+     Cancels the active override. Nothing running is the state the intent asks for.
      */
-    func cancelOverride() async {
-        await disableAllActiveOverrides(shouldStartBackgroundTask: true)
-    }
-
-    /**
-     Disables all active overrides and optionally starts a background task.
-
-     - Parameter shouldStartBackgroundTask: A boolean indicating whether to start a background task.
-     */
-    @MainActor func disableAllActiveOverrides(shouldStartBackgroundTask: Bool) async {
-        debug(.default, "Disabling all active overrides")
-        var backgroundTaskID: UIBackgroundTaskIdentifier?
-
-        if shouldStartBackgroundTask {
-            debug(.default, "Starting background task for override cancel")
-            backgroundTaskID = .invalid
-            backgroundTaskID = startBackgroundTask(withName: "Override Cancel")
-        }
+    @MainActor func cancelOverride() async {
+        debug(.default, "Cancelling active override")
+        var backgroundTaskID = startBackgroundTask(withName: "Override Cancel")
+        defer { endBackgroundTaskSafely(&backgroundTaskID, taskName: "Override Cancel") }
 
         do {
-            // Get NSManagedObjectID of all active overrides
-            let ids = try await overrideStorage.loadLatestOverrideConfigurations(fetchLimit: 0)
-            let results = try ids.compactMap { id in
-                try self.viewContext.existingObject(with: id) as? OverrideStored
-            }
-
-            // Return early if no results
-            guard !results.isEmpty else {
-                debug(.default, "No active overrides to cancel… returning early")
-                if var backgroundTaskID = backgroundTaskID {
-                    debug(.default, "Ending background task for override cancel")
-                    endBackgroundTaskSafely(&backgroundTaskID, taskName: "Override Cancel")
-                }
-                return
-            }
-
-            // Create OverrideRunStored entry if needed
-            if let canceledOverride = results.first {
-                let newOverrideRunStored = OverrideRunStored(context: viewContext)
-                newOverrideRunStored.id = UUID()
-                newOverrideRunStored.name = canceledOverride.name
-                newOverrideRunStored.startDate = canceledOverride.date ?? .distantPast
-                newOverrideRunStored.endDate = Date()
-                newOverrideRunStored.target = NSDecimalNumber(
-                    decimal: overrideStorage.calculateTarget(override: canceledOverride)
-                )
-                newOverrideRunStored.override = canceledOverride
-                newOverrideRunStored.isUploadedToNS = false
-            }
-
-            // Disable all active overrides
-            for overrideToCancel in results {
-                let endTime = overrideToCancel.date?
-                    .addingTimeInterval(TimeInterval(truncating: overrideToCancel.duration ?? 0))
-
-                debugPrint(
-                    "Disabling override: \(overrideToCancel.name ?? "Unnamed") with end time: \(endTime?.description ?? "Unknown")"
-                )
-                overrideToCancel.enabled = false
-                overrideToCancel.isUploadedToNS = false
-            }
-
-            if viewContext.hasChanges {
-                try viewContext.save()
-                debug(.default, "Waiting for notification...")
-                Foundation.NotificationCenter.default.post(name: .willUpdateOverrideConfiguration, object: nil)
-                await awaitNotification(.didUpdateOverrideConfiguration)
-                debug(.default, "Notification received, continuing...")
-            }
-
-            if var backgroundTaskID = backgroundTaskID {
-                debug(.default, "Ending background task for override cancel")
-                endBackgroundTaskSafely(&backgroundTaskID, taskName: "Override Cancel")
-            }
+            try await adjustmentManager.cancelOverride(source: .shortcut, waitForUpload: true)
+        } catch AdjustmentError.nothingActive {
+            debug(.default, "No active override to cancel")
         } catch {
-            debugPrint(
-                "\(DebuggingIdentifiers.failed) \(#file) \(#function) Failed to disable active Overrides with error: \(error)"
-            )
-            if var backgroundTaskID = backgroundTaskID {
-                debug(.default, "Ending background task for override cancel")
-                endBackgroundTaskSafely(&backgroundTaskID, taskName: "Override Cancel")
-            }
+            debug(.default, "\(DebuggingIdentifiers.failed) Failed to cancel override: \(error)")
         }
     }
 }

--- a/Trio/Sources/Shortcuts/TempPresets/TempPresetsIntentRequest.swift
+++ b/Trio/Sources/Shortcuts/TempPresets/TempPresetsIntentRequest.swift
@@ -10,9 +10,6 @@ final class TempPresetsIntentRequest: BaseIntentsRequest {
         case noDurationDefined
     }
 
-    /// Tracks whether the intent execution was successful.
-    private var intentSuccess: Bool = false
-
     /// Fetches and processes all available temporary target presets.
     ///
     /// - Returns: An array of `TempPreset` objects.
@@ -86,183 +83,47 @@ final class TempPresetsIntentRequest: BaseIntentsRequest {
         }
     }
 
-    /// Fetches the `NSManagedObjectID` for a given `TempPreset`.
-    ///
-    /// - Parameter preset: The `TempPreset` to find.
-    /// - Returns: The `NSManagedObjectID` of the temp target if found, otherwise `nil`.
-    private func fetchTempTargetID(_ preset: TempPreset) async ->
-        NSManagedObjectID?
-    {
-        let context = CoreDataStack.shared.newTaskContext()
-        context.name = "fetchTempTargetID"
-
-        let fetchRequest: NSFetchRequest<TempTargetStored> = TempTargetStored.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "id == %@", preset.id.uuidString)
-        fetchRequest.fetchLimit = 1
-
-        return await context.perform {
-            do {
-                return try context.fetch(fetchRequest).first?.objectID
-            } catch {
-                debugPrint(
-                    "\(DebuggingIdentifiers.failed) \(#file) \(#function) Failed to fetch Temp Target: \(error)"
-                )
-                return nil
-            }
-        }
-    }
-
-    /// Enacts a temporary target preset by updating Core Data and notifying relevant components.
+    /// Enacts a temporary target preset. The adjustment manager ends whatever runs, records its run
+    /// entry, enables the preset, hands oref the new entry and uploads the change to Nightscout
+    /// before returning.
     ///
     /// - Parameter preset: The `TempPreset` to apply.
     /// - Returns: `true` if successfully enacted, otherwise `false`.
     @MainActor func enactTempTarget(_ preset: TempPreset) async -> Bool {
         debug(.default, "Enacting Temp Target: \(preset.name)")
-        intentSuccess = false
-
-        // Start background task
-        var backgroundTaskID: UIBackgroundTaskIdentifier = .invalid
-        backgroundTaskID = startBackgroundTask(withName: "TempTarget Enact")
-
-        // Disable previous temp targets if necessary, without starting a background task
-        await disableAllActiveTempTargets(shouldStartBackgroundTask: false)
+        var backgroundTaskID = startBackgroundTask(withName: "TempTarget Enact")
+        defer { endBackgroundTaskSafely(&backgroundTaskID, taskName: "TempTarget Enact") }
 
         do {
-            // Get NSManagedObjectID of Preset
-            guard let tempTargetID = await fetchTempTargetID(preset),
-                  let tempTargetObject = try viewContext.existingObject(with: tempTargetID) as? TempTargetStored
-            else {
-                endBackgroundTaskSafely(&backgroundTaskID, taskName: "TempTarget Enact")
-                throw TempPresetsError.noTempTargetFound
-            }
-
-            // Enable TempTarget
-            tempTargetObject.enabled = true
-            tempTargetObject.date = Date()
-            tempTargetObject.isUploadedToNS = false
-
-            if viewContext.hasChanges {
-                debug(.default, "Saving changes...")
-                try viewContext.save()
-                debug(.default, "Waiting for notification...")
-                // Update State variables in TempTargetView
-                Foundation.NotificationCenter.default.post(name: .willUpdateTempTargetConfiguration, object: nil)
-
-                // Prepare JSON for oref
-                guard let tempTargetDate = tempTargetObject.date, let tempTarget = tempTargetObject.target,
-                      let tempTargetDuration = tempTargetObject.duration else { return false }
-
-                let tempTargetToStoreAsJSON = TempTarget(
-                    name: tempTargetObject.name,
-                    createdAt: tempTargetDate,
-                    targetTop: tempTarget as Decimal,
-                    targetBottom: tempTarget as Decimal,
-                    duration: tempTargetDuration as Decimal,
-                    enteredBy: TempTarget.local,
-                    reason: TempTarget.custom,
-                    isPreset: tempTargetObject.isPreset,
-                    enabled: tempTargetObject.enabled,
-                    halfBasalTarget: tempTargetObject.halfBasalTarget as Decimal?
-                )
-                // Save the temp targets to JSON so that they get used by oref
-                tempTargetsStorage.saveTempTargetsToStorage([tempTargetToStoreAsJSON])
-
-                await awaitNotification(.didUpdateTempTargetConfiguration)
-
-                debug(.default, "Notification received, continuing...")
-                intentSuccess = true
-            }
-
-            endBackgroundTaskSafely(&backgroundTaskID, taskName: "TempTarget Enact")
-
+            try await adjustmentManager.activateTempTarget(
+                .presetID(preset.id.uuidString),
+                source: .shortcut,
+                waitForUpload: true
+            )
             debug(.default, "Finished. Temp Target enacted via Shortcut.")
-
-            return intentSuccess
+            return true
         } catch {
             debugPrint(
                 "\(DebuggingIdentifiers.failed) \(#file) \(#function) Failed to enact Temp Target with error: \(error)"
             )
-
-            endBackgroundTaskSafely(&backgroundTaskID, taskName: "TempTarget Enact")
-
-            intentSuccess = false
-            return intentSuccess
+            return false
         }
     }
 
-    /// Cancels an active temporary target.
-    func cancelTempTarget() async {
-        await disableAllActiveTempTargets(shouldStartBackgroundTask: true)
-        tempTargetsStorage.saveTempTargetsToStorage([TempTarget.cancel(at: Date().addingTimeInterval(-1))])
-    }
-
-    /// Disables all active temporary targets.
-    ///
-    /// - Parameter shouldStartBackgroundTask: A flag indicating whether a background task should be started.
-    @MainActor func disableAllActiveTempTargets(shouldStartBackgroundTask: Bool) async {
-        var backgroundTaskID: UIBackgroundTaskIdentifier?
-
-        if shouldStartBackgroundTask {
-            debug(.default, "Starting background task for temp target cancel")
-            backgroundTaskID = .invalid
-            backgroundTaskID = startBackgroundTask(withName: "TempTarget Cancel")
-        }
+    /// Cancels the active temporary target. Nothing running is the state the intent asks for.
+    @MainActor func cancelTempTarget() async {
+        debug(.default, "Cancelling active temp target")
+        var backgroundTaskID = startBackgroundTask(withName: "TempTarget Cancel")
+        defer { endBackgroundTaskSafely(&backgroundTaskID, taskName: "TempTarget Cancel") }
 
         do {
-            // Fetch active temp targets
-            let ids = try await tempTargetsStorage.loadLatestTempTargetConfigurations(fetchLimit: 0)
-            let results = try ids.compactMap { id in
-                try self.viewContext.existingObject(with: id) as? TempTargetStored
-            }
-
-            guard !results.isEmpty else {
-                debug(.default, "No active temp targets to cancel... returning early")
-
-                if var backgroundTaskID = backgroundTaskID {
-                    debug(.default, "Ending background task for temp target cancel")
-                    endBackgroundTaskSafely(&backgroundTaskID, taskName: "TempTarget Cancel")
-                }
-                return
-            }
-
-            // Create a new `TempTargetRunStored` entry
-            if let canceledTempTarget = results.first {
-                let newTempTargetRunStored = TempTargetRunStored(context: viewContext)
-                newTempTargetRunStored.id = UUID()
-                newTempTargetRunStored.name = canceledTempTarget.name
-                newTempTargetRunStored.startDate = canceledTempTarget.date ?? .distantPast
-                newTempTargetRunStored.endDate = Date()
-                newTempTargetRunStored.target = canceledTempTarget.target ?? 0
-                newTempTargetRunStored.tempTarget = canceledTempTarget
-                newTempTargetRunStored.isUploadedToNS = false
-            }
-
-            // Disable all temp targets
-            for tempTargetToCancel in results {
-                tempTargetToCancel.enabled = false
-                tempTargetToCancel.isUploadedToNS = false
-            }
-
-            if viewContext.hasChanges {
-                try viewContext.save()
-                debug(.default, "Waiting for notification...")
-                Foundation.NotificationCenter.default.post(name: .willUpdateTempTargetConfiguration, object: nil)
-                await awaitNotification(.didUpdateTempTargetConfiguration)
-                debug(.default, "Notification received, continuing...")
-            }
-
-            if var backgroundTaskID = backgroundTaskID {
-                debug(.default, "Ending background task for temp target cancel")
-                endBackgroundTaskSafely(&backgroundTaskID, taskName: "TempTarget Cancel")
-            }
+            try await adjustmentManager.cancelTempTarget(source: .shortcut, waitForUpload: true)
+        } catch AdjustmentError.nothingActive {
+            debug(.default, "No active temp target to cancel")
         } catch {
             debugPrint(
-                "\(DebuggingIdentifiers.failed) \(#file) \(#function) Failed to disable active Temp Targets with error: \(error)"
+                "\(DebuggingIdentifiers.failed) \(#file) \(#function) Failed to cancel Temp Target with error: \(error)"
             )
-            if var backgroundTaskID = backgroundTaskID {
-                debug(.default, "Ending background task for temp target cancel")
-                endBackgroundTaskSafely(&backgroundTaskID, taskName: "TempTarget Cancel")
-            }
         }
     }
 }

--- a/TrioTests/AdjustmentsTests/AdjustmentManagerTests.swift
+++ b/TrioTests/AdjustmentsTests/AdjustmentManagerTests.swift
@@ -1,0 +1,358 @@
+import CoreData
+import Foundation
+import Swinject
+import Testing
+
+@testable import Trio
+
+/// Covers the transaction the manager owns: which rows end, which run entries appear, what is
+/// marked for upload, and what happens when a command cannot be resolved. The determination step is
+/// stubbed out in `TestAssembly`, so these tests never enter the algorithm.
+@Suite("Adjustment Manager Tests", .serialized) struct AdjustmentManagerTests: Injectable {
+    @Injected() var manager: AdjustmentManager!
+    let resolver: Resolver
+    var coreDataStack: CoreDataStack!
+    var testContext: NSManagedObjectContext!
+
+    init() async throws {
+        coreDataStack = try await CoreDataStack.createForTests()
+        testContext = coreDataStack.newTaskContext()
+
+        let assembler = Assembler([
+            StorageAssembly(),
+            ServiceAssembly(),
+            APSAssembly(),
+            NetworkAssembly(),
+            UIAssembly(),
+            SecurityAssembly(),
+            TestAssembly(testContext: testContext)
+        ])
+
+        resolver = assembler.resolver
+        injectServices(resolver)
+    }
+
+    // MARK: - Resolution
+
+    @Test("Manager resolves from the service container") func testManagerResolves() {
+        #expect(manager != nil, "AdjustmentManager should be registered in ServiceAssembly")
+        #expect(manager is BaseAdjustmentManager, "Manager should be of type BaseAdjustmentManager")
+    }
+
+    @Test("Every caller shares one manager") func testManagerIsShared() {
+        let first = resolver.resolve(AdjustmentManager.self)
+        let second = resolver.resolve(AdjustmentManager.self)
+        #expect(first != nil)
+        #expect(first as AnyObject? === second as AnyObject?, "One instance means one serializer across callers")
+    }
+
+    // MARK: - Overrides
+
+    @Test("Switching overrides records the one that ends") func testSwitchOverrideRecordsRun() async throws {
+        let start = Date().addingTimeInterval(-60 * 60)
+        await makeOverride(name: "Tempbasal", enabled: true, date: start)
+        await makeOverride(name: "Fotboll", enabled: false, date: Date().addingTimeInterval(-24 * 60 * 60), orderPosition: 2)
+
+        let outcome = try await manager.activateOverride(.presetName("Fotboll"), source: .watch)
+
+        #expect(outcome.started?.name == "Fotboll")
+        #expect(outcome.ended.map(\.name) == ["Tempbasal"])
+
+        let runs = try await overrideRuns()
+        #expect(runs.count == 1, "The override that ended has exactly one run entry")
+        #expect(runs.first?.name == "Tempbasal")
+        #expect(runs.first?.startDate == start, "The run starts when the override it records started")
+        #expect(runs.first?.isUploadedToNS == false, "The run is queued for Nightscout")
+        #expect(runs.first?.linkedName == "Tempbasal", "The run points at the override it records")
+
+        let rows = try await overrides()
+        #expect(rows.first(where: { $0.name == "Tempbasal" })?.enabled == false)
+        let started = rows.first(where: { $0.name == "Fotboll" })
+        #expect(started?.enabled == true)
+        #expect(started?.isUploadedToNS == false, "The started override is queued for Nightscout")
+    }
+
+    @Test("Re-activating the running override records the elapsed segment") func testRestartOverride() async throws {
+        let start = Date().addingTimeInterval(-30 * 60)
+        await makeOverride(name: "Tempbasal", enabled: true, date: start)
+
+        try await manager.activateOverride(.presetName("Tempbasal"), source: .remote)
+
+        let runs = try await overrideRuns()
+        #expect(runs.count == 1, "The elapsed segment is recorded")
+        #expect(runs.first?.startDate == start)
+
+        let rows = try await overrides()
+        let row = rows.first(where: { $0.name == "Tempbasal" })
+        #expect(row?.enabled == true, "The override keeps running")
+        #expect((row?.date ?? .distantPast) > start, "Its start moves to the restart")
+    }
+
+    @Test("A finite override that ran out ends at its expiry") func testExpiredOverrideEndsAtExpiry() async throws {
+        let start = Date().addingTimeInterval(-120 * 60)
+        await makeOverride(name: "Expired", enabled: true, date: start, duration: 60, indefinite: false)
+
+        try await manager.cancelOverride(source: .app)
+
+        let runs = try await overrideRuns()
+        let expiry = start.addingTimeInterval(60 * 60)
+        #expect(runs.count == 1)
+        let endDate = try #require(runs.first?.endDate)
+        #expect(abs(endDate.timeIntervalSince(expiry)) < 1, "The run ends 60 minutes after it started")
+    }
+
+    @Test("Cancelling with nothing running throws and writes nothing") func testCancelNothingActive() async throws {
+        await makeOverride(name: "Tempbasal", enabled: false, date: Date())
+
+        await #expect(throws: AdjustmentError.nothingActive) {
+            try await manager.cancelOverride(source: .watch)
+        }
+
+        let runs = try await overrideRuns()
+        #expect(runs.isEmpty, "A rejected command writes no run entry")
+    }
+
+    @Test("An unknown preset leaves the running override untouched") func testUnknownPresetIsAtomic() async throws {
+        let start = Date().addingTimeInterval(-45 * 60)
+        await makeOverride(name: "Tempbasal", enabled: true, date: start)
+
+        await #expect(throws: AdjustmentError.presetNotFound("Simning")) {
+            try await manager.activateOverride(.presetName("Simning"), source: .watch)
+        }
+
+        let rows = try await overrides()
+        #expect(rows.first(where: { $0.name == "Tempbasal" })?.enabled == true, "The running override stays enabled")
+        let runs = try await overrideRuns()
+        #expect(runs.isEmpty, "No run entry is written")
+    }
+
+    @Test("Concurrent activations leave exactly one override running") func testConcurrentActivations() async throws {
+        await makeOverride(name: "Tempbasal", enabled: true, date: Date().addingTimeInterval(-60 * 60))
+        await makeOverride(name: "Fotboll", enabled: false, date: Date().addingTimeInterval(-24 * 60 * 60), orderPosition: 2)
+        await makeOverride(name: "Simning", enabled: false, date: Date().addingTimeInterval(-24 * 60 * 60), orderPosition: 3)
+
+        // A context per command, so two commands reach the store independently and the serializer
+        // is what keeps them in order.
+        let stack = coreDataStack!
+        let manager = BaseAdjustmentManager(
+            resolver: resolver,
+            contextProvider: { stack.newTaskContext() },
+            recompute: {}
+        )
+
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { _ = try? await manager.activateOverride(.presetName("Fotboll"), source: .watch) }
+            group.addTask { _ = try? await manager.activateOverride(.presetName("Simning"), source: .remote) }
+            await group.waitForAll()
+        }
+
+        await testContext.perform { self.testContext.refreshAllObjects() }
+
+        let rows = try await overrides()
+        #expect(rows.filter(\.enabled).count == 1, "Commands are applied one after another")
+        let runs = try await overrideRuns()
+        #expect(runs.count == 2, "Each ended override is recorded once")
+    }
+
+    @Test("A stored row activates by object ID") func testActivateByObjectID() async throws {
+        await makeOverride(name: "Tempbasal", enabled: true, date: Date().addingTimeInterval(-30 * 60))
+        let objectID = await makeOverride(
+            name: "Custom Override",
+            enabled: false,
+            date: Date().addingTimeInterval(-24 * 60 * 60),
+            orderPosition: 2
+        )
+
+        let outcome = try await manager.activateOverride(.objectID(objectID), source: .remote)
+
+        #expect(outcome.started?.name == "Custom Override")
+        #expect(outcome.ended.map(\.name) == ["Tempbasal"])
+
+        let rows = try await overrides()
+        #expect(rows.first(where: { $0.name == "Custom Override" })?.enabled == true)
+        #expect(rows.first(where: { $0.name == "Tempbasal" })?.enabled == false)
+    }
+
+    // MARK: - Temp targets
+
+    @Test("Switching temp targets records the one that ends") func testSwitchTempTargetRecordsRun() async throws {
+        let start = Date().addingTimeInterval(-20 * 60)
+        await makeTempTarget(name: "Activity", enabled: true, date: start, duration: 90, target: 140)
+        await makeTempTarget(
+            name: "Eating Soon",
+            enabled: false,
+            date: Date().addingTimeInterval(-24 * 60 * 60),
+            duration: 60,
+            target: 80,
+            orderPosition: 2
+        )
+
+        let outcome = try await manager.activateTempTarget(.presetName("Eating Soon"), source: .watch)
+
+        #expect(outcome.started?.name == "Eating Soon")
+        #expect(outcome.ended.map(\.name) == ["Activity"])
+
+        let runs = try await tempTargetRuns()
+        #expect(runs.count == 1)
+        #expect(runs.first?.name == "Activity")
+        #expect(runs.first?.startDate == start)
+        #expect(runs.first?.isUploadedToNS == false)
+
+        let rows = try await tempTargets()
+        #expect(rows.first(where: { $0.name == "Activity" })?.enabled == false)
+        #expect(rows.first(where: { $0.name == "Eating Soon" })?.enabled == true)
+    }
+
+    @Test("Cancelling a temp target records it and disables the row") func testCancelTempTarget() async throws {
+        let start = Date().addingTimeInterval(-15 * 60)
+        await makeTempTarget(name: "Activity", enabled: true, date: start, duration: 90, target: 140)
+
+        let outcome = try await manager.cancelTempTarget(source: .watch)
+
+        #expect(outcome.started == nil)
+        #expect(outcome.ended.map(\.name) == ["Activity"])
+
+        let runs = try await tempTargetRuns()
+        #expect(runs.count == 1)
+        #expect(runs.first?.startDate == start)
+        #expect(runs.first?.linkedName == "Activity", "The run points at the temp target it records")
+
+        let rows = try await tempTargets()
+        #expect(rows.first(where: { $0.name == "Activity" })?.enabled == false)
+    }
+
+    @Test("Cancelling a temp target with nothing running throws") func testCancelTempTargetNothingActive() async throws {
+        await makeTempTarget(name: "Activity", enabled: false, date: Date(), duration: 90, target: 140)
+
+        await #expect(throws: AdjustmentError.nothingActive) {
+            try await manager.cancelTempTarget(source: .watch)
+        }
+
+        let runs = try await tempTargetRuns()
+        #expect(runs.isEmpty, "A rejected command writes no run entry")
+    }
+
+    // MARK: - Fixtures
+
+    @discardableResult private func makeOverride(
+        name: String,
+        enabled: Bool,
+        date: Date,
+        duration: Decimal = 0,
+        indefinite: Bool = true,
+        orderPosition: Int16 = 1
+    ) async -> NSManagedObjectID {
+        await testContext.perform {
+            let row = OverrideStored(context: self.testContext)
+            row.id = UUID().uuidString
+            row.name = name
+            row.enabled = enabled
+            row.date = date
+            row.duration = NSDecimalNumber(decimal: duration)
+            row.indefinite = indefinite
+            row.isPreset = true
+            row.orderPosition = orderPosition
+            row.percentage = 100
+            row.isUploadedToNS = true
+            try? self.testContext.save()
+            return row.objectID
+        }
+    }
+
+    @discardableResult private func makeTempTarget(
+        name: String,
+        enabled: Bool,
+        date: Date,
+        duration: Decimal,
+        target: Decimal,
+        orderPosition: Int16 = 1
+    ) async -> NSManagedObjectID {
+        await testContext.perform {
+            let row = TempTargetStored(context: self.testContext)
+            row.id = UUID()
+            row.name = name
+            row.enabled = enabled
+            row.date = date
+            row.duration = NSDecimalNumber(decimal: duration)
+            row.target = NSDecimalNumber(decimal: target)
+            row.isPreset = true
+            row.orderPosition = orderPosition
+            row.enteredBy = TempTarget.local
+            row.isUploadedToNS = true
+            try? self.testContext.save()
+            return row.objectID
+        }
+    }
+
+    // MARK: - Snapshots
+
+    //
+    // Values are read on the context's own queue and handed back as plain structs.
+
+    private struct RowSnapshot {
+        let name: String?
+        let enabled: Bool
+        let date: Date?
+        let isUploadedToNS: Bool
+    }
+
+    private struct RunSnapshot {
+        let name: String?
+        let startDate: Date?
+        let endDate: Date?
+        let isUploadedToNS: Bool
+        /// Name of the row the run points at; the Nightscout payload reads it through this
+        /// relationship.
+        let linkedName: String?
+    }
+
+    private func overrides() async throws -> [RowSnapshot] {
+        try await testContext.perform {
+            let request: NSFetchRequest<OverrideStored> = OverrideStored.fetchRequest()
+            return try self.testContext.fetch(request).map {
+                RowSnapshot(name: $0.name, enabled: $0.enabled, date: $0.date, isUploadedToNS: $0.isUploadedToNS)
+            }
+        }
+    }
+
+    private func tempTargets() async throws -> [RowSnapshot] {
+        try await testContext.perform {
+            let request: NSFetchRequest<TempTargetStored> = TempTargetStored.fetchRequest()
+            return try self.testContext.fetch(request).map {
+                RowSnapshot(name: $0.name, enabled: $0.enabled, date: $0.date, isUploadedToNS: $0.isUploadedToNS)
+            }
+        }
+    }
+
+    private func overrideRuns() async throws -> [RunSnapshot] {
+        try await testContext.perform {
+            let request: NSFetchRequest<OverrideRunStored> = OverrideRunStored.fetchRequest()
+            request.sortDescriptors = [NSSortDescriptor(key: "startDate", ascending: true)]
+            return try self.testContext.fetch(request).map {
+                RunSnapshot(
+                    name: $0.name,
+                    startDate: $0.startDate,
+                    endDate: $0.endDate,
+                    isUploadedToNS: $0.isUploadedToNS,
+                    linkedName: $0.override?.name
+                )
+            }
+        }
+    }
+
+    private func tempTargetRuns() async throws -> [RunSnapshot] {
+        try await testContext.perform {
+            let request: NSFetchRequest<TempTargetRunStored> = TempTargetRunStored.fetchRequest()
+            request.sortDescriptors = [NSSortDescriptor(key: "startDate", ascending: true)]
+            return try self.testContext.fetch(request).map {
+                RunSnapshot(
+                    name: $0.name,
+                    startDate: $0.startDate,
+                    endDate: $0.endDate,
+                    isUploadedToNS: $0.isUploadedToNS,
+                    linkedName: $0.tempTarget?.name
+                )
+            }
+        }
+    }
+}

--- a/TrioTests/CoreDataTests/OverrideStorageTests.swift
+++ b/TrioTests/CoreDataTests/OverrideStorageTests.swift
@@ -222,4 +222,58 @@ import Testing
         #expect(notUploadedOverrides[0].duration == 90, "Duration should match")
         #expect(notUploadedOverrides[0].eventType == .nsExercise, "Event type should be exercise")
     }
+
+    @Test("Get override runs not yet uploaded to Nightscout") func testGetOverrideRunsNotYetUploadedToNightscout() async throws {
+        // Given
+        let now = Date()
+        let hour: TimeInterval = 60 * 60
+        let recentStart = now.addingTimeInterval(-2 * hour)
+        let longRunningStart = now.addingTimeInterval(-72 * hour)
+
+        await testContext.perform {
+            let recent = OverrideRunStored(context: self.testContext)
+            recent.id = UUID()
+            recent.name = "Recent"
+            recent.startDate = recentStart
+            recent.endDate = now.addingTimeInterval(-hour)
+            recent.isUploadedToNS = false
+
+            let longRunning = OverrideRunStored(context: self.testContext)
+            longRunning.id = UUID()
+            longRunning.name = "Long running"
+            longRunning.startDate = longRunningStart
+            longRunning.endDate = now.addingTimeInterval(-hour)
+            longRunning.isUploadedToNS = false
+
+            let stale = OverrideRunStored(context: self.testContext)
+            stale.id = UUID()
+            stale.name = "Stale"
+            stale.startDate = now.addingTimeInterval(-72 * hour)
+            stale.endDate = now.addingTimeInterval(-48 * hour)
+            stale.isUploadedToNS = false
+
+            let uploaded = OverrideRunStored(context: self.testContext)
+            uploaded.id = UUID()
+            uploaded.name = "Uploaded"
+            uploaded.startDate = recentStart
+            uploaded.endDate = now.addingTimeInterval(-hour)
+            uploaded.isUploadedToNS = true
+
+            try? self.testContext.save()
+        }
+
+        // When
+        let runs = try await storage.getOverrideRunsNotYetUploadedToNightscout()
+
+        // Then
+        #expect(
+            runs.compactMap(\.notes).sorted() == ["Long running", "Recent"],
+            "Runs that ended within the last day are uploaded, whenever they started"
+        )
+
+        let longRunning = try #require(runs.first { $0.notes == "Long running" })
+        #expect(longRunning.createdAt == longRunningStart, "created_at is the run's start")
+        #expect(longRunning.duration == 71 * 60, "Duration spans the whole run")
+        #expect(longRunning.eventType == .nsExercise, "Event type should be exercise")
+    }
 }

--- a/TrioTests/CoreDataTests/TempTargetStorageTests.swift
+++ b/TrioTests/CoreDataTests/TempTargetStorageTests.swift
@@ -147,6 +147,63 @@ import Testing
         #expect(target.targetBottom == 120, "Target bottom should match target")
     }
 
+    @Test("Get temp target runs not yet uploaded to Nightscout") func testGetTempTargetRunsNotYetUploadedToNightscout() async throws {
+        // Given
+        let now = Date()
+        let hour: TimeInterval = 60 * 60
+        let recentStart = now.addingTimeInterval(-2 * hour)
+        let longRunningStart = now.addingTimeInterval(-72 * hour)
+
+        await testContext.perform {
+            let recent = TempTargetRunStored(context: self.testContext)
+            recent.id = UUID()
+            recent.name = "Recent"
+            recent.startDate = recentStart
+            recent.endDate = now.addingTimeInterval(-hour)
+            recent.target = 140
+            recent.isUploadedToNS = false
+
+            let longRunning = TempTargetRunStored(context: self.testContext)
+            longRunning.id = UUID()
+            longRunning.name = "Long running"
+            longRunning.startDate = longRunningStart
+            longRunning.endDate = now.addingTimeInterval(-hour)
+            longRunning.target = 140
+            longRunning.isUploadedToNS = false
+
+            let stale = TempTargetRunStored(context: self.testContext)
+            stale.id = UUID()
+            stale.name = "Stale"
+            stale.startDate = now.addingTimeInterval(-72 * hour)
+            stale.endDate = now.addingTimeInterval(-48 * hour)
+            stale.target = 140
+            stale.isUploadedToNS = false
+
+            let uploaded = TempTargetRunStored(context: self.testContext)
+            uploaded.id = UUID()
+            uploaded.name = "Uploaded"
+            uploaded.startDate = recentStart
+            uploaded.endDate = now.addingTimeInterval(-hour)
+            uploaded.target = 140
+            uploaded.isUploadedToNS = true
+
+            try? self.testContext.save()
+        }
+
+        // When
+        let runs = try await storage.getTempTargetRunsNotYetUploadedToNightscout()
+
+        // Then
+        #expect(
+            Set(runs.compactMap(\.createdAt)) == [recentStart, longRunningStart],
+            "Runs that ended within the last day are uploaded, whenever they started"
+        )
+
+        let longRunning = try #require(runs.first { $0.createdAt == longRunningStart })
+        #expect(longRunning.duration == 71 * 60, "Duration spans the whole run")
+        #expect(longRunning.eventType == .nsTempTarget, "Event type should be NS temp target")
+    }
+
     @Test(
         "Main chart predicate excludes presets saved after the predicate was built"
     ) func testMainChartPredicateExcludesNewPresets() async throws {

--- a/TrioTests/CoreDataTests/TestAssembly.swift
+++ b/TrioTests/CoreDataTests/TestAssembly.swift
@@ -40,5 +40,11 @@ class TestAssembly: Assembly {
         container.register(OverrideStorage.self) { r in
             BaseOverrideStorage(resolver: r, contextProvider: { self.testContext })
         }.inObjectScope(.container)
+
+        // Override AdjustmentManager registration for tests: same context as the storages, and the
+        // determination step stubbed out so the algorithm stays out of the transaction tests.
+        container.register(AdjustmentManager.self) { r in
+            BaseAdjustmentManager(resolver: r, contextProvider: { self.testContext }, recompute: {})
+        }.inObjectScope(.container)
     }
 }

--- a/TrioTests/CoreDataTests/TestAssembly.swift
+++ b/TrioTests/CoreDataTests/TestAssembly.swift
@@ -41,8 +41,7 @@ class TestAssembly: Assembly {
             BaseOverrideStorage(resolver: r, contextProvider: { self.testContext })
         }.inObjectScope(.container)
 
-        // Override AdjustmentManager registration for tests: same context as the storages, and the
-        // determination step stubbed out so the algorithm stays out of the transaction tests.
+        // Override AdjustmentManager registration for tests
         container.register(AdjustmentManager.self) { r in
             BaseAdjustmentManager(resolver: r, contextProvider: { self.testContext }, recompute: {})
         }.inObjectScope(.container)


### PR DESCRIPTION
This rewrite was done because overrides activated from the watch were not sent to Nightscout until they were cancelled. The change has successfully been tested in real-world use for several days with no issues.

Shortcuts, remote control and the watch route activation and cancellation through AdjustmentManager, which performs the whole sequence in one Core Data transaction: end every enabled adjustment and record each as a run entry, enable the requested one, then apply the side effects in a fixed order. Commands are serialized, so two arriving at once cannot interleave. The Adjustments view keeps its own write path in this PR.

The run entry carries the elapsed duration to Nightscout and draws the finished band on the home chart. uploadOverrideRuns deletes the entry at the run's own created_at and re-posts it there, so the cleanup holds for a preset row whose date moves on every activation, and the run upload window keys on endDate so an adjustment that ran for more than a day still retracts its placeholder. deleteNightscoutOverride filters on event type.

APSManager.determineBasalSync() is the single entry point for a determination outside the loop. It waits for a loop in flight to finish, collapses concurrent calls into one, never delays a loop start, and keeps throwing so the treatment views still see algorithm errors. The manager and the Adjustments view models go through it.

A custom, non-preset adjustment is stored disabled and activated by object ID, so storeTempTarget returns the inserted row's NSManagedObjectID.

The watch acknowledges a command from the returned outcome, and its failure acknowledgment applies only to messages carrying none of the recognized payloads. A remote cancel with nothing running is the state the command asked for.
