### PR TITLE
Anchor bolus and carb amount labels to a zero-size companion mark

### DIFF
--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/CarbView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/CarbView.swift
@@ -38,6 +38,12 @@ struct CarbView: ChartContent {
                     Image(systemName: "arrowtriangle.down.fill").font(.system(size: size)).foregroundStyle(Color.orange)
                         .rotationEffect(.degrees(180))
                 }
+
+                PointMark(
+                    x: .value("Time", carbDate, unit: .second),
+                    y: .value("Value", yPosition)
+                )
+                .symbolSize(0)
                 .annotation(position: .bottom) {
                     Text(Formatter.integerFormatter.string(from: carbAmount as NSNumber)!).font(.caption2)
                         .foregroundStyle(Color.primary)

--- a/Trio/Sources/Modules/Home/View/Chart/ChartElements/InsulinView.swift
+++ b/Trio/Sources/Modules/Home/View/Chart/ChartElements/InsulinView.swift
@@ -32,6 +32,12 @@ struct InsulinView: ChartContent {
                 .symbol {
                     Image(systemName: "arrowtriangle.down.fill").font(.system(size: size)).foregroundStyle(Color.insulin)
                 }
+
+                PointMark(
+                    x: .value("Time", bolusDate, unit: .second),
+                    y: .value("Value", yPosition)
+                )
+                .symbolSize(0)
                 .annotation(position: .top) {
                     if amount as Decimal >= bolusDisplayThreshold.rawValue {
                         Text(Formatter.bolusFormatter.string(from: amount) ?? "")


### PR DESCRIPTION
resolves #1488 

This seems to just be an Apple bug when building to iOS 27 from Xcode 27. I tried several methods to address it but this is the only one I found that works — attaching the annotation to a different PointMark at the same location of the triangle.

Tested with the RC of both iOS 27 and Xcode 27.