### PR TITLE
[Dosing Modes – Part 2 of 6] Stop the loop pill claiming to loop in open loop

### DIFF
--- a/Trio.xcodeproj/project.pbxproj
+++ b/Trio.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 		3EF667132FE48509009FB31A /* BasalDeliveryState+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF667122FE48502009FB31A /* BasalDeliveryState+Extension.swift */; };
 		3F23E18680094E6DA98628E4 /* QuickPickTreatmentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A54068ABDAE4898B243DF14 /* QuickPickTreatmentsView.swift */; };
 		41740E936552456AAC0EDAC3 /* SettingsSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3919BBB515547118D684CA2 /* SettingsSearchTests.swift */; };
+		41740E936552456AAC0EDDC3 /* LoopIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3919BBB515547118D684CD2 /* LoopIndicatorTests.swift */; };
 		41740E936552456AAC0EDCC3 /* MaxIOBSuggestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3919BBB515547118D684CC2 /* MaxIOBSuggestionTests.swift */; };
 		41740E936552456AAC0EDBC3 /* DosingModeMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3919BBB515547118D684CB2 /* DosingModeMigrationTests.swift */; };
 		45252C95D220E796FDB3B022 /* ConfigEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8A87AA037BD079BA3528BA /* ConfigEditorDataFlow.swift */; };
@@ -1509,6 +1510,7 @@
 		B015AFE12E500000000D7351 /* BolusSafetyValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusSafetyValidator.swift; sourceTree = "<group>"; };
 		B015AFE42E500000000D7351 /* BolusSafetyValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusSafetyValidatorTests.swift; sourceTree = "<group>"; };
 		B3919BBB515547118D684CA2 /* SettingsSearchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsSearchTests.swift; sourceTree = "<group>"; };
+		B3919BBB515547118D684CD2 /* LoopIndicatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoopIndicatorTests.swift; sourceTree = "<group>"; };
 		B3919BBB515547118D684CC2 /* MaxIOBSuggestionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MaxIOBSuggestionTests.swift; sourceTree = "<group>"; };
 		B3919BBB515547118D684CB2 /* DosingModeMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DosingModeMigrationTests.swift; sourceTree = "<group>"; };
 		B6E925122EB3932A0076D719 /* OmnipodKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = OmnipodKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3209,6 +3211,7 @@
 				DC01A00D2E9F100000000004 /* DeviceCatalogTests.swift */,
 				3B5CD2C72D4AECD500CE213C /* OpenAPSSwiftTests */,
 				B3919BBB515547118D684CA2 /* SettingsSearchTests.swift */,
+				B3919BBB515547118D684CD2 /* LoopIndicatorTests.swift */,
 				B3919BBB515547118D684CC2 /* MaxIOBSuggestionTests.swift */,
 				B3919BBB515547118D684CB2 /* DosingModeMigrationTests.swift */,
 				BD8FC0532D66186000B95AED /* TestError.swift */,
@@ -6010,6 +6013,7 @@
 				BD8FC05E2D6618CE00B95AED /* BolusCalculatorTests.swift in Sources */,
 				41740E936552456AAC0EDAC3 /* SettingsSearchTests.swift in Sources */,
 				B015AFF52E600000000D7351 /* AdjustmentManagerTests.swift in Sources */,
+				41740E936552456AAC0EDDC3 /* LoopIndicatorTests.swift in Sources */,
 				41740E936552456AAC0EDCC3 /* MaxIOBSuggestionTests.swift in Sources */,
 				41740E936552456AAC0EDBC3 /* DosingModeMigrationTests.swift in Sources */,
 				B015AFE52E500000000D7351 /* BolusSafetyValidatorTests.swift in Sources */,

