### PR TITLE
Fix empty PluginSource fetch results

### DIFF
--- a/Trio/Sources/APS/CGM/PluginSource.swift
+++ b/Trio/Sources/APS/CGM/PluginSource.swift
@@ -47,18 +47,18 @@ final class PluginSource: GlucoseSource {
         cgmProgressHighlight.value = cgmManager?.cgmLifecycleProgress
     }
 
-    /// Function that fetches blood glucose data
-    /// This function combines two data fetching mechanisms (`callBLEFetch` and `fetchIfNeeded`) into a single publisher.
-    /// It returns the first non-empty result from either of the sources within a 5-minute timeout period.
-    /// If no valid data is fetched within the timeout, it returns an empty array.
+    /// Returns the first fetch result, including an empty array, within five minutes.
+    /// Empty completion, timeout, or failure produces an empty array.
+    /// Plugin readings and backfill arrive separately through the CGM manager delegate;
+    /// the fetch callback is not a second source of glucose readings.
     ///
     /// - Parameter timer: An optional `DispatchTimer` (not used in the function but can be used to trigger fetch logic).
     /// - Returns: An `AnyPublisher` that emits an array of `BloodGlucose` values or an empty array if an error occurs or the timeout is reached.
     func fetch(_: DispatchTimer?) -> AnyPublisher<[BloodGlucose], Never> {
         fetchIfNeeded()
-            .filter { !$0.isEmpty }
             .first()
             .timeout(60 * 5, scheduler: processQueue, options: nil, customError: nil)
+            .replaceEmpty(with: [])
             .replaceError(with: [])
             .eraseToAnyPublisher()
     }

