### PR TITLE
Fix crash in HomeRootView by injecting the existing SettingsSearchHighlight instance

### DIFF
--- a/Trio/Sources/Modules/Home/View/HomeRootView.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView.swift
@@ -290,6 +290,7 @@ extension Home {
                         cgmCurrent: state.cgmCurrent,
                         deleteCGM: state.deleteCGM
                     )
+                    .environment(settingsSearchHighlight)
                 case .plugin:
                     if let fetchGlucoseManager = state.fetchGlucoseManager,
                        let cgmManager = fetchGlucoseManager.cgmManager,


### PR DESCRIPTION
`NightscoutUploadView` and `NightscoutFetchView` require a `SettingsSearchHighlight` environment object that is missing when Nightscout configuration is opened from the Home-screen CGM sheet.

Cause of the crash is https://github.com/nightscout/Trio/commit/5cb78b6af0bae7751167527160d7f9232a9559b2 which added `.settingsHighlightScroll()` to these two views.

- Both destinations apply `.settingsHighlightScroll()`
- That modifier unconditionally reads  `@Environment(SettingsSearchHighlight.self)`
- The object is injected only into the Settings tab’s `NavigationStack`
- The Home-screen CGM sheet is outside that subtree, so navigating to Upload or Fetch causes SwiftUI’s fatal “no observable object of type `SettingsSearchHighlight` found” failure
- Settings to Services to Nightscout works because that route inherits the required environment object

So we can inject the existing settings-highlight environment into the Home CGM sheet so the Nightscout child routes inherit it, without changing the working `Settings` navigation path.

PR fixes the crash in `HomeRootView.swift` by injecting the existing `SettingsSearchHighlight` instance into the Home-screen CGM configuration sheet. Nightscout’s Upload and Fetch views now inherit their required environment dependency.

Fixes #1480 

**Test steps:**
1. Enable nightscout as a CGM (you may need to delete your existing CGM and set up nightscout as the CGM)
2. Click on your CGM and configure nightscout, then go to 'Fetch' or 'Upload' and verify the subscreens open without crashing