--- a/Trio/Sources/Modules/Home/HomeStateModel.swift
+++ b/Trio/Sources/Modules/Home/HomeStateModel.swift
@@ -126,6 +126,18 @@ extension Home {
         var pumpInitialSettings = PumpConfig.PumpInitialSettings.default
         var shouldRunDeleteOnSettingsChange = true
 
+        /// Newest CGM reading. `glucoseFromPersistence` is ascending, so the last entry is the newest.
+        var lastGlucoseDate: Date? { glucoseFromPersistence.last?.date }
+
+        /// Last time the pump reported status; the battery row is restamped on every status update.
+        var lastPumpCommsDate: Date? { batteryFromPersistence.first?.date }
+
+        /// A device has stopped reporting: the pump raised a status highlight, or readings have dried up.
+        var hasDeviceIssue: Bool {
+            if pumpStatusHighlightMessage != nil { return true }
+            return timerDate.timeIntervalSince(lastGlucoseDate ?? .distantPast) > MultiUsePanelState.cgmStaleAfter
+        }
+
         var showCarbsRequiredBadge: Bool = true
         var enableQuickPickTreatments: Bool = false
         var quickPickBolusSuggestions: [Decimal] = []

--- a/Trio/Sources/Modules/Home/View/Header/LoopStatusView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/LoopStatusView.swift
@@ -129,9 +129,13 @@ struct LoopStatusView: View {
     }
 
     private var statusBadgeColor: Color {
+        // Open loop enacts nothing, so loop freshness says nothing; report device health, as LoopView does.
+        guard state.dosingMode.automation != .off else {
+            return state.hasDeviceIssue ? .loopRed : .loopGreen
+        }
         guard let determination = state.determinationsFromPersistence.first, determination.timestamp != nil
         else {
-            // previously the .timestamp property was used here because this only gets updated when the reportenacted function in the aps manager gets called
+            // .timestamp only updates when reportEnacted runs
             return .secondary
         }
 
@@ -157,36 +161,34 @@ struct LoopStatusView: View {
         }
     }
 
-    private func setStatusTitle() {
-        if let determination = state.determinationsFromPersistence.first, let deliverAt = determination.deliverAt {
-            let minutesAgo = abs(deliverAt.timeIntervalSinceNow) / 60
+    /// Open loop calculates a determination but never sends it, so it was determined, not enacted.
+    private func title(forDeliverAt deliverAt: Date) -> String {
+        let isOpenLoop = state.dosingMode.automation == .off
 
-            if deliverAt < Date().addingTimeInterval(-5 * 60) {
-                let roundedMinutes = Int(minutesAgo.rounded())
-                statusTitle = String(
-                    localized: "Trio has not looped in \(roundedMinutes) minutes."
-                )
-            } else {
-                statusTitle = String(
-                    localized: "Enacted at \(Formatter.dateFormatter.string(from: deliverAt))"
-                )
-            }
-        } else if let determination = lastDetermination, let deliverAt = determination.deliverAt {
-            let minutesAgo = abs(deliverAt.timeIntervalSinceNow) / 60
-
-            if deliverAt < Date().addingTimeInterval(-5 * 60) {
-                let roundedMinutes = Int(minutesAgo.rounded())
-                statusTitle = String(
-                    localized: "Trio has not looped in \(roundedMinutes) minutes."
-                )
-            } else {
-                statusTitle = String(
-                    localized: "Enacted at \(Formatter.dateFormatter.string(from: deliverAt))"
-                )
-            }
-        } else {
-            statusTitle = String(localized: "Not looping.")
+        guard deliverAt >= Date().addingTimeInterval(-5 * 60) else {
+            let roundedMinutes = Int((abs(deliverAt.timeIntervalSinceNow) / 60).rounded())
+            return isOpenLoop
+                ? String(localized: "Trio has not run in \(roundedMinutes) minutes.")
+                : String(localized: "Trio has not looped in \(roundedMinutes) minutes.")
         }
+
+        let time = Formatter.dateFormatter.string(from: deliverAt)
+        return isOpenLoop
+            ? String(localized: "Determined at \(time)")
+            : String(localized: "Enacted at \(time)")
+    }
+
+    private func setStatusTitle() {
+        let determination = state.determinationsFromPersistence.first ?? lastDetermination
+
+        guard let deliverAt = determination?.deliverAt else {
+            statusTitle = state.dosingMode.automation == .off
+                ? String(localized: "No recent determination.")
+                : String(localized: "Not looping.")
+            return
+        }
+
+        statusTitle = title(forDeliverAt: deliverAt)
     }
 
     // TODO: Consolidate all mmol parsing methods (in TagCloudView, NightscoutManager and HomeRootView) to one central func

--- a/Trio/Sources/Modules/Home/View/Header/LoopView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/LoopView.swift
@@ -157,7 +157,7 @@ struct LoopView: View {
     // @ScaledMetric so the ring grows with the user's text size; a fixed point size would leave
     // it unreadable for anyone relying on larger type.
     @ScaledMetric(relativeTo: .callout) private var compactRingDiameter: CGFloat = 18
-    @ScaledMetric(relativeTo: .callout) private var expandedRingDiameter: CGFloat = 32
+    @ScaledMetric(relativeTo: .callout) private var expandedRingDiameter: CGFloat = 26
 
     private var ringDiameter: CGFloat { showsCaption ? compactRingDiameter : expandedRingDiameter }
     private var ringLineWidth: CGFloat { max(2, ringDiameter * 0.08) }

--- a/Trio/Sources/Modules/Home/View/Header/LoopView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/LoopView.swift
@@ -6,7 +6,7 @@ import UIKit
 struct LoopView: View {
     @Environment(\.colorScheme) var colorScheme
 
-    private enum Config {
+    fileprivate enum Config {
         static let lag: TimeInterval = 30
     }
 
@@ -15,10 +15,55 @@ struct LoopView: View {
     let isLooping: Bool
     let lastLoopDate: Date
     let manualTempBasal: Bool
+    let lastGlucoseDate: Date?
+    let lastPumpCommsDate: Date?
+    let hasDeviceIssue: Bool
 
     let determination: [OrefDetermination]
 
-    private let rect = CGRect(x: 0, y: 0, width: 18, height: 18)
+    /// Fraction of the ring left open. Widens as Trio is allowed to do less.
+    static func ringGap(automation: AutomationLevel, manualTempBasal: Bool) -> CGFloat {
+        guard !manualTempBasal else { return 0.22 }
+        switch automation {
+        case .off: return 0.22
+        case .hypoSuspendOnly: return 0.16
+        case .reductionsOnly: return 0.1
+        case .full: return 0
+        }
+    }
+
+    /// Ring colour. Closed-loop freshness is meaningless when nothing is enacted, so open loop
+    /// reports device health instead: green while the devices talk to Trio, red when they do not.
+    static func ringColor(
+        automation: AutomationLevel,
+        manualTempBasal: Bool,
+        hasDeviceIssue: Bool,
+        hasEnactedDetermination: Bool,
+        secondsSinceLastLoop: TimeInterval
+    ) -> Color {
+        guard !manualTempBasal else { return .loopManualTemp }
+        guard automation != .off else { return hasDeviceIssue ? .loopRed : .loopGreen }
+        // .timestamp only updates when reportEnacted runs
+        guard hasEnactedDetermination else { return .secondary }
+
+        let delta = secondsSinceLastLoop - Config.lag
+        if delta <= 5.minutes.timeInterval {
+            return .loopGreen
+        } else if delta <= 10.minutes.timeInterval {
+            return .loopYellow
+        } else {
+            return .loopRed
+        }
+    }
+
+    private var ringGap: CGFloat {
+        Self.ringGap(automation: dosingMode.automation, manualTempBasal: manualTempBasal)
+    }
+
+    /// Newest sign of life from either device, which is what freshness means when nothing is enacted.
+    private var lastDeviceDate: Date? {
+        [lastGlucoseDate, lastPumpCommsDate].compactMap { $0 }.max()
+    }
 
     var body: some View {
         loopStatusWithMinutes
@@ -73,27 +118,43 @@ struct LoopView: View {
     private var loopStatusWithMinutes: some View {
         HStack(alignment: .center) {
             ZStack {
-                Image(systemName: (dosingMode.automation == .off || manualTempBasal) ? "circle.and.line.horizontal" : "circle")
+                Circle()
+                    .trim(from: ringGap, to: 1)
+                    .stroke(style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                    .frame(width: 18, height: 18)
                 if isLooping {
                     ProgressView()
                 }
             }
-            if isLooping {
-                Text("looping")
-            } else if manualTempBasal {
-                Text("Manual")
-            } else if determination.first?
-                .deliverAt !=
-                nil
-            {
-                // previously the .timestamp property was used here because this only gets updated when the reportenacted function in the aps manager gets called
-                Text(timeString)
-            } else {
-                Text("--")
+            // Open loop enacts nothing, so a "minutes since last loop" caption would imply
+            // an action that never happened. The ring alone carries the state.
+            if dosingMode.automation != .off {
+                if isLooping {
+                    Text("looping")
+                } else if manualTempBasal {
+                    Text("Manual")
+                } else if determination.first?.deliverAt != nil {
+                    // .timestamp only updates when reportEnacted runs, so key the caption off deliverAt
+                    Text(timeString)
+                } else {
+                    Text("--")
+                }
             }
         }
         .font(.callout).fontWeight(.bold).fontDesign(.rounded)
         .foregroundColor(color)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: Text {
+        guard dosingMode.automation == .off else {
+            return Text("\(dosingMode.displayName), last loop \(timeString)")
+        }
+        guard let lastDeviceDate else {
+            return Text("\(dosingMode.displayName), no recent device communication")
+        }
+        return Text("\(dosingMode.displayName), last device communication \(TimeAgoFormatter.minutesAgo(from: lastDeviceDate))")
     }
 
     private var timeString: String {
@@ -106,30 +167,13 @@ struct LoopView: View {
     }
 
     private var color: Color {
-        guard determination.first?.timestamp != nil
-        else {
-            // previously the .timestamp property was used here because this only gets updated when the reportenacted function in the aps manager gets called
-            return .secondary
-        }
-        guard manualTempBasal == false else {
-            return .loopManualTemp
-        }
-        guard dosingMode.automation != .off else {
-            return .secondary
-        }
-
-        let delta = timerDate.timeIntervalSince(lastLoopDate) - Config.lag
-
-        if delta <= 5.minutes.timeInterval {
-            guard determination.first?.timestamp != nil else {
-                return .loopYellow
-            }
-            return .loopGreen
-        } else if delta <= 10.minutes.timeInterval {
-            return .loopYellow
-        } else {
-            return .loopRed
-        }
+        Self.ringColor(
+            automation: dosingMode.automation,
+            manualTempBasal: manualTempBasal,
+            hasDeviceIssue: hasDeviceIssue,
+            hasEnactedDetermination: determination.first?.timestamp != nil,
+            secondsSinceLastLoop: timerDate.timeIntervalSince(lastLoopDate)
+        )
     }
 }
 

--- a/Trio/Sources/Modules/Home/View/Header/LoopView.swift
+++ b/Trio/Sources/Modules/Home/View/Header/LoopView.swift
@@ -21,14 +21,26 @@ struct LoopView: View {
 
     let determination: [OrefDetermination]
 
-    /// Fraction of the ring left open. Widens as Trio is allowed to do less.
+    /// Fraction of the ring removed at *each* of the two horizontal gaps (3 and 9 o'clock),
+    /// leaving a top and a bottom arc. Anything short of full automation reads as an open ring;
+    /// the centre symbol says why.
+    static let openRingGap: CGFloat = 0.12
+
     static func ringGap(automation: AutomationLevel, manualTempBasal: Bool) -> CGFloat {
-        guard !manualTempBasal else { return 0.22 }
+        guard !manualTempBasal else { return openRingGap }
+        return automation == .full ? 0 : openRingGap
+    }
+
+    /// Symbol inside the ring for the modes that still dose, but only under a constraint.
+    static func centerSymbol(automation: AutomationLevel) -> String? {
         switch automation {
-        case .off: return 0.22
-        case .hypoSuspendOnly: return 0.16
-        case .reductionsOnly: return 0.1
-        case .full: return 0
+        case .reductionsOnly:
+            return "hand.raised.fill"
+        case .hypoSuspendOnly:
+            return "hand.pinch.fill"
+        case .full,
+             .off:
+            return nil
         }
     }
 
@@ -60,21 +72,39 @@ struct LoopView: View {
         Self.ringGap(automation: dosingMode.automation, manualTempBasal: manualTempBasal)
     }
 
+    private var centerSymbol: String? {
+        manualTempBasal ? nil : Self.centerSymbol(automation: dosingMode.automation)
+    }
+
     /// Newest sign of life from either device, which is what freshness means when nothing is enacted.
     private var lastDeviceDate: Date? {
         [lastGlucoseDate, lastPumpCommsDate].compactMap { $0 }.max()
     }
 
-    var body: some View {
-        loopStatusWithMinutes
-            .padding(.vertical, 5)
-            .padding(.horizontal, 10)
-            .overlay(
-                Capsule()
-                    .stroke(color.opacity(0.4), lineWidth: 2)
-            )
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(Text(loopAccessibilityLabel))
+    /// Only full automation carries a "last loop" caption. The constrained modes drop it and show
+    /// the bare ring; their freshness still comes through in the ring colour.
+    static func showsCaption(automation: AutomationLevel) -> Bool { automation == .full }
+
+    private var showsCaption: Bool { Self.showsCaption(automation: dosingMode.automation) }
+
+    @ViewBuilder var body: some View {
+        if showsCaption {
+            loopStatus
+                .padding(.vertical, 5)
+                .padding(.horizontal, 10)
+                .overlay(
+                    Capsule()
+                        .stroke(color.opacity(0.4), lineWidth: 2)
+                )
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(loopAccessibilityLabel))
+        } else {
+            // No caption to enclose, so the capsule would frame empty space. The ring stands alone,
+            // drawn larger to hold the same visual weight.
+            loopStatus
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(loopAccessibilityLabel))
+        }
     }
 
     /// Spoken description of loop state — mirrors the color/text logic so the
@@ -83,10 +113,11 @@ struct LoopView: View {
         let status: String
         if manualTempBasal {
             status = String(localized: "manual temporary basal running", comment: "Accessibility: loop status")
+        } else if dosingMode.automation == .off {
+            // checked before the determination, which never carries a timestamp in open loop
+            status = String(localized: "not dosing", comment: "Accessibility: loop status")
         } else if determination.first?.timestamp == nil {
             status = String(localized: "not looping", comment: "Accessibility: loop status")
-        } else if dosingMode.automation == .off {
-            status = String(localized: "open loop", comment: "Accessibility: loop status")
         } else {
             let delta = timerDate.timeIntervalSince(lastLoopDate) - Config.lag
             if delta <= 5.minutes.timeInterval {
@@ -101,6 +132,14 @@ struct LoopView: View {
         let age: String
         if isLooping {
             age = String(localized: "in progress", comment: "Accessibility: loop currently running")
+        } else if dosingMode.automation == .off {
+            // loop age says nothing when nothing is enacted; report device contact instead
+            age = lastDeviceDate.map {
+                String(
+                    format: String(localized: "last device communication %@", comment: "Accessibility: device age"),
+                    TimeAgoFormatter.minutesAgoAccessible(from: $0)
+                )
+            } ?? ""
         } else if determination.first?.deliverAt != nil, timeString != "--" {
             age = String(
                 format: String(localized: "last loop %@", comment: "Accessibility: loop age"),
@@ -110,26 +149,44 @@ struct LoopView: View {
             age = ""
         }
 
-        return [String(localized: "Loop", comment: "Accessibility: loop pill label"), status, age]
+        return [dosingMode.displayName, status, age]
             .filter { !$0.isEmpty }
             .joined(separator: ", ")
     }
 
-    private var loopStatusWithMinutes: some View {
+    // @ScaledMetric so the ring grows with the user's text size; a fixed point size would leave
+    // it unreadable for anyone relying on larger type.
+    @ScaledMetric(relativeTo: .callout) private var compactRingDiameter: CGFloat = 18
+    @ScaledMetric(relativeTo: .callout) private var expandedRingDiameter: CGFloat = 32
+
+    private var ringDiameter: CGFloat { showsCaption ? compactRingDiameter : expandedRingDiameter }
+    private var ringLineWidth: CGFloat { max(2, ringDiameter * 0.08) }
+
+    private var loopStatus: some View {
         HStack(alignment: .center) {
             ZStack {
-                Circle()
-                    .trim(from: ringGap, to: 1)
-                    .stroke(style: StrokeStyle(lineWidth: 2, lineCap: .round))
-                    .rotationEffect(.degrees(-90))
-                    .frame(width: 18, height: 18)
+                // A manual temp basal blocks enactment, so closed loop does not get a closed ring.
+                if dosingMode == .closed, !manualTempBasal {
+                    Image(systemName: "circle")
+                } else {
+                    Circle()
+                        .trim(from: ringGap / 2, to: 0.5 - ringGap / 2)
+                        .stroke(style: StrokeStyle(lineWidth: ringLineWidth, lineCap: .round))
+                    Circle()
+                        .trim(from: 0.5 + ringGap / 2, to: 1 - ringGap / 2)
+                        .stroke(style: StrokeStyle(lineWidth: ringLineWidth, lineCap: .round))
+                }
                 if isLooping {
                     ProgressView()
+                } else if let centerSymbol {
+                    Image(systemName: centerSymbol)
+                        .font(.system(size: ringDiameter * 0.44, weight: .semibold))
                 }
             }
-            // Open loop enacts nothing, so a "minutes since last loop" caption would imply
-            // an action that never happened. The ring alone carries the state.
-            if dosingMode.automation != .off {
+            .frame(width: ringDiameter, height: ringDiameter)
+            // A caption would imply an action that did not happen in open loop, and overstates what
+            // the constrained modes do. The ring carries the state instead.
+            if showsCaption {
                 if isLooping {
                     Text("looping")
                 } else if manualTempBasal {
@@ -144,17 +201,6 @@ struct LoopView: View {
         }
         .font(.callout).fontWeight(.bold).fontDesign(.rounded)
         .foregroundColor(color)
-        .accessibilityLabel(accessibilityLabel)
-    }
-
-    private var accessibilityLabel: Text {
-        guard dosingMode.automation == .off else {
-            return Text("\(dosingMode.displayName), last loop \(timeString)")
-        }
-        guard let lastDeviceDate else {
-            return Text("\(dosingMode.displayName), no recent device communication")
-        }
-        return Text("\(dosingMode.displayName), last device communication \(TimeAgoFormatter.minutesAgo(from: lastDeviceDate))")
     }
 
     private var timeString: String {

--- a/Trio/Sources/Modules/Home/View/HomeRootView+Header.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+Header.swift
@@ -145,7 +145,7 @@ extension Home.RootView {
     }
 
     @ViewBuilder func rightHeaderPanel() -> some View {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .center, spacing: 20) {
             /// Loop view at bottomLeading
             LoopView(
                 dosingMode: state.dosingMode,
@@ -178,8 +178,6 @@ extension Home.RootView {
                         .fontWeight(.bold)
                         .fontDesign(.rounded)
                 }
-                // aligns the evBG icon exactly with the first pixel of loop status icon
-                .padding(.leading, 12)
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(Text("Eventual glucose"))
                 .accessibilityValue(Text(

--- a/Trio/Sources/Modules/Home/View/HomeRootView+Header.swift
+++ b/Trio/Sources/Modules/Home/View/HomeRootView+Header.swift
@@ -153,6 +153,9 @@ extension Home.RootView {
                 isLooping: state.isLooping,
                 lastLoopDate: state.lastLoopDate,
                 manualTempBasal: state.manualTempBasal,
+                lastGlucoseDate: state.lastGlucoseDate,
+                lastPumpCommsDate: state.lastPumpCommsDate,
+                hasDeviceIssue: state.hasDeviceIssue,
                 determination: state.determinationsFromPersistence
             )
             .onTapGesture {

--- a/TrioTests/LoopIndicatorTests.swift
+++ b/TrioTests/LoopIndicatorTests.swift
@@ -52,23 +52,29 @@ import Testing
         }
     }
 
-    @Test("The ring opens wider the less Trio may do") func ringGapWidensWithConstraint() {
-        let full = LoopView.ringGap(automation: .full, manualTempBasal: false)
-        let reductions = LoopView.ringGap(automation: .reductionsOnly, manualTempBasal: false)
-        let hypo = LoopView.ringGap(automation: .hypoSuspendOnly, manualTempBasal: false)
-        let off = LoopView.ringGap(automation: .off, manualTempBasal: false)
-
-        #expect(full == 0)
-        #expect(full < reductions)
-        #expect(reductions < hypo)
-        #expect(hypo < off)
+    @Test("Only full automation closes the ring") func onlyFullAutomationClosesRing() {
+        #expect(LoopView.ringGap(automation: .full, manualTempBasal: false) == 0)
+        for automation in [AutomationLevel.off, .reductionsOnly, .hypoSuspendOnly] {
+            #expect(LoopView.ringGap(automation: automation, manualTempBasal: false) == LoopView.openRingGap)
+        }
     }
 
-    @Test("A manual temp basal opens the ring fully") func manualTempBasalOpensRing() {
-        #expect(
-            LoopView.ringGap(automation: .full, manualTempBasal: true)
-                == LoopView.ringGap(automation: .off, manualTempBasal: false)
-        )
+    @Test("A manual temp basal opens the ring even in closed loop") func manualTempBasalOpensRing() {
+        #expect(LoopView.ringGap(automation: .full, manualTempBasal: true) == LoopView.openRingGap)
+    }
+
+    @Test("Only closed loop keeps the time caption") func captionOnlyInClosedLoop() {
+        #expect(LoopView.showsCaption(automation: .full))
+        for automation in [AutomationLevel.off, .reductionsOnly, .hypoSuspendOnly] {
+            #expect(LoopView.showsCaption(automation: automation) == false)
+        }
+    }
+
+    @Test("Constrained modes carry a centre symbol, plain open and closed loop do not") func centerSymbols() {
+        #expect(LoopView.centerSymbol(automation: .full) == nil)
+        #expect(LoopView.centerSymbol(automation: .off) == nil)
+        #expect(LoopView.centerSymbol(automation: .reductionsOnly) == "hand.raised.fill")
+        #expect(LoopView.centerSymbol(automation: .hypoSuspendOnly) == "hand.pinch.fill")
     }
 }
 

--- a/TrioTests/LoopIndicatorTests.swift
+++ b/TrioTests/LoopIndicatorTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SwiftUI
+import Testing
+@testable import Trio
+
+@Suite("Loop Indicator") struct LoopIndicatorTests {
+    private func color(
+        _ automation: AutomationLevel,
+        deviceIssue: Bool = false,
+        enacted: Bool = true,
+        secondsSinceLoop: TimeInterval = 60,
+        manualTempBasal: Bool = false
+    ) -> Color {
+        LoopView.ringColor(
+            automation: automation,
+            manualTempBasal: manualTempBasal,
+            hasDeviceIssue: deviceIssue,
+            hasEnactedDetermination: enacted,
+            secondsSinceLastLoop: secondsSinceLoop
+        )
+    }
+
+    @Test("Open loop is green while devices are reporting, whatever the loop age") func openLoopIsGreen() {
+        #expect(color(.off) == .loopGreen)
+        // Stale loop age must not colour the ring: nothing is being enacted anyway.
+        #expect(color(.off, secondsSinceLoop: 60 * 60) == .loopGreen)
+    }
+
+    @Test("Open loop goes red only on a device issue") func openLoopDeviceIssue() {
+        #expect(color(.off, deviceIssue: true) == .loopRed)
+    }
+
+    @Test("Open loop no longer greys out when nothing was enacted") func openLoopIgnoresEnactment() {
+        // The old behaviour returned .secondary here, which is what made the pill permanently grey.
+        #expect(color(.off, enacted: false) == .loopGreen)
+    }
+
+    @Test("Dosing modes keep loop freshness colouring") func dosingModesUseFreshness() {
+        for automation in [AutomationLevel.full, .reductionsOnly, .hypoSuspendOnly] {
+            #expect(color(automation, secondsSinceLoop: 60) == .loopGreen)
+            #expect(color(automation, secondsSinceLoop: 8 * 60) == .loopYellow)
+            #expect(color(automation, secondsSinceLoop: 20 * 60) == .loopRed)
+            #expect(color(automation, enacted: false) == .secondary)
+            // A device issue alone must not mask loop staleness when Trio is dosing.
+            #expect(color(automation, deviceIssue: true, secondsSinceLoop: 60) == .loopGreen)
+        }
+    }
+
+    @Test("A manual temp basal wins over every mode") func manualTempBasalWins() {
+        for automation in AutomationLevel.allTestCases {
+            #expect(color(automation, manualTempBasal: true) == .loopManualTemp)
+        }
+    }
+
+    @Test("The ring opens wider the less Trio may do") func ringGapWidensWithConstraint() {
+        let full = LoopView.ringGap(automation: .full, manualTempBasal: false)
+        let reductions = LoopView.ringGap(automation: .reductionsOnly, manualTempBasal: false)
+        let hypo = LoopView.ringGap(automation: .hypoSuspendOnly, manualTempBasal: false)
+        let off = LoopView.ringGap(automation: .off, manualTempBasal: false)
+
+        #expect(full == 0)
+        #expect(full < reductions)
+        #expect(reductions < hypo)
+        #expect(hypo < off)
+    }
+
+    @Test("A manual temp basal opens the ring fully") func manualTempBasalOpensRing() {
+        #expect(
+            LoopView.ringGap(automation: .full, manualTempBasal: true)
+                == LoopView.ringGap(automation: .off, manualTempBasal: false)
+        )
+    }
+}
+
+private extension AutomationLevel {
+    static var allTestCases: [AutomationLevel] { [.off, .hypoSuspendOnly, .reductionsOnly, .full] }
+}


### PR DESCRIPTION
Closes #643. Stacked on #1300 and the PR below it.

The pill was permanently grey and never signalled staleness, while the status sheet said "Enacted at …" when nothing had been enacted — both caused by a guard on `determination.timestamp`, which only `reportEnacted` sets, so it is never set in open loop.

Open loop now reports device health: green while CGM and pump are reporting, red on a device issue. The time caption is dropped outside closed loop, where it would imply an action that did not happen.

The glyph becomes a drawn ring with horizontal gaps — closed only in closed loop — with a centre symbol for the constrained modes. It scales with Dynamic Type.

| Open loop | Closed loop |
|---|---|
| <img src="https://raw.githubusercontent.com/dnzxy/Trio/assets/open-loop-screenshots/2-ring-open-loop.png" width="320"> | <img src="https://raw.githubusercontent.com/dnzxy/Trio/assets/open-loop-screenshots/2-ring-closed-loop.png" width="320"> |