--- a/scripts/tests/plugin-fetch/README.md
+++ b/scripts/tests/plugin-fetch/README.md
@@ -1,0 +1,33 @@
+# Plugin fetch Combine contract tests
+
+Run on macOS with Xcode selected and Python 3:
+
+```sh
+python3 scripts/tests/plugin-fetch/run.py
+python3 scripts/tests/plugin-fetch/run.py --full-timeout
+```
+
+These XCTest cases compile the **current `PluginSource.fetch(_:)` method**, extracted from source, against Apple's Combine. They require neither submodules nor signing. To compare a baseline without editing your checkout:
+
+```sh
+git show a708381782825c03745db1c6377efe632b5f2161:Trio/Sources/APS/CGM/PluginSource.swift > /tmp/PluginSource-before.swift
+python3 scripts/tests/plugin-fetch/run.py --source /tmp/PluginSource-before.swift
+```
+
+The default run shortens only the timeout to 40 ms. `--full-timeout` leaves the method text unchanged and waits through the actual five-minute timeout. Both compile with warnings as errors.
+
+## Coverage and boundaries
+
+- Empty array and empty completion: exactly one empty value, then completion.
+- Nonempty array: unchanged; later values/errors do not produce another value.
+- Silent publisher: timeout produces one empty value and cancels upstream.
+- Event order, upstream cancellation, downstream cancellation, finite demand, and asynchronous Future callback.
+- Defensive outer error replacement is exercised with a failing publisher. Production `fetchIfNeeded()` has `Failure == Never`, so this is not a reachable plugin callback error scenario.
+
+The test-only host injects the `fetchIfNeeded()` publisher, substitutes synthetic integer elements for `BloodGlucose`, and supplies a serial DispatchQueue. This is a source-extracted **operator contract** suite, not an integration test of the PluginSource class, CGM drivers, UIKit, Core Data, app background execution, or pump scheduling. Signature/timeout changes fail the extractor so it must be reviewed rather than silently using a stale operator copy. Tests are not wired into the iOS TrioTests target.
+
+The original `Collection.isEmpty` / Combine Filter `EXC_BAD_ACCESS` has **not** been reproduced by these tests. Empty Swift arrays are valid; removing that closure is not proof that an underlying memory-lifetime or concurrency problem is resolved.
+
+## Scheduling review
+
+`fetchIfNeeded()` currently resolves the Future with `[]` when the plugin fetch callback returns. Actual readings/backfill use `cgmManager(_:hasNew:)` → `newGlucoseFromCgmManager`, independently of this publisher (see PR #703). This change intentionally makes the empty result observable by the timer subscriber instead of completing without a value. The existing `glucoseStoreAndHeartDecision` empty-data guard returns before storage, pump heartbeat schedule updates, or `heartbeat`. It does acquire the existing semaphore and begin/end a background task first. The timer interval, BLE capability, delegate queue, and share-client suppression are unchanged. Device-level scheduling remains a maintainer/integration validation concern, not a claim of these tests.

--- a/scripts/tests/plugin-fetch/run.py
+++ b/scripts/tests/plugin-fetch/run.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Run the source-extracted PluginSource.fetch Combine contract on macOS."""
+import argparse
+import pathlib
+import subprocess
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--source", type=pathlib.Path, default=ROOT / "Trio/Sources/APS/CGM/PluginSource.swift")
+parser.add_argument("--full-timeout", action="store_true", help="Use the production five-minute timeout")
+args = parser.parse_args()
+source = args.source.read_text()
+signature = "    func fetch(_: DispatchTimer?) -> AnyPublisher<[BloodGlucose], Never> {"
+assert source.count(signature) == 1, "fetch signature changed; review this harness"
+start = source.index(signature)
+opening = source.index("{", start)
+depth = 1
+end = opening + 1
+while depth:
+    depth += (source[end] == "{") - (source[end] == "}")
+    end += 1
+method = source[start:end]
+assert method.count(".timeout(60 * 5,") == 1, "timeout changed; review this harness"
+if not args.full_timeout:
+    method = method.replace(".timeout(60 * 5,", ".timeout(.milliseconds(40),")
+# The operator expression is read from production, not copied into the tests.
+# Only dependencies are substituted: an injected publisher and synthetic elements.
+# Failure is generic to exercise the defensive replaceError; production uses Never.
+preamble = """import Combine
+import Foundation
+import XCTest
+
+typealias BloodGlucose = Int
+struct DispatchTimer {}
+final class FetchHarness<Failure: Error> {
+    let processQueue = DispatchQueue(label: "PluginFetchContractTests")
+    let upstream: AnyPublisher<[BloodGlucose], Failure>
+    init<P: Publisher>(_ upstream: P) where P.Output == [BloodGlucose], P.Failure == Failure {
+        self.upstream = upstream.eraseToAnyPublisher()
+    }
+    func fetchIfNeeded() -> AnyPublisher<[BloodGlucose], Failure> { upstream }
+"""
+swift = preamble + method + "\n}\n"
+swift += "let timeoutWait: TimeInterval = " + ("310" if args.full_timeout else "3") + "\n"
+swift += "let minimumTimeout: TimeInterval = " + ("299" if args.full_timeout else "0.035") + "\n"
+swift += (pathlib.Path(__file__).parent / "tests.swift").read_text()
+with tempfile.TemporaryDirectory(prefix="plugin-fetch-contract-") as directory:
+    path = pathlib.Path(directory)
+    tests = path / "Tests/PluginFetchTests"
+    tests.mkdir(parents=True)
+    (tests / "PluginFetchTests.swift").write_text(swift)
+    (path / "Package.swift").write_text('''// swift-tools-version: 5.9
+import PackageDescription
+let package = Package(name: "PluginFetchContract", platforms: [.macOS(.v13)],
+    targets: [.testTarget(name: "PluginFetchTests")])
+''')
+    print("Testing source:", args.source, "full-timeout:", args.full_timeout, flush=True)
+    raise SystemExit(subprocess.run(["swift", "test", "--package-path", str(path), "-Xswiftc", "-warnings-as-errors"]).returncode)

--- a/scripts/tests/plugin-fetch/tests.swift
+++ b/scripts/tests/plugin-fetch/tests.swift
@@ -1,0 +1,142 @@
+// Compiled by run.py with the production fetch method and test-only dependencies.
+final class PluginFetchContractTests: XCTestCase {
+    enum FetchError: Error { case failed }
+
+    private func assertEvents<P: Publisher>(
+        _ publisher: P, _ expected: [String],
+        file: StaticString = #filePath, line: UInt = #line
+    ) where P.Output == [Int] {
+        let source = FetchHarness(publisher)
+        var events: [String] = []
+        let finished = expectation(description: "fetch completes")
+        let subscription = source.fetch(nil).sink(
+            receiveCompletion: { _ in events.append("finished"); finished.fulfill() },
+            receiveValue: { events.append("value:\($0)") }
+        )
+        wait(for: [finished], timeout: timeoutWait)
+        source.processQueue.sync {
+            XCTAssertEqual(events, expected, file: file, line: line)
+        }
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testEmptyArrayEmitsOnceThenFinishes() {
+        assertEvents(Just<[Int]>([]), ["value:[]", "finished"])
+    }
+
+    func testEmptyCompletionEmitsOnceThenFinishes() {
+        assertEvents(Empty<[Int], Never>(), ["value:[]", "finished"])
+    }
+
+    func testNonemptyArrayIsUnchanged() {
+        assertEvents(Just([1, 2]), ["value:[1, 2]", "finished"])
+    }
+
+    func testDefensiveErrorReplacementEmitsOnceThenFinishes() {
+        // Production fetchIfNeeded has Failure == Never. This probes the outer
+        // defensive operator, not a reachable plugin callback failure path.
+        assertEvents(Fail<[Int], FetchError>(error: .failed), ["value:[]", "finished"])
+    }
+
+    func testSilentPublisherTimesOutWithOneEmptyValueAndCancels() {
+        var cancellations = 0
+        let publisher = Empty<[Int], Never>(completeImmediately: false)
+            .handleEvents(receiveCancel: { cancellations += 1 })
+        let start = Date()
+        assertEvents(publisher, ["value:[]", "finished"])
+        XCTAssertEqual(cancellations, 1)
+        XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(start), minimumTimeout)
+    }
+
+    func testFirstEmptyValueDoesNotWaitForLaterNonemptyValue() {
+        assertEvents([[], [1]].publisher, ["value:[]", "finished"])
+    }
+
+    func testFirstNonemptyValueDoesNotEmitLaterValues() {
+        assertEvents([[1], [2]].publisher, ["value:[1]", "finished"])
+    }
+
+    func testErrorAfterFirstValueIsNotEmittedAsAnotherEmptyValue() {
+        assertEvents(
+            Just([1]).setFailureType(to: FetchError.self)
+                .append(Fail<[Int], FetchError>(error: .failed)),
+            ["value:[1]", "finished"]
+        )
+    }
+
+    func testFirstValueCancelsUpstreamWithoutRequiringUpstreamCompletion() {
+        let subject = PassthroughSubject<[Int], Never>()
+        var cancellations = 0
+        let source = FetchHarness(subject.handleEvents(receiveCancel: { cancellations += 1 }))
+        let finished = expectation(description: "first value finishes")
+        var events: [String] = []
+        let subscription = source.fetch(nil).sink(
+            receiveCompletion: { _ in events.append("finished"); finished.fulfill() },
+            receiveValue: { events.append("value:\($0)") }
+        )
+        subject.send([])
+        subject.send([1])
+        wait(for: [finished], timeout: timeoutWait)
+        source.processQueue.sync {
+            XCTAssertEqual(events, ["value:[]", "finished"])
+            XCTAssertEqual(cancellations, 1)
+        }
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testAsynchronousFutureEmptyCallbackIsDelivered() {
+        var resolve: ((Result<[Int], Never>) -> Void)?
+        let future = Future<[Int], Never> { resolve = $0 }
+        let source = FetchHarness(future)
+        let finished = expectation(description: "asynchronous future completes")
+        var values: [[Int]] = []
+        let subscription = source.fetch(nil).sink(
+            receiveCompletion: { _ in finished.fulfill() },
+            receiveValue: { values.append($0) }
+        )
+        let promise = resolve!
+        source.processQueue.async { promise(.success([])) }
+        wait(for: [finished], timeout: timeoutWait)
+        source.processQueue.sync { XCTAssertEqual(values, [[]]) }
+        withExtendedLifetime(subscription) {}
+    }
+
+    func testDownstreamCancellationDoesNotSynthesizeAnEmptyValue() {
+        let source = FetchHarness(Empty<[Int], Never>(completeImmediately: false))
+        let unexpected = expectation(description: "no events after cancellation")
+        unexpected.isInverted = true
+        let subscription = source.fetch(nil).sink(
+            receiveCompletion: { _ in unexpected.fulfill() },
+            receiveValue: { _ in unexpected.fulfill() }
+        )
+        subscription.cancel()
+        // Exceeds the accelerated timeout; full-timeout mode still checks prompt cancellation.
+        wait(for: [unexpected], timeout: 0.15)
+    }
+
+    func testOneElementDemandReceivesEmptyValueThenCompletion() {
+        let finished = expectation(description: "one-element subscriber completes")
+        let subscriber = OneElementSubscriber { finished.fulfill() }
+        let source = FetchHarness(Empty<[Int], Never>())
+        source.fetch(nil).subscribe(subscriber)
+        wait(for: [finished], timeout: timeoutWait)
+        source.processQueue.sync { XCTAssertEqual(subscriber.events, ["value:[]", "finished"]) }
+    }
+}
+
+private final class OneElementSubscriber: Subscriber {
+    typealias Input = [Int]
+    typealias Failure = Never
+    var events: [String] = []
+    private let finished: () -> Void
+    init(finished: @escaping () -> Void) { self.finished = finished }
+    func receive(subscription: Subscription) { subscription.request(.max(1)) }
+    func receive(_ input: [Int]) -> Subscribers.Demand {
+        events.append("value:\(input)")
+        return .none
+    }
+    func receive(completion: Subscribers.Completion<Never>) {
+        events.append("finished")
+        finished()
+    }
+}


### PR DESCRIPTION
## Summary
- Return the first plugin fetch result even when it is empty, instead of filtering out the sole callback value.
- Emit `[]` on empty completion or timeout using `replaceEmpty(with: [])`; keep first-result cancellation, five-minute timeout, and defensive error replacement.
- Add a standalone macOS native-Combine contract regression suite and correct the fetch documentation.

## Why
`fetchIfNeeded()` currently resolves a single-result Future with `[]`. Its callback intentionally ignores share-client values (see #703); actual CGM readings/backfill arrive separately through the manager delegate. Filtering the callback's only output makes the fetch complete without a value, rather than delivering the documented empty result. With `customError: nil`, timeout also completes without a value unless explicitly replaced.

This intentionally changes empty-result observability. The timer subscriber now enters its existing semaphore/task path, including starting/ending a background task. Source review shows its empty-data guard returns before glucose storage or pump heartbeat scheduling. Delegate delivery, share-client suppression, and timer configuration are unchanged. Device-level scheduling still needs maintainer/integration validation.

## Verification
On macOS, Xcode 26.6 / Apple Swift 6.3.3, with warnings as errors:
- `python3 scripts/tests/plugin-fetch/run.py` — 12 tests, 0 failures.
- `python3 scripts/tests/plugin-fetch/run.py --full-timeout` — 12 tests, 0 failures; silent-publisher test exercised the unchanged production timeout for 300.007 seconds.
- Same suite against pre-change `a708381782825c03745db1c6377efe632b5f2161` source — 7 expected failures out of 12 tests, covering the changed empty-result contract.
- `git diff --cached --check` — passed.

Coverage includes empty array/completion, nonempty result, defensive error replacement, timeout, first-result/upstream cancellation, downstream cancellation, finite demand, late values/errors, and asynchronous Future delivery.

## Boundaries / review attention
The suite extracts the current production method into a test-only host with synthetic integer elements and an injected publisher. It is not an app/driver integration test and is not wired into TrioTests or CI. The generic error case probes a defensive operator; production `fetchIfNeeded()` has `Failure == Never`.

The reported `Collection.isEmpty` / Combine Filter `EXC_BAD_ACCESS` has **not** been reproduced. This removes that closure and verifies empty-fetch semantics; it does not establish that an underlying memory-lifetime or concurrency defect is fixed. No full iOS app build, device testing, or deployment was performed.

AI-assisted preparation and manual source/diff review were used for this narrow change. No dosing, bolus, dependency, signing, or deployment changes are included.
